### PR TITLE
PLANNER-607 Workbench: Add support for solving test example from the UI

### DIFF
--- a/optaplanner-wb-screens/optaplanner-wb-solver-editor/optaplanner-wb-solver-editor-api/src/main/java/org/optaplanner/workbench/screens/solver/service/SolverEditorService.java
+++ b/optaplanner-wb-screens/optaplanner-wb-solver-editor/optaplanner-wb-solver-editor-api/src/main/java/org/optaplanner/workbench/screens/solver/service/SolverEditorService.java
@@ -15,8 +15,11 @@
  */
 package org.optaplanner.workbench.screens.solver.service;
 
+import java.util.List;
+
 import org.guvnor.common.services.shared.file.SupportsUpdate;
 import org.guvnor.common.services.shared.validation.ValidationService;
+import org.guvnor.common.services.shared.validation.model.ValidationMessage;
 import org.jboss.errai.bus.server.annotations.Remote;
 import org.kie.workbench.common.services.shared.source.ViewSourceService;
 import org.optaplanner.workbench.screens.solver.model.SolverConfigModel;
@@ -41,5 +44,7 @@ public interface SolverEditorService
         SupportsRename {
 
     SolverModelContent loadContent( final Path path );
+
+    List<ValidationMessage> smokeTest( final Path path, final SolverConfigModel config);
 
 }

--- a/optaplanner-wb-screens/optaplanner-wb-solver-editor/optaplanner-wb-solver-editor-backend/src/main/java/org/optaplanner/workbench/screens/solver/backend/server/SolverEditorServiceImpl.java
+++ b/optaplanner-wb-screens/optaplanner-wb-solver-editor/optaplanner-wb-solver-editor-backend/src/main/java/org/optaplanner/workbench/screens/solver/backend/server/SolverEditorServiceImpl.java
@@ -225,4 +225,17 @@ public class SolverEditorServiceImpl
             throw ExceptionUtilities.handleException( e );
         }
     }
+
+    @Override
+    public List<ValidationMessage> smokeTest( final Path path,
+                                              final SolverConfigModel config ) {
+        try {
+
+            return solverValidator.validateAndRun( path,
+                                                   toSource( path, config ) );
+
+        } catch ( Exception e ) {
+            throw ExceptionUtilities.handleException( e );
+        }
+    }
 }

--- a/optaplanner-wb-screens/optaplanner-wb-solver-editor/optaplanner-wb-solver-editor-backend/src/main/java/org/optaplanner/workbench/screens/solver/backend/server/XStreamSolutionImporter.java
+++ b/optaplanner-wb-screens/optaplanner-wb-solver-editor/optaplanner-wb-solver-editor-backend/src/main/java/org/optaplanner/workbench/screens/solver/backend/server/XStreamSolutionImporter.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.optaplanner.workbench.screens.solver.backend.server;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+
+import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.XStreamException;
+
+/**
+ * TODO Remove once org.optaplanner.persistence.xstream.impl.domain.solution.XStreamSolutionFileIO
+ * supports setting custom classloader & read() allows supplying java.io.InputStream parameter
+ */
+public class XStreamSolutionImporter<T> {
+
+    private final XStream xStream;
+
+    public XStreamSolutionImporter( ClassLoader classLoader ) {
+        xStream = new XStream(  );
+        xStream.setClassLoader( classLoader );
+        xStream.setMode( XStream.ID_REFERENCES );
+    }
+
+    public T read( InputStream inputStream ) {
+        try (Reader reader = new InputStreamReader( inputStream, "UTF-8")) {
+            return (T) xStream.fromXML(reader);
+        } catch (XStreamException | IOException e) {
+            throw new IllegalArgumentException("Failed reading solution.", e);
+        }
+    }
+}

--- a/optaplanner-wb-screens/optaplanner-wb-solver-editor/optaplanner-wb-solver-editor-backend/src/main/resources/org/optaplanner/workbench/screens/solver/backend/server/solution/optacloud.xml
+++ b/optaplanner-wb-screens/optaplanner-wb-solver-editor/optaplanner-wb-solver-editor-backend/src/main/resources/org/optaplanner/workbench/screens/solver/backend/server/solution/optacloud.xml
@@ -1,0 +1,48 @@
+<opta.optacloud.CloudSolution id="1">
+  <computerList id="2">
+    <opta.optacloud.Computer id="3">
+      <cpuPower>24</cpuPower>
+      <memory>96</memory>
+      <networkBandwidth>16</networkBandwidth>
+      <cost>4800</cost>
+    </opta.optacloud.Computer>
+    <opta.optacloud.Computer id="4">
+      <cpuPower>6</cpuPower>
+      <memory>4</memory>
+      <networkBandwidth>6</networkBandwidth>
+      <cost>660</cost>
+    </opta.optacloud.Computer>
+  </computerList>
+  <processList id="5">
+    <opta.optacloud.Process id="6">
+      <requiredCpuPower>1</requiredCpuPower>
+      <requiredMemory>1</requiredMemory>
+      <requiredNetworkBandwidth>1</requiredNetworkBandwidth>
+    </opta.optacloud.Process>
+    <opta.optacloud.Process id="7">
+      <requiredCpuPower>3</requiredCpuPower>
+      <requiredMemory>6</requiredMemory>
+      <requiredNetworkBandwidth>1</requiredNetworkBandwidth>
+    </opta.optacloud.Process>
+    <opta.optacloud.Process id="8">
+      <requiredCpuPower>1</requiredCpuPower>
+      <requiredMemory>1</requiredMemory>
+      <requiredNetworkBandwidth>3</requiredNetworkBandwidth>
+    </opta.optacloud.Process>
+    <opta.optacloud.Process id="9">
+      <requiredCpuPower>1</requiredCpuPower>
+      <requiredMemory>2</requiredMemory>
+      <requiredNetworkBandwidth>11</requiredNetworkBandwidth>
+    </opta.optacloud.Process>
+    <opta.optacloud.Process id="10">
+      <requiredCpuPower>1</requiredCpuPower>
+      <requiredMemory>1</requiredMemory>
+      <requiredNetworkBandwidth>1</requiredNetworkBandwidth>
+    </opta.optacloud.Process>
+    <opta.optacloud.Process id="11">
+      <requiredCpuPower>1</requiredCpuPower>
+      <requiredMemory>1</requiredMemory>
+      <requiredNetworkBandwidth>5</requiredNetworkBandwidth>
+    </opta.optacloud.Process>
+  </processList>
+</opta.optacloud.CloudSolution>

--- a/optaplanner-wb-screens/optaplanner-wb-solver-editor/optaplanner-wb-solver-editor-client/src/main/java/org/optaplanner/workbench/screens/solver/client/resources/i18n/SolverEditorConstants.java
+++ b/optaplanner-wb-screens/optaplanner-wb-solver-editor/optaplanner-wb-solver-editor-client/src/main/java/org/optaplanner/workbench/screens/solver/client/resources/i18n/SolverEditorConstants.java
@@ -27,6 +27,10 @@ public interface SolverEditorConstants
 
     public static final SolverEditorConstants INSTANCE = GWT.create( SolverEditorConstants.class );
 
+    String SmokeTest();
+
+    String SmokeTestSuccess();
+
     String solverResourceTypeDescription();
 
     String newSolverDescription();

--- a/optaplanner-wb-screens/optaplanner-wb-solver-editor/optaplanner-wb-solver-editor-client/src/main/java/org/optaplanner/workbench/screens/solver/client/util/SuperDevModeFlag.java
+++ b/optaplanner-wb-screens/optaplanner-wb-solver-editor/optaplanner-wb-solver-editor-client/src/main/java/org/optaplanner/workbench/screens/solver/client/util/SuperDevModeFlag.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.optaplanner.workbench.screens.solver.client.util;
+
+public class SuperDevModeFlag {
+
+    public boolean isSuperDevModeUsed() {
+        return false;
+    }
+}

--- a/optaplanner-wb-screens/optaplanner-wb-solver-editor/optaplanner-wb-solver-editor-client/src/main/java/org/optaplanner/workbench/screens/solver/client/util/SuperDevModeUsedFlag.java
+++ b/optaplanner-wb-screens/optaplanner-wb-solver-editor/optaplanner-wb-solver-editor-client/src/main/java/org/optaplanner/workbench/screens/solver/client/util/SuperDevModeUsedFlag.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.optaplanner.workbench.screens.solver.client.util;
+
+public class SuperDevModeUsedFlag extends SuperDevModeFlag {
+
+    @Override
+    public boolean isSuperDevModeUsed() {
+        return true;
+    }
+}

--- a/optaplanner-wb-screens/optaplanner-wb-solver-editor/optaplanner-wb-solver-editor-client/src/main/resources/org/optaplanner/workbench/screens/solver/OptaPlannerWorkbenchSolverEditorClient.gwt.xml
+++ b/optaplanner-wb-screens/optaplanner-wb-solver-editor/optaplanner-wb-solver-editor-client/src/main/resources/org/optaplanner/workbench/screens/solver/OptaPlannerWorkbenchSolverEditorClient.gwt.xml
@@ -32,4 +32,9 @@
 
   <inherits name='org.optaplanner.workbench.screens.solver.OptaPlannerWorkbenchSolverEditorAPI'/>
 
+  <replace-with class="org.optaplanner.workbench.screens.solver.client.util.SuperDevModeUsedFlag">
+    <when-type-is class="org.optaplanner.workbench.screens.solver.client.util.SuperDevModeFlag"/>
+    <when-property-is name="superdevmode" value="on" />
+  </replace-with>
+
 </module>

--- a/optaplanner-wb-screens/optaplanner-wb-solver-editor/optaplanner-wb-solver-editor-client/src/main/resources/org/optaplanner/workbench/screens/solver/client/resources/i18n/SolverEditorConstants.properties
+++ b/optaplanner-wb-screens/optaplanner-wb-solver-editor/optaplanner-wb-solver-editor-client/src/main/resources/org/optaplanner/workbench/screens/solver/client/resources/i18n/SolverEditorConstants.properties
@@ -13,6 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+SmokeTest=Smoke test
+SmokeTestSuccess=Smoke test finished successfully.
+SmokeTestUnsupported=Running a smoke test for this project is not supported.
 solverResourceTypeDescription=Solver configuration
 newSolverDescription=Solver configuration
 Source=Source

--- a/optaplanner-wb-screens/optaplanner-wb-solver-editor/optaplanner-wb-solver-editor-client/src/test/java/org/optaplanner/workbench/screens/solver/client/editor/SolverEditorPresenterTest.java
+++ b/optaplanner-wb-screens/optaplanner-wb-solver-editor/optaplanner-wb-solver-editor-client/src/test/java/org/optaplanner/workbench/screens/solver/client/editor/SolverEditorPresenterTest.java
@@ -167,6 +167,11 @@ public class SolverEditorPresenterTest {
                 return null;
             }
 
+            @Override
+            public List<ValidationMessage> smokeTest( Path path, SolverConfigModel config ) {
+                return null;
+            }
+
             @Override public Path copy( Path path, String newName, String comment ) {
                 return null;
             }


### PR DESCRIPTION
Motivation behind the change - it's essential to have a feature which allows us to test the ability to check current solver configuration in a quick way, without the need to build/deploy/rest query etc. With the help of this feature, we can discover configuration issues which appear only when the solver is actually run (as opposed to just building the project). 
Currently only optacloud example is supported, optawedding will be added once https://issues.jboss.org/browse/PLANNER-590 is resolved.
