### PR TITLE
Setting errai-cdi-client to provided scope

### DIFF
--- a/optaplanner-wb-webapp/pom.xml
+++ b/optaplanner-wb-webapp/pom.xml
@@ -839,7 +839,7 @@
     <dependency>
       <groupId>org.jboss.errai</groupId>
       <artifactId>errai-cdi-client</artifactId>
-      <!-- Unlike all other client only dependencies, errai-cdi-client must not be in scope provided -->
+      <scope>provided</scope>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Fix is in Errai 4 so errai-cdi-client is no longer needed on the server.
