### PR TITLE
BZ-1221380: remove use of cookies (that have 4k limit) what, depending

### DIFF
--- a/optaplanner-wb-webapp/src/main/resources/ErraiApp.properties
+++ b/optaplanner-wb-webapp/src/main/resources/ErraiApp.properties
@@ -30,4 +30,4 @@
 # file, although it is rarely necessary. See the documentation at
 # https://docs.jboss.org/author/display/ERRAI/ErraiApp.properties
 # for details.
-errai.security.user_cookie_enabled=true
+errai.security.user_on_hostpage_enabled=true

--- a/optaplanner-wb-webapp/src/main/webapp/WEB-INF/web.xml
+++ b/optaplanner-wb-webapp/src/main/webapp/WEB-INF/web.xml
@@ -57,6 +57,16 @@
     <url-pattern>/maven2/*</url-pattern>
   </filter-mapping>
 
+  <filter>
+    <filter-name>Host Page Patch</filter-name>
+    <filter-class>org.jboss.errai.security.server.servlet.UserHostPageFilter</filter-class>
+  </filter>
+
+  <filter-mapping>
+    <filter-name>Host Page Patch</filter-name>
+    <url-pattern>/optaplanner-wb.html</url-pattern>
+  </filter-mapping>
+
   <servlet>
     <!-- NOTE: the integration-test profile uses this web.xml. Integration tests only work properly
 with the DefaultBlockingServlet. If you change this setting, make a backup of this web.xml


### PR DESCRIPTION
of the number of roles/groups of a user, can be reached. new solution
`patches` the host page (UserHostPageFilter) with user's info that now
is supported on errai client security.
