### PR TITLE
PLANNER-585: Workbench: Consolidate test names

### DIFF
--- a/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-client/src/test/java/org/optaplanner/workbench/screens/domaineditor/client/widgets/planner/PlannerDataObjectEditorTest.java
+++ b/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-client/src/test/java/org/optaplanner/workbench/screens/domaineditor/client/widgets/planner/PlannerDataObjectEditorTest.java
@@ -43,7 +43,7 @@ public class PlannerDataObjectEditorTest
     }
 
     @Test
-    public void loadDataObjectTest() {
+    public void loadDataObject() {
         PlannerDataObjectEditor objectEditor = createObjectEditor();
 
         //The domain editors typically reacts upon DataModelerContext changes.
@@ -60,7 +60,7 @@ public class PlannerDataObjectEditorTest
     }
 
     @Test
-    public void changeToPlanningEntityTest() {
+    public void changeToPlanningEntity() {
 
         PlannerDataObjectEditor objectEditor = createObjectEditor();
 
@@ -82,7 +82,7 @@ public class PlannerDataObjectEditorTest
     }
 
     @Test
-    public void changeToPlanningSolutionTest() {
+    public void changeToPlanningSolution() {
 
         PlannerDataObjectEditor objectEditor = createObjectEditor();
 

--- a/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-client/src/test/java/org/optaplanner/workbench/screens/domaineditor/client/widgets/planner/PlannerDataObjectFieldEditorTest.java
+++ b/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-client/src/test/java/org/optaplanner/workbench/screens/domaineditor/client/widgets/planner/PlannerDataObjectFieldEditorTest.java
@@ -54,7 +54,7 @@ public class PlannerDataObjectFieldEditorTest
     }
 
     @Test
-    public void loadDataObjectFieldTest() {
+    public void loadDataObjectField() {
 
         PlannerDataObjectFieldEditor fieldEditor = createFieldEditor();
 
@@ -73,7 +73,7 @@ public class PlannerDataObjectFieldEditorTest
     }
 
     @Test
-    public void fieldPlanningEntitySettingsTest() {
+    public void fieldPlanningEntitySettings() {
 
         PlannerDataObjectFieldEditor fieldEditor = createFieldEditor();
 
@@ -105,7 +105,7 @@ public class PlannerDataObjectFieldEditorTest
     }
 
     @Test
-    public void planningSolutionSettingsTest() {
+    public void planningSolutionSettings() {
 
         PlannerDataObjectFieldEditor fieldEditor = createFieldEditor();
 

--- a/optaplanner-wb-screens/optaplanner-wb-solver-editor/optaplanner-wb-solver-editor-backend/src/test/java/org/optaplanner/workbench/screens/solver/backend/server/SolverConfigModelPersistenceTest.java
+++ b/optaplanner-wb-screens/optaplanner-wb-solver-editor/optaplanner-wb-solver-editor-backend/src/test/java/org/optaplanner/workbench/screens/solver/backend/server/SolverConfigModelPersistenceTest.java
@@ -38,7 +38,7 @@ public class SolverConfigModelPersistenceTest {
     ConfigPersistence configPersistence;
 
     @Test
-    public void testNew() throws Exception {
+    public void newSolverConfigModel() throws Exception {
         SolverConfigModel config = new SolverConfigModel();
         config.setTerminationConfig( new TerminationConfigModel() );
         final ScoreDirectorFactoryConfigModel scoreDirectorFactoryConfig = new ScoreDirectorFactoryConfigModel();
@@ -53,7 +53,7 @@ public class SolverConfigModelPersistenceTest {
     }
 
     @Test
-    public void testTerminationIsNotEmpty() throws Exception {
+    public void terminationIsNotEmpty() throws Exception {
 
         SolverConfigModel solverConfigModel = configPersistence.toConfig( "<solver  />" );
 
@@ -61,7 +61,7 @@ public class SolverConfigModelPersistenceTest {
     }
 
     @Test
-    public void testScoreDirectorFactoryConfigIsNotEmpty() throws Exception {
+    public void scoreDirectorFactoryConfigIsNotEmpty() throws Exception {
 
         SolverConfigModel solverConfigModel = configPersistence.toConfig( "<solver />" );
 
@@ -69,7 +69,7 @@ public class SolverConfigModelPersistenceTest {
     }
 
     @Test
-    public void testFromFile() throws Exception {
+    public void fromFile() throws Exception {
         SolverConfigModel config = configPersistence.toConfig( loadResource( "solver.xml" ) );
 
         assertNotNull( config );
@@ -82,7 +82,7 @@ public class SolverConfigModelPersistenceTest {
     }
 
     @Test
-    public void testFromFileNoKSessionName() throws Exception {
+    public void fromFileNoKSessionName() throws Exception {
         SolverConfigModel config = configPersistence.toConfig( loadResource( "ksessionNameNull.solver.xml" ) );
 
         assertNotNull( config );

--- a/optaplanner-wb-screens/optaplanner-wb-solver-editor/optaplanner-wb-solver-editor-backend/src/test/java/org/optaplanner/workbench/screens/solver/backend/server/SolverValidatorTest.java
+++ b/optaplanner-wb-screens/optaplanner-wb-solver-editor/optaplanner-wb-solver-editor-backend/src/test/java/org/optaplanner/workbench/screens/solver/backend/server/SolverValidatorTest.java
@@ -54,7 +54,7 @@ public class SolverValidatorTest {
     }
 
     @Test
-    public void testProjectWorks() throws Exception {
+    public void projectWorks() throws Exception {
 
         final String url = "/ProjectWorks/src/main/resources/cb/my.solver.xml";
 
@@ -71,7 +71,7 @@ public class SolverValidatorTest {
     }
 
     @Test
-    public void testProjectBuildError() throws Exception {
+    public void projectBuildError() throws Exception {
 
         final String url = "/ProjectBuildError/src/main/resources/cb/my.solver.xml";
 
@@ -88,7 +88,7 @@ public class SolverValidatorTest {
     }
 
     @Test
-    public void testProjectPlannerError() throws Exception {
+    public void projectPlannerError() throws Exception {
 
         final String url = "/ProjectPlannerError/src/main/resources/cb/my.solver.xml";
 

--- a/optaplanner-wb-screens/optaplanner-wb-solver-editor/optaplanner-wb-solver-editor-client/src/test/java/org/optaplanner/workbench/screens/solver/client/editor/ScoreDirectorFactoryFormTest.java
+++ b/optaplanner-wb-screens/optaplanner-wb-solver-editor/optaplanner-wb-solver-editor-client/src/test/java/org/optaplanner/workbench/screens/solver/client/editor/ScoreDirectorFactoryFormTest.java
@@ -44,12 +44,12 @@ public class ScoreDirectorFactoryFormTest {
     }
 
     @Test
-    public void testSetPresenter() throws Exception {
+    public void setPresenter() throws Exception {
         verify( view ).setPresenter( form );
     }
 
     @Test
-    public void testScoreDefinitionTypesSet() throws Exception {
+    public void scoreDefinitionTypesSet() throws Exception {
 
         for ( ScoreDefinitionTypeModel type : ScoreDefinitionTypeModel.values() ) {
             verify( view ).addScoreDefinitionType( type );
@@ -60,7 +60,7 @@ public class ScoreDirectorFactoryFormTest {
     }
 
     @Test
-    public void testSetEmptyModel() throws Exception {
+    public void setEmptyModel() throws Exception {
         ScoreDirectorFactoryConfigModel model = new ScoreDirectorFactoryConfigModel();
         form.setModel( model, path );
 
@@ -70,7 +70,7 @@ public class ScoreDirectorFactoryFormTest {
     }
 
     @Test
-    public void testSetEmptyKSession() throws Exception {
+    public void setEmptyKSession() throws Exception {
         ScoreDirectorFactoryConfigModel model = new ScoreDirectorFactoryConfigModel();
         model.setScoreDefinitionType( ScoreDefinitionTypeModel.SIMPLE );
         form.setModel( model, path );
@@ -80,7 +80,7 @@ public class ScoreDirectorFactoryFormTest {
     }
 
     @Test
-    public void testSetModel() throws Exception {
+    public void setModel() throws Exception {
         ScoreDirectorFactoryConfigModel model = new ScoreDirectorFactoryConfigModel();
         model.setScoreDefinitionType( ScoreDefinitionTypeModel.SIMPLE_BIG_DECIMAL );
         model.setKSessionName( "someSession" );
@@ -93,7 +93,7 @@ public class ScoreDirectorFactoryFormTest {
     }
 
     @Test
-    public void testOnNameChange() throws Exception {
+    public void onNameChange() throws Exception {
         ScoreDirectorFactoryConfigModel model = new ScoreDirectorFactoryConfigModel();
 
         form.setModel( model, path );
@@ -104,7 +104,7 @@ public class ScoreDirectorFactoryFormTest {
     }
 
     @Test
-    public void testOnNameChangeToDefault() throws Exception {
+    public void onNameChangeToDefault() throws Exception {
         ScoreDirectorFactoryConfigModel model = new ScoreDirectorFactoryConfigModel();
 
         form.setModel( model, path );
@@ -115,7 +115,7 @@ public class ScoreDirectorFactoryFormTest {
     }
 
     @Test
-    public void testOnNameChangeNull() throws Exception {
+    public void onNameChangeNull() throws Exception {
         ScoreDirectorFactoryConfigModel model = new ScoreDirectorFactoryConfigModel();
 
         form.setModel( model, path );
@@ -126,7 +126,7 @@ public class ScoreDirectorFactoryFormTest {
     }
 
     @Test
-    public void testSelectScoreDefinitionType() throws Exception {
+    public void selectScoreDefinitionType() throws Exception {
         ScoreDirectorFactoryConfigModel model = new ScoreDirectorFactoryConfigModel();
         form.setModel( model, path );
 

--- a/optaplanner-wb-screens/optaplanner-wb-solver-editor/optaplanner-wb-solver-editor-client/src/test/java/org/optaplanner/workbench/screens/solver/client/editor/SolverEditorPresenterTest.java
+++ b/optaplanner-wb-screens/optaplanner-wb-solver-editor/optaplanner-wb-solver-editor-client/src/test/java/org/optaplanner/workbench/screens/solver/client/editor/SolverEditorPresenterTest.java
@@ -112,7 +112,7 @@ public class SolverEditorPresenterTest {
     }
 
     @Test
-    public void testLoad() throws Exception {
+    public void load() throws Exception {
         presenter.onStartup( path,
                              mock( PlaceRequest.class ) );
 

--- a/optaplanner-wb-screens/optaplanner-wb-solver-editor/optaplanner-wb-solver-editor-client/src/test/java/org/optaplanner/workbench/screens/solver/client/editor/TerminationConfigFormTest.java
+++ b/optaplanner-wb-screens/optaplanner-wb-solver-editor/optaplanner-wb-solver-editor-client/src/test/java/org/optaplanner/workbench/screens/solver/client/editor/TerminationConfigFormTest.java
@@ -50,7 +50,7 @@ public class TerminationConfigFormTest {
     }
 
     @Test
-    public void testSetModel() {
+    public void setModel() {
         TerminationConfigModel terminationConfigModel = new TerminationConfigModel();
         terminationConfigModel.setBestScoreFeasible( Boolean.TRUE );
         terminationConfigModel.setMillisecondsSpentLimit( 10l );

--- a/optaplanner-wb-screens/optaplanner-wb-solver-editor/optaplanner-wb-solver-editor-client/src/test/java/org/optaplanner/workbench/screens/solver/client/editor/TerminationConfigFormViewImplTest.java
+++ b/optaplanner-wb-screens/optaplanner-wb-solver-editor/optaplanner-wb-solver-editor-client/src/test/java/org/optaplanner/workbench/screens/solver/client/editor/TerminationConfigFormViewImplTest.java
@@ -39,7 +39,7 @@ public class TerminationConfigFormViewImplTest {
     }
 
     @Test
-    public void testInitTree() {
+    public void initTree() {
         TreeItem treeItem = new TreeItem();
         terminationConfigFormView.initTree( treeItem );
         verify( tree ).addItem( treeItem );

--- a/optaplanner-wb-webapp/src/test/java/org/optaplanner/workbench/client/OptaPlannerWorkbenchEntryPointTest.java
+++ b/optaplanner-wb-webapp/src/test/java/org/optaplanner/workbench/client/OptaPlannerWorkbenchEntryPointTest.java
@@ -87,7 +87,7 @@ public class OptaPlannerWorkbenchEntryPointTest {
     }
 
     @Test
-    public void setupMenuTest() {
+    public void setupMenu() {
         optaPlannerWorkbenchEntryPoint.setupMenu();
 
         ArgumentCaptor<Menus> menusCaptor = ArgumentCaptor.forClass( Menus.class );


### PR DESCRIPTION
As https://github.com/droolsjbpm/optaplanner-wb/pull/75/ already uses naming convention without "test" pre/suffixes that we agreed on with @ge0ffrey , this PR fixes that optaplanner-wb - wide.

@manstis What about the other projects (e.g. drools-wb), is there any will to update the names as well? 
