### PR TITLE
PLANNER-513 Workbench: starting the server twice without deleting .niogit crashes on bootstrap the 2th time

### DIFF
--- a/optaplanner-wb-webapp/src/main/webapp/WEB-INF/web.xml
+++ b/optaplanner-wb-webapp/src/main/webapp/WEB-INF/web.xml
@@ -6,6 +6,10 @@
 
   <distributable/>
 
+  <listener>
+    <listener-class>org.uberfire.backend.server.io.DisposableShutdownService</listener-class>
+  </listener>
+
   <filter>
     <filter-name>UI Security Filter</filter-name>
 


### PR DESCRIPTION
Make sure resources held by JGitFileSystemProvider are released as described in https://issues.jboss.org/browse/PLANNER-513?focusedCommentId=13200007&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-13200007
