### PR TITLE
Include uberfire-wires-core-grids compile sources artifact in optaplanner-wb-webapp module

### DIFF
--- a/optaplanner-wb-webapp/pom.xml
+++ b/optaplanner-wb-webapp/pom.xml
@@ -1071,6 +1071,7 @@
             <!-- Wires -->
             <compileSourcesArtifact>org.uberfire:uberfire-wires-core-api</compileSourcesArtifact>
             <compileSourcesArtifact>org.uberfire:uberfire-wires-core-client</compileSourcesArtifact>
+            <compileSourcesArtifact>org.uberfire:uberfire-wires-core-grids</compileSourcesArtifact>
             <compileSourcesArtifact>org.uberfire:uberfire-wires-core-trees</compileSourcesArtifact>
 
             <!-- UberFire -->


### PR DESCRIPTION
Fixes build issues caused by https://github.com/droolsjbpm/drools-wb/pull/185.
