### PR TITLE
PLANNER-620 Workbench: CH: Support difficulty comparator definition

### DIFF
--- a/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-api/pom.xml
+++ b/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-api/pom.xml
@@ -32,4 +32,26 @@
   <name>OptaPlanner Workbench - Domain Editor API</name>
   <description>OptaPlanner Workbench - Domain API</description>
 
+
+  <dependencies>
+
+    <!-- dependencies added because of new illegal transitive dependency check -->
+    <dependency>
+      <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-bus</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-common</artifactId>
+    </dependency>
+
+    <!-- Regular dependencies -->
+    <dependency>
+      <groupId>org.kie.workbench.services</groupId>
+      <artifactId>kie-wb-common-data-modeller-core</artifactId>
+    </dependency>
+
+  </dependencies>
+
 </project>

--- a/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-api/src/main/java/org/optaplanner/workbench/screens/domaineditor/model/ComparatorDefinition.java
+++ b/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-api/src/main/java/org/optaplanner/workbench/screens/domaineditor/model/ComparatorDefinition.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.screens.domaineditor.model;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Added to a planning entity, the annotation contains definition of object properties used for comparison. Avoids parsing of compare method body.
+ *
+ * The following format is used: fqn:property-fqn:nestedProperty-fqn:moreNestedProperty=asc.
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ComparatorDefinition {
+
+    String[] fieldPaths() default {};
+
+}

--- a/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-api/src/main/java/org/optaplanner/workbench/screens/domaineditor/model/ComparatorObject.java
+++ b/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-api/src/main/java/org/optaplanner/workbench/screens/domaineditor/model/ComparatorObject.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.screens.domaineditor.model;
+
+import java.util.List;
+
+import org.kie.workbench.common.services.datamodeller.core.JavaClass;
+
+/**
+ * Contains definitions of selected object properties and generated compare method. Added as a nested static class to a planning entity.
+ */
+public interface ComparatorObject extends JavaClass {
+
+    void setType(String type);
+
+    String getType();
+
+    List<ObjectPropertyPath> getObjectPropertyPathList();
+
+    void setObjectPropertyPathList(List<ObjectPropertyPath> objectPropertyPaths);
+
+}

--- a/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-api/src/main/java/org/optaplanner/workbench/screens/domaineditor/model/ComparatorObjectImpl.java
+++ b/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-api/src/main/java/org/optaplanner/workbench/screens/domaineditor/model/ComparatorObjectImpl.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.screens.domaineditor.model;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jboss.errai.common.client.api.annotations.Portable;
+import org.kie.workbench.common.services.datamodeller.core.Visibility;
+import org.kie.workbench.common.services.datamodeller.core.impl.JavaClassImpl;
+
+@Portable
+public class ComparatorObjectImpl extends JavaClassImpl implements ComparatorObject {
+
+    private List<ObjectPropertyPath> objectPropertyPathList = new ArrayList<>(  );
+    private String type;
+
+    public ComparatorObjectImpl() {
+    }
+
+    public ComparatorObjectImpl( String packageName, String name, Visibility visibility, boolean isAbstract, boolean isFinal ) {
+        super( packageName, name, visibility, isAbstract, isFinal );
+    }
+
+    public ComparatorObjectImpl( String packageName, String className ) {
+        super(packageName, className);
+    }
+
+    @Override
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    @Override
+    public String getType() {
+        return type;
+    }
+
+    @Override
+    public List<ObjectPropertyPath> getObjectPropertyPathList() {
+        return objectPropertyPathList;
+    }
+
+    @Override
+    public void setObjectPropertyPathList(List<ObjectPropertyPath> objectPropertyPathList) {
+        this.objectPropertyPathList = objectPropertyPathList;
+    }
+
+}

--- a/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-api/src/main/java/org/optaplanner/workbench/screens/domaineditor/model/ObjectPropertyPath.java
+++ b/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-api/src/main/java/org/optaplanner/workbench/screens/domaineditor/model/ObjectPropertyPath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,23 +14,22 @@
  * limitations under the License.
  */
 
-package org.optaplanner.workbench.screens.domaineditor.client.resources.i18n;
+package org.optaplanner.workbench.screens.domaineditor.model;
 
-import com.google.gwt.core.client.GWT;
-import com.google.gwt.i18n.client.Messages;
+import java.util.List;
+
+import org.kie.workbench.common.services.datamodeller.core.ObjectProperty;
 
 /**
- * Domain Editor i18n constants.
+ * Defines a chain of object properties to be used for comparison, starting from a planning entity.
  */
-public interface DomainEditorConstants
-        extends Messages {
+public interface ObjectPropertyPath {
 
-    DomainEditorConstants INSTANCE = GWT.create( DomainEditorConstants.class );
+    List<ObjectProperty> getObjectPropertyPath();
 
-    String planner_domain_screen_name();
+    void appendObjectProperty( ObjectProperty objectProperty );
 
-    String UnexpectedErrorComparatorInit();
+    void setDescending( boolean descending );
 
-    String UnexpectedErrorComparatorUpdate();
-
+    boolean isDescending();
 }

--- a/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-api/src/main/java/org/optaplanner/workbench/screens/domaineditor/model/ObjectPropertyPathImpl.java
+++ b/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-api/src/main/java/org/optaplanner/workbench/screens/domaineditor/model/ObjectPropertyPathImpl.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.screens.domaineditor.model;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jboss.errai.common.client.api.annotations.Portable;
+import org.kie.workbench.common.services.datamodeller.core.ObjectProperty;
+
+@Portable
+public class ObjectPropertyPathImpl implements ObjectPropertyPath {
+
+    private List<ObjectProperty> objectPropertyList = new ArrayList<>();
+    private boolean descending;
+
+    public ObjectPropertyPathImpl() {
+    }
+
+    @Override
+    public List<ObjectProperty> getObjectPropertyPath() {
+        return objectPropertyList;
+    }
+
+    @Override
+    public void appendObjectProperty( ObjectProperty objectProperty ) {
+        objectPropertyList.add( objectProperty );
+    }
+
+    @Override
+    public void setDescending( boolean descending ) {
+        this.descending = descending;
+    }
+
+    @Override
+    public boolean isDescending() {
+        return descending;
+    }
+}

--- a/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-api/src/main/java/org/optaplanner/workbench/screens/domaineditor/service/PlannerDataObjectEditorService.java
+++ b/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-api/src/main/java/org/optaplanner/workbench/screens/domaineditor/service/PlannerDataObjectEditorService.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.screens.domaineditor.service;
+
+import java.util.List;
+
+import org.jboss.errai.bus.server.annotations.Remote;
+import org.kie.workbench.common.services.datamodeller.core.Annotation;
+import org.kie.workbench.common.services.datamodeller.core.DataModel;
+import org.kie.workbench.common.services.datamodeller.core.DataObject;
+import org.optaplanner.workbench.screens.domaineditor.model.ComparatorObject;
+import org.optaplanner.workbench.screens.domaineditor.model.ObjectPropertyPath;
+
+@Remote
+public interface PlannerDataObjectEditorService {
+
+    ComparatorObject extractComparatorObject( DataObject dataObject, DataModel dataModel );
+
+    ComparatorObject updateComparatorObject( DataObject dataObject, ComparatorObject comparatorObject, List<ObjectPropertyPath> objectPropertyPaths );
+
+}

--- a/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-backend/pom.xml
+++ b/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-backend/pom.xml
@@ -33,6 +33,33 @@
 
   <dependencies>
 
+    <!-- dependencies added because of new illegal transitive dependency check -->
+    <dependency>
+      <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-bus</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.forge.roaster</groupId>
+      <artifactId>roaster-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.kie.workbench.services</groupId>
+      <artifactId>kie-wb-common-refactoring-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.kie.workbench.services</groupId>
+      <artifactId>kie-wb-common-refactoring-backend</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+
+    <!-- Regular dependencies -->
     <dependency>
       <groupId>org.optaplanner</groupId>
       <artifactId>optaplanner-core</artifactId>
@@ -51,6 +78,11 @@
     <dependency>
       <groupId>org.optaplanner</groupId>
       <artifactId>optaplanner-wb-domain-editor-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.kie.workbench.services</groupId>
+      <artifactId>kie-wb-common-refactoring-api</artifactId>
     </dependency>
 
   </dependencies>

--- a/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-backend/src/main/java/org/optaplanner/workbench/screens/domaineditor/backend/server/ComparatorDefinitionIndexerExtension.java
+++ b/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-backend/src/main/java/org/optaplanner/workbench/screens/domaineditor/backend/server/ComparatorDefinitionIndexerExtension.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.screens.domaineditor.backend.server;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.jboss.forge.roaster.model.Annotation;
+import org.jboss.forge.roaster.model.JavaType;
+import org.kie.workbench.common.screens.datamodeller.backend.server.indexing.JavaFileIndexerExtension;
+import org.kie.workbench.common.services.refactoring.backend.server.indexing.DefaultIndexBuilder;
+import org.kie.workbench.common.services.refactoring.model.index.ResourceReference;
+import org.kie.workbench.common.services.refactoring.service.PartType;
+import org.kie.workbench.common.services.refactoring.service.ResourceType;
+import org.optaplanner.workbench.screens.domaineditor.model.ComparatorDefinition;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@ApplicationScoped
+public class ComparatorDefinitionIndexerExtension implements JavaFileIndexerExtension {
+
+    private static final Logger logger = LoggerFactory.getLogger( ComparatorDefinitionIndexerExtension.class );
+
+    @Override
+    public void process( DefaultIndexBuilder builder, JavaType javaType ) {
+        try {
+            Annotation comparatorDefinition = javaType.getAnnotation( ComparatorDefinition.class.getName() );
+
+            if ( comparatorDefinition == null ) {
+                return;
+            }
+
+            if ( javaType.getSyntaxErrors() == null || javaType.getSyntaxErrors().isEmpty() ) {
+
+                String[] fieldPathDefinitions = comparatorDefinition.getStringArrayValue( "fieldPaths" );
+
+                String previousFullyQualifiedClassname = null;
+
+                if ( fieldPathDefinitions != null ) {
+                    for ( String fieldPathDefinition : fieldPathDefinitions ) {
+                        if ( !fieldPathDefinition.matches( "\\w[\\.\\w]*:\\w[\\-\\w[\\.\\w]*:\\w]*=(asc|desc)" ) ) {
+                            throw new IllegalStateException( "Invalid field path string " + fieldPathDefinition );
+                        }
+                        String[] fieldPathDefinitionParts = fieldPathDefinition.split( "=" );
+                        String[] fieldPath = fieldPathDefinitionParts[0].split( "-" );
+
+                        previousFullyQualifiedClassname = fieldPath[0].split( ":" )[0];
+
+                        for (int i = 1; i < fieldPath.length; i++) {
+                            String[] fieldPathElementPair = fieldPath[i].split( ":" );
+
+                            ResourceReference resourceReference = new ResourceReference( previousFullyQualifiedClassname, ResourceType.JAVA );
+                            resourceReference.addPartReference( fieldPathElementPair[1], PartType.FIELD );
+
+                            previousFullyQualifiedClassname = fieldPathElementPair[0];
+
+                            builder.addGenerator( resourceReference );
+                        }
+                    }
+                }
+            }
+        } catch ( Exception e ) {
+            logger.error( "Unable to index comparator definition for " + javaType.getQualifiedName() );
+        }
+    }
+}

--- a/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-backend/src/main/java/org/optaplanner/workbench/screens/domaineditor/backend/server/PlannerDataObjectEditorServiceImpl.java
+++ b/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-backend/src/main/java/org/optaplanner/workbench/screens/domaineditor/backend/server/PlannerDataObjectEditorServiceImpl.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.screens.domaineditor.backend.server;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.enterprise.context.ApplicationScoped;
+
+import org.jboss.errai.bus.server.annotations.Service;
+import org.kie.workbench.common.services.datamodeller.codegen.GenerationTools;
+import org.kie.workbench.common.services.datamodeller.core.Annotation;
+import org.kie.workbench.common.services.datamodeller.core.DataModel;
+import org.kie.workbench.common.services.datamodeller.core.DataObject;
+import org.kie.workbench.common.services.datamodeller.core.Method;
+import org.kie.workbench.common.services.datamodeller.core.ObjectProperty;
+import org.kie.workbench.common.services.datamodeller.core.impl.MethodImpl;
+import org.optaplanner.workbench.screens.domaineditor.model.ComparatorDefinition;
+import org.optaplanner.workbench.screens.domaineditor.model.ComparatorObject;
+import org.optaplanner.workbench.screens.domaineditor.model.ComparatorObjectImpl;
+import org.optaplanner.workbench.screens.domaineditor.model.ObjectPropertyPath;
+import org.optaplanner.workbench.screens.domaineditor.model.ObjectPropertyPathImpl;
+import org.optaplanner.workbench.screens.domaineditor.service.PlannerDataObjectEditorService;
+
+import static org.kie.workbench.common.services.datamodeller.codegen.GenerationTools.EOL;
+
+@Service
+@ApplicationScoped
+public class PlannerDataObjectEditorServiceImpl implements PlannerDataObjectEditorService {
+
+    private GenerationTools generationTools = new GenerationTools();
+
+    @Override
+    public ComparatorObject extractComparatorObject( DataObject dataObject, DataModel dataModel ) {
+        Annotation comparatorDefinition = dataObject.getAnnotation( ComparatorDefinition.class.getName() );
+        if ( comparatorDefinition == null ) {
+            return null;
+        }
+        List<String> fieldPathDefinitions = (List<String>) comparatorDefinition.getValue( "fieldPaths" );
+
+        if ( fieldPathDefinitions == null || fieldPathDefinitions.isEmpty() ) {
+            return null;
+        }
+
+        List<ObjectPropertyPath> objectPropertyPaths = new ArrayList<>();
+
+        for ( String fieldPathDefinition : fieldPathDefinitions ) {
+            if ( !fieldPathDefinition.matches( "\\w[\\.\\w]*:\\w[\\-\\w[\\.\\w]*:\\w]*=(asc|desc)" ) ) {
+                throw new IllegalStateException( "Invalid field path string (service)" + fieldPathDefinition );
+            }
+            String[] fieldPathDefinitionParts = fieldPathDefinition.split( "=" );
+            String[] fieldPath = fieldPathDefinitionParts[0].split( "\\-" );
+            List<String> fieldPaths = Arrays.asList( fieldPath ).stream().map( o -> o.split( ":" )[1] ).collect( Collectors.toList() );
+            boolean descending = fieldPathDefinitionParts[1].equals( "desc" );
+
+            ObjectPropertyPath objectPropertyPath = new ObjectPropertyPathImpl();
+
+            ObjectProperty objectProperty = dataObject.getProperty( fieldPaths.get( 0 ) );
+            if ( objectProperty == null ) {
+                throw new IllegalStateException( "Field " + fieldPaths.get( 0 ) + " not found in data object " + dataObject.getClassName() );
+            }
+
+            objectPropertyPath.appendObjectProperty( objectProperty );
+
+            for ( int i = 1; i < fieldPaths.size(); i++ ) {
+                ObjectProperty lastObjectPropertyInPath = objectPropertyPath.getObjectPropertyPath().get( objectPropertyPath.getObjectPropertyPath().size() - 1 );
+                if ( lastObjectPropertyInPath.isBaseType() || lastObjectPropertyInPath.isPrimitiveType() ) {
+                    throw new IllegalStateException( "Cannot append property " + fieldPaths.get( i ) + " to primitive/base type " + lastObjectPropertyInPath.getClassName() );
+                }
+                DataObject lastDataObjectInPath = dataModel.getDataObject( lastObjectPropertyInPath.getClassName() );
+                if ( lastObjectPropertyInPath == null ) {
+                    throw new IllegalStateException( "Data object " + lastObjectPropertyInPath.getClassName() + " not found" );
+                }
+                ObjectProperty currentObjectProperty = lastDataObjectInPath.getProperty( fieldPaths.get( i ) );
+                if ( currentObjectProperty == null ) {
+                    throw new IllegalStateException( "Property " + fieldPaths.get( i ) + " not found in data object " + lastDataObjectInPath.getClassName() );
+                }
+                objectPropertyPath.appendObjectProperty( currentObjectProperty );
+            }
+
+            objectPropertyPath.setDescending( descending );
+            objectPropertyPaths.add( objectPropertyPath );
+        }
+
+        List<String> objectPropertyPathList = new ArrayList<>();
+        for ( ObjectPropertyPath objectPropertyPath : objectPropertyPaths ) {
+            StringBuilder pathBuilder = new StringBuilder();
+            List<ObjectProperty> path = objectPropertyPath.getObjectPropertyPath();
+            for ( int i = 0; i < path.size(); i++ ) {
+                ObjectProperty objectProperty = path.get( i );
+
+                pathBuilder.append( objectProperty.getClassName() )
+                        .append( ":" )
+                        .append( objectProperty.getName() );
+                if ( i != path.size() - 1 ) {
+                    pathBuilder.append( "-" );
+                }
+            }
+            pathBuilder.append( "=" )
+                    .append( objectPropertyPath.isDescending() ? "desc" : "asc" );
+            objectPropertyPathList.add( pathBuilder.toString() );
+        }
+
+        if ( objectPropertyPathList.isEmpty() ) {
+            return null;
+        }
+
+        ComparatorObject comparatorObject = new ComparatorObjectImpl( "", dataObject.getName() + "Comparator" );
+        comparatorObject.setType( dataObject.getClassName() );
+        comparatorObject.addInterface( "java.util.Comparator<" + dataObject.getClassName() + ">" );
+        comparatorObject.setObjectPropertyPathList( objectPropertyPaths );
+        comparatorObject.addMethod( getCompareMethod( comparatorObject ) );
+
+        return comparatorObject;
+    }
+
+    @Override
+    public ComparatorObject updateComparatorObject( DataObject dataObject, ComparatorObject comparatorObject, List<ObjectPropertyPath> objectPropertyPaths ) {
+        if ( objectPropertyPaths == null || objectPropertyPaths.isEmpty() ) {
+            return null;
+        }
+        if ( comparatorObject == null ) {
+            comparatorObject = new ComparatorObjectImpl( "", dataObject.getName() + "Comparator" );
+        }
+        comparatorObject.setName( dataObject.getName() + "Comparator" );
+        comparatorObject.setType( dataObject.getClassName() );
+        comparatorObject.getInterfaces().clear();
+        comparatorObject.addInterface( "java.util.Comparator<" + dataObject.getClassName() + ">" );
+        comparatorObject.setObjectPropertyPathList( objectPropertyPaths );
+        comparatorObject.getMethods().clear();
+        comparatorObject.addMethod( getCompareMethod( comparatorObject ) );
+
+        return comparatorObject;
+    }
+
+
+    private Method getCompareMethod( ComparatorObject comparatorObject ) {
+        return new MethodImpl( "compare", Arrays.asList( comparatorObject.getType(), comparatorObject.getType() ), generateCompareBody( comparatorObject ), "int" );
+    }
+
+    public String generateCompareBody( ComparatorObject comparatorObject ) {
+        StringBuilder sb = new StringBuilder();
+        sb.append( "return java.util.Comparator" );
+
+        List<ObjectPropertyPath> objectPropertyPathList = comparatorObject.getObjectPropertyPathList();
+        if ( objectPropertyPathList == null || objectPropertyPathList.isEmpty() ) {
+            throw new IllegalStateException( "No comparing fields have been specified" );
+        }
+        ObjectPropertyPath firstObjectPropertyPath = objectPropertyPathList.get( 0 );
+        sb.append( getComparingRow( firstObjectPropertyPath, true, comparatorObject ) );
+        for ( int i = 1; i < objectPropertyPathList.size(); i++ ) {
+            sb.append( getComparingRow( objectPropertyPathList.get( i ), false, comparatorObject ) );
+        }
+        sb.append( ".compare(o1, o2);" );
+        return sb.toString();
+    }
+
+    private String getComparingRow( ObjectPropertyPath objectPropertyPath, boolean firstElement, ComparatorObject dataObject ) {
+        StringBuilder sb = new StringBuilder();
+        String comparatorMethodName = firstElement ? "comparing" : "thenComparing";
+        sb.append( "." )
+                .append( comparatorMethodName )
+                .append( "( (" )
+                .append( dataObject.getType() )
+                .append( " o) -> { Object tempResult = o;" );
+        String previousObjectPropertyClassName = dataObject.getType();
+        for ( ObjectProperty pathElement : objectPropertyPath.getObjectPropertyPath() ) {
+            sb.append( "tempResult = tempResult == null ? null : " )
+                    .append( "(( " )
+                    .append( previousObjectPropertyClassName )
+                    .append( ") tempResult )." )
+                    .append( generationTools.toJavaGetter( pathElement.getName(), pathElement.getClassName() ) )
+                    .append( "();" );
+            previousObjectPropertyClassName = pathElement.getClassName();
+        }
+        sb.append( "return tempResult; }" );
+        if ( objectPropertyPath.isDescending() ) {
+            sb.append( ", java.util.Comparator.reverseOrder()" );
+        }
+        sb.append( ")" )
+                .append( EOL );
+        return sb.toString();
+    }
+
+}

--- a/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-backend/src/test/java/org/optaplanner/workbench/screens/domaineditor/backend/server/PlannerDataObjectEditorServiceTest.java
+++ b/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-backend/src/test/java/org/optaplanner/workbench/screens/domaineditor/backend/server/PlannerDataObjectEditorServiceTest.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.screens.domaineditor.backend.server;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.services.datamodeller.core.Annotation;
+import org.kie.workbench.common.services.datamodeller.core.DataModel;
+import org.kie.workbench.common.services.datamodeller.core.DataObject;
+import org.kie.workbench.common.services.datamodeller.core.ObjectProperty;
+import org.kie.workbench.common.services.datamodeller.core.impl.AnnotationImpl;
+import org.kie.workbench.common.services.datamodeller.core.impl.DataModelImpl;
+import org.kie.workbench.common.services.datamodeller.core.impl.DataObjectImpl;
+import org.kie.workbench.common.services.datamodeller.core.impl.ObjectPropertyImpl;
+import org.kie.workbench.common.services.datamodeller.util.DriverUtils;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.optaplanner.workbench.screens.domaineditor.model.ComparatorDefinition;
+import org.optaplanner.workbench.screens.domaineditor.model.ComparatorObject;
+import org.optaplanner.workbench.screens.domaineditor.model.ObjectPropertyPath;
+import org.optaplanner.workbench.screens.domaineditor.service.PlannerDataObjectEditorService;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PlannerDataObjectEditorServiceTest {
+
+    private DataModel dataModel;
+
+    private DataObject dataObject1;
+
+    private DataObject dataObject2;
+
+    private PlannerDataObjectEditorService service ;
+
+    @Before
+    public void setUp() {
+        dataModel = getDataModel();
+        service = new PlannerDataObjectEditorServiceImpl();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void invalidAnnotationFieldPathNoOrder() {
+        DataObject dataObject = mock(DataObject.class);
+        when( dataObject.getAnnotation( ComparatorDefinition.class.getName() ) ).thenReturn( getAnnotation( Arrays.asList("abc.def=") ) );
+        service.extractComparatorObject( dataObject, dataModel );
+
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void invalidAnnotationFieldPathWrongOrder() {
+        DataObject dataObject = mock(DataObject.class);
+        when( dataObject.getAnnotation( ComparatorDefinition.class.getName() ) ).thenReturn( getAnnotation( Arrays.asList("abc.def=foo") ) );
+        service.extractComparatorObject( dataObject, dataModel );
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void invalidAnnotationFieldPathNoTypesIncluded() {
+        DataObject dataObject = mock(DataObject.class);
+        when( dataObject.getAnnotation( ComparatorDefinition.class.getName() ) ).thenReturn( getAnnotation( Arrays.asList("abc,def=desc") ) );
+        service.extractComparatorObject( dataObject, dataModel );
+    }
+
+    @Test
+    public void validFieldPathBaseProperty() {
+        dataObject1.addAnnotation( getAnnotation( Arrays.asList("foo.bar.DataObject1:dataObject1Property1=desc") ) );
+        ComparatorObject result = service.extractComparatorObject( dataObject1, dataModel );
+
+        List<ObjectPropertyPath> objectPropertyPathList = result.getObjectPropertyPathList();
+        Assert.assertEquals( 1, objectPropertyPathList.size());
+
+        ObjectPropertyPath objectPropertyPath = objectPropertyPathList.get( 0 );
+        Assert.assertEquals( Arrays.asList( dataObject1.getProperty( "dataObject1Property1" ) ), objectPropertyPath.getObjectPropertyPath() );
+        Assert.assertEquals( true, objectPropertyPath.isDescending() );
+    }
+
+    @Test
+    public void validFieldPathComplexProperty() {
+        dataObject1.addAnnotation( getAnnotation( Arrays.asList("foo.bar.DataObject1:dataObject1Property2=asc") ) );
+        ComparatorObject result = service.extractComparatorObject( dataObject1, dataModel );
+
+        List<ObjectPropertyPath> objectPropertyPathList = result.getObjectPropertyPathList();
+        Assert.assertEquals( 1, objectPropertyPathList.size());
+
+        ObjectPropertyPath objectPropertyPath = objectPropertyPathList.get( 0 );
+        Assert.assertEquals( Arrays.asList( dataObject1.getProperty( "dataObject1Property2" ) ), objectPropertyPath.getObjectPropertyPath() );
+        Assert.assertEquals( false, objectPropertyPath.isDescending() );
+    }
+
+    @Test
+    public void validFieldPathNestedProperties() {
+        dataObject1.addAnnotation( getAnnotation( Arrays.asList("foo.bar.DataObject1:dataObject1Property2-foo.bar.DataObject2:dataObjext2Property1=desc") ) );
+        ComparatorObject result = service.extractComparatorObject( dataObject1, dataModel );
+
+        List<ObjectPropertyPath> objectPropertyPathList = result.getObjectPropertyPathList();
+        Assert.assertEquals( 1, objectPropertyPathList.size());
+
+        ObjectPropertyPath objectPropertyPath = objectPropertyPathList.get( 0 );
+        Assert.assertEquals( Arrays.asList( dataObject1.getProperty( "dataObject1Property2"), dataObject2.getProperty( "dataObjext2Property1" ) ), objectPropertyPath.getObjectPropertyPath() );
+        Assert.assertEquals( true, objectPropertyPath.isDescending() );
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void invalidFieldPathNonExistentProperty() {
+        dataObject1.addAnnotation( getAnnotation( Arrays.asList("foo.bar.DataObject1:nonExistentProperty=desc") ) );
+        service.extractComparatorObject( dataObject1, dataModel );
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void invalidFieldPathNonExistentNestedProperty() {
+        dataObject1.addAnnotation( getAnnotation( Arrays.asList("foo.bar.DataObject1:dataObject1Property2-java.lang.Integer:nonExistentProperty=desc") ) );
+        service.extractComparatorObject( dataObject1, dataModel );
+    }
+
+    private Annotation getAnnotation(List<String> fieldPaths) {
+        Annotation annotation = new AnnotationImpl( DriverUtils.buildAnnotationDefinition( ComparatorDefinition.class ) );
+        annotation.setValue( "fieldPaths", fieldPaths );
+        return annotation;
+    }
+
+    private DataModel getDataModel() {
+        DataModel dataModel = new DataModelImpl();
+
+        DataObject dataObject1 = new DataObjectImpl( "bar.foo", "DataObject1" );
+        ObjectProperty dataObject1Property1 = new ObjectPropertyImpl( "dataObject1Property1", "java.lang.Integer", false );
+        ObjectProperty dataObject1Property2 = new ObjectPropertyImpl( "dataObject1Property2", "bar.foo.DataObject2", false );
+        dataObject1.addProperty( dataObject1Property1 );
+        dataObject1.addProperty( dataObject1Property2 );
+        dataModel.addDataObject( dataObject1 );
+
+        DataObject dataObject2 = new DataObjectImpl( "bar.foo", "DataObject2" );
+        ObjectProperty dataObject2Property1 = new ObjectPropertyImpl( "dataObjext2Property1", "java.lang.Double", false );
+        dataObject2.addProperty( dataObject2Property1 );
+        dataModel.addDataObject( dataObject2 );
+
+        this.dataObject1 = dataObject1;
+        this.dataObject2 = dataObject2;
+
+        return dataModel;
+    }
+
+}

--- a/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-client/pom.xml
+++ b/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-client/pom.xml
@@ -58,6 +58,10 @@
       <artifactId>errai-ioc</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.kie.workbench.services</groupId>
+      <artifactId>kie-wb-common-services-api</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-api</artifactId>
     </dependency>

--- a/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-client/src/main/java/org/optaplanner/workbench/screens/domaineditor/client/handlers/planner/PlannerDomainHandler.java
+++ b/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-client/src/main/java/org/optaplanner/workbench/screens/domaineditor/client/handlers/planner/PlannerDomainHandler.java
@@ -16,16 +16,41 @@
 
 package org.optaplanner.workbench.screens.domaineditor.client.handlers.planner;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.ListIterator;
 import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
 
+import org.jboss.errai.common.client.api.Caller;
+import org.jboss.errai.common.client.api.RemoteCallback;
 import org.kie.workbench.common.screens.datamodeller.client.command.DataModelCommand;
 import org.kie.workbench.common.screens.datamodeller.client.handlers.DomainHandler;
 import org.kie.workbench.common.screens.datamodeller.client.widgets.common.domain.ResourceOptions;
+import org.kie.workbench.common.screens.datamodeller.events.ChangeType;
 import org.kie.workbench.common.screens.datamodeller.events.DataModelerEvent;
-import org.kie.workbench.common.screens.datamodeller.events.DataModelerValueChangeEvent;
+import org.kie.workbench.common.screens.datamodeller.events.DataObjectChangeEvent;
+import org.kie.workbench.common.screens.datamodeller.events.DataObjectFieldChangeEvent;
+import org.kie.workbench.common.screens.datamodeller.events.DataObjectFieldDeletedEvent;
+import org.kie.workbench.common.services.datamodeller.core.Annotation;
+import org.kie.workbench.common.services.datamodeller.core.DataObject;
+import org.kie.workbench.common.services.datamodeller.core.JavaClass;
+import org.kie.workbench.common.services.datamodeller.core.ObjectProperty;
+import org.optaplanner.workbench.screens.domaineditor.model.ComparatorDefinition;
+import org.optaplanner.workbench.screens.domaineditor.model.ComparatorObject;
+import org.optaplanner.workbench.screens.domaineditor.model.ObjectPropertyPath;
+import org.optaplanner.workbench.screens.domaineditor.model.PlannerDomainAnnotations;
+import org.optaplanner.workbench.screens.domaineditor.service.PlannerDataObjectEditorService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @ApplicationScoped
 public class PlannerDomainHandler implements DomainHandler {
+
+    private static final Logger logger = LoggerFactory.getLogger( PlannerDomainHandler.class );
+
+    @Inject
+    private Caller<PlannerDataObjectEditorService> plannerDataObjectEditorService;
 
     public PlannerDomainHandler() {
     }
@@ -53,6 +78,193 @@ public class PlannerDomainHandler implements DomainHandler {
 
     @Override
     public void postEventProcessing( DataModelerEvent event ) {
-        //not apply for this domain.
+        try {
+            DataObject dataObject = event.getCurrentDataObject();
+            if ( dataObject.getAnnotation( PlannerDomainAnnotations.PLANNING_ENTITY_ANNOTATION ) != null ) {
+                Annotation comparatorDefinition = dataObject.getAnnotation( ComparatorDefinition.class.getName() );
+                if ( comparatorDefinition == null ) {
+                    return;
+                }
+                if ( dataObject.getNestedClasses() == null || dataObject.getNestedClasses().isEmpty() ) {
+                    return;
+                }
+
+                ComparatorObject comparatorObject = getComparatorNestedClass( dataObject );
+
+                if ( event instanceof DataObjectFieldDeletedEvent ) {
+                    boolean changed = false;
+                    ListIterator<ObjectPropertyPath> objectPropertyPathListIterator = comparatorObject.getObjectPropertyPathList().listIterator();
+                    while ( objectPropertyPathListIterator.hasNext() ) {
+                        ObjectPropertyPath objectPropertyPath = objectPropertyPathListIterator.next();
+                        ListIterator<ObjectProperty> iterator = objectPropertyPath.getObjectPropertyPath().listIterator();
+                        boolean remove = false;
+                        while ( iterator.hasNext() ) {
+                            ObjectProperty objectProperty = iterator.next();
+                            if ( remove ) {
+                                iterator.remove();
+                                continue;
+                            }
+                            if ( objectProperty.equals( event.getCurrentField() ) ) {
+                                iterator.remove();
+                                remove = true;
+                                changed = true;
+                            }
+                        }
+                        if ( objectPropertyPath.getObjectPropertyPath().isEmpty() ) {
+                            objectPropertyPathListIterator.remove();
+                        }
+                    }
+                    if ( changed ) {
+                        plannerDataObjectEditorService.call( new RemoteCallback<ComparatorObject>() {
+                            @Override
+                            public void callback( ComparatorObject updatedComparatorObject ) {
+                                dataObject.getNestedClasses().clear();
+                                if ( updatedComparatorObject != null ) {
+                                    dataObject.addNestedClass( updatedComparatorObject );
+
+                                    comparatorDefinition.setValue( "fieldPaths", getAnnotationDef( updatedComparatorObject.getObjectPropertyPathList() ) );
+                                } else {
+                                    dataObject.removeAnnotation( comparatorDefinition.getClassName() );
+                                    Annotation planningEntityAnnotation = dataObject.getAnnotation( PlannerDomainAnnotations.PLANNING_ENTITY_ANNOTATION );
+                                    if ( planningEntityAnnotation != null ) {
+                                        planningEntityAnnotation.removeValue( "difficultyComparatorClass" );
+                                    }
+                                }
+                            }
+                        } ).updateComparatorObject( dataObject, comparatorObject, comparatorObject.getObjectPropertyPathList() );
+                    }
+                } else if ( event instanceof DataObjectChangeEvent ) {
+                    if ( ( (DataObjectChangeEvent) event ).getChangeType() == ChangeType.OBJECT_NAME_CHANGE
+                            || ( (DataObjectChangeEvent) event ).getChangeType() == ChangeType.PACKAGE_NAME_CHANGE
+                            || ( (DataObjectChangeEvent) event ).getChangeType() == ChangeType.CLASS_NAME_CHANGE ) {
+
+                        Annotation planningEntityAnnotation = dataObject.getAnnotation( PlannerDomainAnnotations.PLANNING_ENTITY_ANNOTATION );
+                        planningEntityAnnotation.setValue( "difficultyComparatorClass", dataObject.getName() + "." + dataObject.getName() + "Comparator.class" );
+
+                        plannerDataObjectEditorService.call( new RemoteCallback<ComparatorObject>() {
+                            @Override
+                            public void callback( ComparatorObject updatedComparatorObject ) {
+                                dataObject.getNestedClasses().clear();
+                                if ( updatedComparatorObject != null ) {
+                                    dataObject.addNestedClass( updatedComparatorObject );
+
+                                    comparatorDefinition.setValue( "fieldPaths", getAnnotationDef( updatedComparatorObject.getObjectPropertyPathList() ) );
+                                } else {
+                                    dataObject.removeAnnotation( comparatorDefinition.getClassName() );
+                                    Annotation planningEntityAnnotation = dataObject.getAnnotation( PlannerDomainAnnotations.PLANNING_ENTITY_ANNOTATION );
+                                    if ( planningEntityAnnotation != null ) {
+                                        planningEntityAnnotation.removeValue( "difficultyComparatorClass" );
+                                    }
+                                }
+                            }
+                        } ).updateComparatorObject( dataObject, comparatorObject, comparatorObject.getObjectPropertyPathList() );
+                    }
+                } else if ( event instanceof DataObjectFieldChangeEvent ) {
+                    if ( ( (DataObjectFieldChangeEvent) event ).getChangeType() == ChangeType.FIELD_NAME_CHANGE ) {
+                        for ( ObjectPropertyPath objectPropertyPath : comparatorObject.getObjectPropertyPathList() ) {
+                            List<ObjectProperty> objectPropertyList = objectPropertyPath.getObjectPropertyPath();
+                            if ( objectPropertyList != null && !objectPropertyList.isEmpty() ) {
+                                if ( objectPropertyList.get( 0 ).getName().equals( ( (DataObjectFieldChangeEvent) event ).getOldValue() ) ) {
+                                    objectPropertyList.get( 0 ).setName( ( (DataObjectFieldChangeEvent) event ).getNewValue().toString() );
+                                    break;
+                                }
+                            }
+                        }
+
+                        plannerDataObjectEditorService.call( new RemoteCallback<ComparatorObject>() {
+                            @Override
+                            public void callback( ComparatorObject updatedComparatorObject ) {
+                                dataObject.getNestedClasses().clear();
+                                if ( updatedComparatorObject != null ) {
+                                    dataObject.addNestedClass( updatedComparatorObject );
+
+                                    comparatorDefinition.setValue( "fieldPaths", getAnnotationDef( updatedComparatorObject.getObjectPropertyPathList() ) );
+                                } else {
+                                    dataObject.removeAnnotation( comparatorDefinition.getClassName() );
+                                    Annotation planningEntityAnnotation = dataObject.getAnnotation( PlannerDomainAnnotations.PLANNING_ENTITY_ANNOTATION );
+                                    if ( planningEntityAnnotation != null ) {
+                                        planningEntityAnnotation.removeValue( "difficultyComparatorClass" );
+                                    }
+                                }
+                            }
+                        } ).updateComparatorObject( dataObject, comparatorObject, comparatorObject.getObjectPropertyPathList() );
+                    } else if ( ( (DataObjectFieldChangeEvent) event ).getChangeType() == ChangeType.FIELD_TYPE_CHANGE ) {
+                        boolean changed = false;
+                        ListIterator<ObjectPropertyPath> objectPropertyPathListIterator = comparatorObject.getObjectPropertyPathList().listIterator();
+                        while ( objectPropertyPathListIterator.hasNext() ) {
+                            ObjectPropertyPath objectPropertyPath = objectPropertyPathListIterator.next();
+                            ListIterator<ObjectProperty> iterator = objectPropertyPath.getObjectPropertyPath().listIterator();
+                            boolean remove = false;
+                            while ( iterator.hasNext() ) {
+                                ObjectProperty objectProperty = iterator.next();
+                                if ( remove ) {
+                                    iterator.remove();
+                                    continue;
+                                }
+                                if ( objectProperty.equals( event.getCurrentField() ) ) {
+                                    // remove just all subsequent items in the path
+                                    remove = true;
+                                    changed = true;
+                                }
+                            }
+                            if ( objectPropertyPath.getObjectPropertyPath().isEmpty() ) {
+                                objectPropertyPathListIterator.remove();
+                            }
+                        }
+                        if ( changed ) {
+                            plannerDataObjectEditorService.call( new RemoteCallback<ComparatorObject>() {
+                                @Override
+                                public void callback( ComparatorObject updatedComparatorObject ) {
+                                    dataObject.getNestedClasses().clear();
+                                    if ( updatedComparatorObject != null ) {
+                                        dataObject.addNestedClass( updatedComparatorObject );
+
+                                        comparatorDefinition.setValue( "fieldPaths", getAnnotationDef( updatedComparatorObject.getObjectPropertyPathList() ) );
+                                    } else {
+                                        dataObject.removeAnnotation( comparatorDefinition.getClassName() );
+                                        Annotation planningEntityAnnotation = dataObject.getAnnotation( PlannerDomainAnnotations.PLANNING_ENTITY_ANNOTATION );
+                                        if ( planningEntityAnnotation != null ) {
+                                            planningEntityAnnotation.removeValue( "difficultyComparatorClass" );
+                                        }
+                                    }
+                                }
+                            } ).updateComparatorObject( dataObject, comparatorObject, comparatorObject.getObjectPropertyPathList() );
+                        }
+                    }
+                }
+            }
+        } catch ( Exception e ) {
+            logger.error( "Unexpected error while processing data modeller event " + event, e );
+        }
+    }
+
+    private ComparatorObject getComparatorNestedClass( DataObject dataObject ) {
+        for ( JavaClass javaClass : dataObject.getNestedClasses() ) {
+            if ( javaClass instanceof ComparatorObject ) {
+                return (ComparatorObject) javaClass;
+            }
+        }
+        throw new IllegalStateException( "Data object " + dataObject.getClassName() + " contains " + ComparatorDefinition.class.getName() + " annotation, " +
+                "however no nested comparator object is present." );
+    }
+
+    private List<String> getAnnotationDef( List<ObjectPropertyPath> objectPropertyPaths ) {
+        List<String> objectPropertyPathList = new ArrayList<>();
+        for ( ObjectPropertyPath objectPropertyPath : objectPropertyPaths ) {
+            StringBuilder pathBuilder = new StringBuilder();
+            List<ObjectProperty> path = objectPropertyPath.getObjectPropertyPath();
+            for ( int i = 0; i < path.size(); i++ ) {
+                ObjectProperty objectProperty = path.get( i );
+
+                pathBuilder.append( objectProperty.getClassName() ).append( ":" ).append( objectProperty.getName() );
+                if ( i != path.size() - 1 ) {
+                    pathBuilder.append( "-" );
+                }
+            }
+            pathBuilder.append( "=" ).append( objectPropertyPath.isDescending() ? "desc" : "asc" );
+
+            objectPropertyPathList.add( pathBuilder.toString() );
+        }
+        return objectPropertyPathList;
     }
 }

--- a/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-client/src/main/java/org/optaplanner/workbench/screens/domaineditor/client/widgets/planner/DataObjectFieldPicker.java
+++ b/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-client/src/main/java/org/optaplanner/workbench/screens/domaineditor/client/widgets/planner/DataObjectFieldPicker.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.screens.domaineditor.client.widgets.planner;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import javax.inject.Inject;
+
+import com.google.gwt.user.client.ui.IsWidget;
+import com.google.gwt.user.client.ui.Widget;
+import org.jboss.errai.ioc.client.api.ManagedInstance;
+import org.kie.workbench.common.services.datamodeller.core.DataModel;
+import org.kie.workbench.common.services.datamodeller.core.DataObject;
+import org.kie.workbench.common.services.datamodeller.core.ObjectProperty;
+import org.optaplanner.workbench.screens.domaineditor.model.ComparatorObject;
+import org.optaplanner.workbench.screens.domaineditor.model.ObjectPropertyPath;
+
+/**
+ * Allows user to select object properties to compare multiple planning entities.
+ */
+public class DataObjectFieldPicker implements DataObjectFieldPickerView.Presenter, IsWidget {
+
+    private List<DataObjectFieldPickerItem> fieldPickerItemList = new ArrayList<>();
+
+    ManagedInstance<DataObjectFieldPickerItem> fieldPickerItemProducer;
+
+    private DataModel dataModel;
+    private DataObject rootDataObject;
+
+    private DataObjectFieldPickerView view;
+    private PlannerDataObjectEditorView.Presenter presenter;
+
+    @Inject
+    public DataObjectFieldPicker( final DataObjectFieldPickerView view,
+                                  final ManagedInstance<DataObjectFieldPickerItem> fieldPickerItemProducer ) {
+        this.view = view;
+        this.fieldPickerItemProducer = fieldPickerItemProducer;
+        view.setPresenter( this );
+    }
+
+    public void init( DataModel dataModel, DataObject rootDataObject, ComparatorObject comparatorObject, PlannerDataObjectEditorView.Presenter presenter ) {
+        this.dataModel = dataModel;
+        this.rootDataObject = rootDataObject;
+        this.presenter = presenter;
+
+        view.displayComparatorCheckbox( true );
+        view.clear();
+        for ( DataObjectFieldPickerItem item : fieldPickerItemList ) {
+            fieldPickerItemProducer.destroy( item );
+        }
+        fieldPickerItemList.clear();
+
+        if ( comparatorObject != null && comparatorObject.getObjectPropertyPathList() != null ) {
+            view.setComparatorCheckboxValue( true );
+            view.displayFieldPicker( true );
+            for ( ObjectPropertyPath path : comparatorObject.getObjectPropertyPathList() ) {
+                DataObjectFieldPickerItem fieldPickerItem = addFieldPickerItem();
+                for ( ObjectProperty field : path.getObjectPropertyPath() ) {
+                    fieldPickerItem.onFieldAdded( field.getName(), false );
+                    fieldPickerItem.onOrderSelectValueChange( path.isDescending(), false );
+                }
+            }
+        }
+    }
+
+    public void destroy() {
+        view.displayComparatorCheckbox( false );
+        view.displayFieldPicker( false );
+        view.clear();
+        for ( DataObjectFieldPickerItem item : fieldPickerItemList ) {
+            fieldPickerItemProducer.destroy( item );
+        }
+        fieldPickerItemList.clear();
+    }
+
+    @Override
+    public void onFieldPickerItemRemoved( DataObjectFieldPickerItem fieldPickerItem ) {
+        int removeIndex = fieldPickerItemList.indexOf( fieldPickerItem );
+        view.removeFieldPickerItem( removeIndex );
+        fieldPickerItemList.remove( fieldPickerItem );
+        for ( int i = removeIndex; i < fieldPickerItemList.size(); i++ ) {
+            fieldPickerItemList.get( i ).setFieldPickerItemIndex( i + 1 );
+        }
+        fieldPickerItemProducer.destroy( fieldPickerItem );
+        objectPropertyPathChanged();
+    }
+
+    @Override
+    public void onComparatorSpecified( boolean specified ) {
+        view.displayFieldPicker( specified );
+        if ( !specified ) {
+            presenter.removeComparatorDefinition( rootDataObject, true );
+            view.clear();
+            for ( DataObjectFieldPickerItem item : fieldPickerItemList ) {
+                fieldPickerItemProducer.destroy( item );
+            }
+            fieldPickerItemList.clear();
+        }
+    }
+
+    @Override
+    public void onMoveFieldPickerItemUp( DataObjectFieldPickerItem fieldPickerItem ) {
+        int currentIndex = fieldPickerItemList.indexOf( fieldPickerItem );
+        view.moveFieldItemUp( currentIndex );
+        if ( currentIndex > 0 ) {
+            DataObjectFieldPickerItem swapWithItem = fieldPickerItemList.get( currentIndex - 1 );
+            swapWithItem.setFieldPickerItemIndex( currentIndex + 1 );
+            fieldPickerItem.setFieldPickerItemIndex( currentIndex );
+            Collections.swap( fieldPickerItemList, currentIndex, currentIndex - 1 );
+        }
+        objectPropertyPathChanged();
+    }
+
+    @Override
+    public void onMoveFieldPickerItemDown( DataObjectFieldPickerItem fieldPickerItem ) {
+        int currentIndex = fieldPickerItemList.indexOf( fieldPickerItem );
+        view.moveFieldItemDown( currentIndex );
+        if ( currentIndex < fieldPickerItemList.size() - 1 ) {
+            DataObjectFieldPickerItem swapWithItem = fieldPickerItemList.get( currentIndex + 1 );
+            swapWithItem.setFieldPickerItemIndex( currentIndex + 1 );
+            fieldPickerItem.setFieldPickerItemIndex( currentIndex + 2 );
+            Collections.swap( fieldPickerItemList, currentIndex, currentIndex + 1 );
+        }
+        objectPropertyPathChanged();
+    }
+
+    @Override
+    public DataObjectFieldPickerItem addFieldPickerItem() {
+        DataObjectFieldPickerItem fieldPickerItem = fieldPickerItemProducer.get();
+        fieldPickerItem.init( dataModel, rootDataObject, this );
+        fieldPickerItemList.add( fieldPickerItem );
+        view.addFieldPickerItem( fieldPickerItem );
+        fieldPickerItem.setFieldPickerItemIndex( fieldPickerItemList.size() );
+        return fieldPickerItem;
+    }
+
+    @Override
+    public Widget asWidget() {
+        return view.asWidget();
+    }
+
+    public void objectPropertyPathChanged() {
+        List<ObjectPropertyPath> objectPropertyPathList = new ArrayList<>();
+        for ( DataObjectFieldPickerItem item : fieldPickerItemList ) {
+            if ( !item.getObjectPropertyPath().getObjectPropertyPath().isEmpty() ) {
+                objectPropertyPathList.add( item.getObjectPropertyPath() );
+            }
+        }
+        presenter.objectPropertyPathChanged( objectPropertyPathList );
+    }
+
+}

--- a/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-client/src/main/java/org/optaplanner/workbench/screens/domaineditor/client/widgets/planner/DataObjectFieldPickerItem.java
+++ b/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-client/src/main/java/org/optaplanner/workbench/screens/domaineditor/client/widgets/planner/DataObjectFieldPickerItem.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.screens.domaineditor.client.widgets.planner;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.inject.Inject;
+
+import com.google.gwt.user.client.ui.IsWidget;
+import com.google.gwt.user.client.ui.Widget;
+import org.kie.workbench.common.screens.datamodeller.client.util.DataModelerUtils;
+import org.kie.workbench.common.services.datamodeller.core.DataModel;
+import org.kie.workbench.common.services.datamodeller.core.DataObject;
+import org.kie.workbench.common.services.datamodeller.core.ObjectProperty;
+import org.optaplanner.workbench.screens.domaineditor.model.ObjectPropertyPath;
+import org.optaplanner.workbench.screens.domaineditor.model.ObjectPropertyPathImpl;
+
+public class DataObjectFieldPickerItem implements DataObjectFieldPickerItemView.Presenter, IsWidget {
+
+    private DataObjectFieldPickerItemView view;
+
+    private DataModel dataModel;
+
+    private ObjectPropertyPath objectPropertyPath = new ObjectPropertyPathImpl();
+
+    private DataObject rootDataObject;
+    private DataObjectFieldPicker picker;
+
+    @Inject
+    public DataObjectFieldPickerItem( DataObjectFieldPickerItemView view ) {
+        this.view = view;
+        view.setPresenter( this );
+    }
+
+    public void init( DataModel dataModel, DataObject rootDataObject, DataObjectFieldPicker picker ) {
+        this.dataModel = dataModel;
+        this.rootDataObject = rootDataObject;
+        this.picker = picker;
+        initSelectFieldDropdownOptions( rootDataObject );
+        view.addFieldItem( rootDataObject.getName(), null, true );
+        view.setOrderSelectDescendingValue( false );
+    }
+
+    private void initSelectFieldDropdownOptions( DataObject dataObject ) {
+        List<String> selectFieldOptions = new ArrayList<>();
+        for ( ObjectProperty objectProperty : dataObject.getProperties() ) {
+            if ( DataModelerUtils.isManagedProperty( objectProperty ) ) {
+                selectFieldOptions.add( objectProperty.getName() );
+            }
+        }
+        view.initSelectFieldDropdownOptions( selectFieldOptions );
+    }
+
+    @Override
+    public void onFieldAdded( String field, boolean notify ) {
+        ObjectProperty objectProperty;
+        if ( objectPropertyPath.getObjectPropertyPath().isEmpty() ) {
+            objectProperty = rootDataObject.getProperty( field );
+        } else {
+            ObjectProperty parentObjectProperty = objectPropertyPath.getObjectPropertyPath().get( objectPropertyPath.getObjectPropertyPath().size() - 1 );
+            DataObject dataObject = dataModel.getDataObject( parentObjectProperty.getClassName() );
+            if ( dataObject == null ) {
+                throw new IllegalStateException( "Data object " + parentObjectProperty.getClassName() + " not found in the data model" );
+            }
+            objectProperty = dataObject.getProperty( field );
+            if ( objectProperty == null ) {
+                throw new IllegalStateException( "Object property " + field + " not found in data object " + dataObject.getClassName() );
+            }
+        }
+        objectPropertyPath.appendObjectProperty( objectProperty );
+        view.addFieldItem( field, objectProperty, false );
+        if ( objectProperty.isBaseType() || objectProperty.isPrimitiveType() ) {
+            view.displaySelectFieldButton( false );
+        } else {
+            DataObject dataObject = dataModel.getDataObject( objectProperty.getClassName() );
+            initSelectFieldDropdownOptions( dataObject );
+            view.displaySelectFieldButton( true );
+        }
+        if ( notify ) {
+            picker.objectPropertyPathChanged();
+        }
+    }
+
+    @Override
+    public void onFieldRemoved( ObjectProperty objectProperty ) {
+        for ( int i = objectPropertyPath.getObjectPropertyPath().size() - 1; i >= 0; i-- ) {
+            ObjectProperty currentObjectProperty = objectPropertyPath.getObjectPropertyPath().get( i );
+            objectPropertyPath.getObjectPropertyPath().remove( i );
+            view.removeLastFieldItem();
+            if ( currentObjectProperty.equals( objectProperty ) ) {
+                break;
+            }
+        }
+        DataObject dataObject;
+        if ( objectPropertyPath.getObjectPropertyPath().isEmpty() ) {
+            dataObject = rootDataObject;
+        } else {
+            ObjectProperty parentObjectProperty = objectPropertyPath.getObjectPropertyPath().get( objectPropertyPath.getObjectPropertyPath().size() - 1 );
+            dataObject = dataModel.getDataObject( parentObjectProperty.getClassName() );
+        }
+        initSelectFieldDropdownOptions( dataObject );
+        view.displaySelectFieldButton( true );
+        picker.objectPropertyPathChanged();
+    }
+
+    @Override
+    public void onRootLabelRemoved() {
+        picker.onFieldPickerItemRemoved( this );
+    }
+
+    @Override
+    public void onMoveFieldItemUp() {
+        picker.onMoveFieldPickerItemUp( this );
+    }
+
+    @Override
+    public void onMoveFieldItemDown() {
+        picker.onMoveFieldPickerItemDown( this );
+    }
+
+    @Override
+    public void onOrderSelectValueChange( boolean descending, boolean notify ) {
+        view.setOrderSelectDescendingValue( descending );
+        objectPropertyPath.setDescending( descending );
+        if ( notify ) {
+            picker.objectPropertyPathChanged();
+        }
+    }
+
+    @Override
+    public void setFieldPickerItemIndex( int index ) {
+        view.setFieldPickerItemIndex( index );
+    }
+
+    public ObjectPropertyPath getObjectPropertyPath() {
+        return objectPropertyPath;
+    }
+
+    @Override
+    public Widget asWidget() {
+        return view.asWidget();
+    }
+
+}

--- a/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-client/src/main/java/org/optaplanner/workbench/screens/domaineditor/client/widgets/planner/DataObjectFieldPickerItemView.java
+++ b/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-client/src/main/java/org/optaplanner/workbench/screens/domaineditor/client/widgets/planner/DataObjectFieldPickerItemView.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.screens.domaineditor.client.widgets.planner;
+
+import java.util.List;
+
+import com.google.gwt.user.client.ui.IsWidget;
+import org.kie.workbench.common.services.datamodeller.core.ObjectProperty;
+
+public interface DataObjectFieldPickerItemView extends IsWidget {
+
+    interface Presenter {
+
+        void onFieldAdded( String field, boolean notify );
+
+        void onFieldRemoved( ObjectProperty objectProperty );
+
+        void onRootLabelRemoved();
+
+        void onMoveFieldItemUp();
+
+        void onMoveFieldItemDown();
+
+        void onOrderSelectValueChange( boolean checked, boolean notify );
+
+        void setFieldPickerItemIndex( int index );
+
+    }
+
+    void setPresenter( Presenter presenter );
+
+    void initSelectFieldDropdownOptions( List<String> options );
+
+    void addFieldItem( String field, ObjectProperty objectProperty, boolean rootItem );
+
+    void removeLastFieldItem();
+
+    void displaySelectFieldButton( boolean display );
+
+    void setOrderSelectDescendingValue( boolean descending );
+
+    void setFieldPickerItemIndex( int index );
+
+}

--- a/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-client/src/main/java/org/optaplanner/workbench/screens/domaineditor/client/widgets/planner/DataObjectFieldPickerItemViewImpl.html
+++ b/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-client/src/main/java/org/optaplanner/workbench/screens/domaineditor/client/widgets/planner/DataObjectFieldPickerItemViewImpl.html
@@ -1,0 +1,50 @@
+<!--
+  ~ Copyright 2016 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~       http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<div id="view">
+    <label id="sortIndexLabel" for="fieldPickerItemRow"></label>
+    <div class="row">
+        <div class="col-md-9">
+            <div id="fieldPickerItemRow" ></div>
+        </div>
+        <div class="col-md-3">
+            <span style="float:right;">
+                <div id="moveUpButton"></div>
+                <div id="moveDownButton"></div>
+            </span>
+        </div>
+    </div>
+    <div class="row">
+        <div class="col-md-6">
+            <div id="selectFieldButtonGroup" class="btn-group">
+                <button id="selectFieldButton" type="button" class="btn btn-default dropdown-toggle"
+                        data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                    <span class="glyphicon glyphicon-plus"></span>
+                    <span data-i18n-key="AddField"></span>
+                </button>
+                <span id="selectFieldDropdown"/>
+            </div>
+        </div>
+        <div class="col-md-6">
+            <span style="float:right;">
+                <label for="orderSelect" data-i18n-key="SortOrder"></label>
+                <select id="orderSelect">
+                    <option value="asc" data-i18n-key="Ascending"></option>
+                    <option value="desc" data-i18n-key="Descending"></option>
+                </select>
+            </span>
+        </div>
+    </div>
+</div>

--- a/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-client/src/main/java/org/optaplanner/workbench/screens/domaineditor/client/widgets/planner/DataObjectFieldPickerItemViewImpl.java
+++ b/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-client/src/main/java/org/optaplanner/workbench/screens/domaineditor/client/widgets/planner/DataObjectFieldPickerItemViewImpl.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.screens.domaineditor.client.widgets.planner;
+
+import java.util.List;
+import javax.inject.Inject;
+
+import com.google.gwt.dom.client.Style;
+import com.google.gwt.event.dom.client.ChangeEvent;
+import com.google.gwt.event.dom.client.ClickEvent;
+import com.google.gwt.user.client.ui.Composite;
+import com.google.gwt.user.client.ui.HorizontalPanel;
+import org.gwtbootstrap3.client.ui.AnchorListItem;
+import org.gwtbootstrap3.client.ui.DropDownMenu;
+import org.gwtbootstrap3.client.ui.Label;
+import org.gwtbootstrap3.client.ui.constants.IconType;
+import org.jboss.errai.common.client.dom.Button;
+import org.jboss.errai.common.client.dom.Div;
+import org.jboss.errai.common.client.dom.Select;
+import org.jboss.errai.ui.shared.api.annotations.DataField;
+import org.jboss.errai.ui.shared.api.annotations.EventHandler;
+import org.jboss.errai.ui.shared.api.annotations.Templated;
+import org.kie.workbench.common.services.datamodeller.core.ObjectProperty;
+
+@Templated
+public class DataObjectFieldPickerItemViewImpl extends Composite implements DataObjectFieldPickerItemView {
+
+    @Inject
+    @DataField("view")
+    Div view;
+
+    @DataField("fieldPickerItemRow")
+    HorizontalPanel fieldPickerItemRow;
+
+    @Inject
+    @DataField("selectFieldButton")
+    Button selectFieldButton;
+
+    @Inject
+    @DataField("selectFieldDropdown")
+    DropDownMenu selectFieldDropdown;
+
+    @DataField("moveUpButton")
+    org.gwtbootstrap3.client.ui.Button moveUpButton;
+
+    @DataField("moveDownButton")
+    org.gwtbootstrap3.client.ui.Button moveDownButton;
+
+    @Inject
+    @DataField("orderSelect")
+    Select orderSelect;
+
+    private com.google.gwt.user.client.ui.Label sortIndexLabel;
+
+    private Presenter presenter;
+
+    @Inject
+    public DataObjectFieldPickerItemViewImpl( final HorizontalPanel fieldPickerItemRow,
+                                              final com.google.gwt.user.client.ui.Label sortIndexLabel,
+                                              final org.gwtbootstrap3.client.ui.Button moveUpButton,
+                                              final org.gwtbootstrap3.client.ui.Button moveDownButton ) {
+        this.fieldPickerItemRow = fieldPickerItemRow;
+        this.sortIndexLabel = sortIndexLabel;
+        this.moveUpButton = moveUpButton;
+        this.moveDownButton = moveDownButton;
+
+        sortIndexLabel.getElement().getStyle().setPaddingRight( 5, Style.Unit.PX );
+        sortIndexLabel.getElement().getStyle().setFontWeight( Style.FontWeight.BOLD );
+        fieldPickerItemRow.add( sortIndexLabel );
+
+        moveUpButton.setIcon( IconType.ARROW_UP );
+        moveDownButton.setIcon( IconType.ARROW_DOWN );
+    }
+
+
+    @Override
+    public void setPresenter( Presenter presenter ) {
+        this.presenter = presenter;
+    }
+
+    @Override
+    public void initSelectFieldDropdownOptions( List<String> options ) {
+        selectFieldDropdown.clear();
+        for ( String option : options ) {
+            AnchorListItem listItem = new AnchorListItem( option );
+            listItem.addClickHandler( c -> presenter.onFieldAdded( option, true ) );
+            selectFieldDropdown.add( listItem );
+        }
+    }
+
+    @Override
+    public void addFieldItem( String field, ObjectProperty objectProperty, boolean rootItem ) {
+        if ( rootItem ) {
+            Label label = new Label( field );
+            label.addClickHandler( c -> presenter.onRootLabelRemoved() );
+            label.setMarginRight( 5 );
+            fieldPickerItemRow.add( label );
+        } else {
+            Label label = new Label( field );
+            label.addClickHandler( c -> presenter.onFieldRemoved( objectProperty ) );
+            label.setMarginRight( 5 );
+            fieldPickerItemRow.add( label );
+        }
+    }
+
+    @Override
+    public void removeLastFieldItem() {
+        Label label = (Label) fieldPickerItemRow.getWidget( fieldPickerItemRow.getWidgetCount() - 1 );
+        fieldPickerItemRow.remove( label );
+    }
+
+    @Override
+    public void displaySelectFieldButton( boolean display ) {
+        selectFieldButton.getStyle().setProperty( "display", display ? "inline" : "none" );
+    }
+
+    @Override
+    public void setOrderSelectDescendingValue( boolean descending ) {
+        orderSelect.setValue( descending ? "desc" : "asc" );
+    }
+
+    @Override
+    public void setFieldPickerItemIndex( int index ) {
+        sortIndexLabel.setText( index + "." );
+    }
+
+    @EventHandler("moveUpButton")
+    public void onMoveUpButtonClicked( ClickEvent event ) {
+        presenter.onMoveFieldItemUp();
+    }
+
+    @EventHandler("moveDownButton")
+    public void onMoveDownButtonClicked( ClickEvent event ) {
+        presenter.onMoveFieldItemDown();
+    }
+
+    @EventHandler("orderSelect")
+    public void onOrderSelectValueChange( ChangeEvent event ) {
+        presenter.onOrderSelectValueChange( "desc".equals( orderSelect.getValue() ), true );
+    }
+
+}

--- a/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-client/src/main/java/org/optaplanner/workbench/screens/domaineditor/client/widgets/planner/DataObjectFieldPickerView.java
+++ b/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-client/src/main/java/org/optaplanner/workbench/screens/domaineditor/client/widgets/planner/DataObjectFieldPickerView.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.screens.domaineditor.client.widgets.planner;
+
+import com.google.gwt.user.client.ui.IsWidget;
+
+public interface DataObjectFieldPickerView extends IsWidget {
+
+    interface Presenter {
+
+        DataObjectFieldPickerItem addFieldPickerItem();
+
+        void onFieldPickerItemRemoved( DataObjectFieldPickerItem fieldPickerItem );
+
+        void onMoveFieldPickerItemUp( DataObjectFieldPickerItem fieldPickerItem );
+
+        void onMoveFieldPickerItemDown( DataObjectFieldPickerItem fieldPickerItem );
+
+        void onComparatorSpecified( boolean specified );
+    }
+
+    void setPresenter( Presenter presenter );
+
+    void addFieldPickerItem( DataObjectFieldPickerItem fieldPickerItem );
+
+    void removeFieldPickerItem( int position );
+
+    void displayFieldPicker( boolean display );
+
+    void displayComparatorCheckbox( boolean display );
+
+    void setComparatorCheckboxValue( boolean checked );
+
+    void clear();
+
+    void moveFieldItemUp( int currentPosition );
+
+    void moveFieldItemDown( int currentPosition );
+
+}

--- a/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-client/src/main/java/org/optaplanner/workbench/screens/domaineditor/client/widgets/planner/DataObjectFieldPickerViewImpl.html
+++ b/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-client/src/main/java/org/optaplanner/workbench/screens/domaineditor/client/widgets/planner/DataObjectFieldPickerViewImpl.html
@@ -1,7 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
-
 <!--
-  ~ Copyright 2015 Red Hat, Inc. and/or its affiliates.
+  ~ Copyright 2016 Red Hat, Inc. and/or its affiliates.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -15,12 +13,14 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-
-<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.7.0//EN"
-    "http://www.gwtproject.org/doctype/2.7.0/gwt-module.dtd">
-<module>
-
-  <source path="model"/>
-  <source path="service"/>
-
-</module>
+<div id="view">
+    <input id="comparatorCheckbox" type="checkbox"></input>
+    <label for="comparatorCheckbox" data-i18n-key="SpecifyComparator"></label>
+    <div id="fieldDiv">
+        <div id="fieldList"></div>
+        <button id="addFieldPickerItemButton">
+            <span class="glyphicon glyphicon-plus"></span>
+            <span data-i18n-key="AddCondition"></span>
+        </button>
+    </div>
+</div>

--- a/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-client/src/main/java/org/optaplanner/workbench/screens/domaineditor/client/widgets/planner/DataObjectFieldPickerViewImpl.java
+++ b/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-client/src/main/java/org/optaplanner/workbench/screens/domaineditor/client/widgets/planner/DataObjectFieldPickerViewImpl.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.screens.domaineditor.client.widgets.planner;
+
+import javax.inject.Inject;
+
+import com.google.gwt.event.dom.client.ChangeEvent;
+import com.google.gwt.event.dom.client.ClickEvent;
+import com.google.gwt.user.client.ui.Composite;
+import com.google.gwt.user.client.ui.Label;
+import com.google.gwt.user.client.ui.Widget;
+import org.gwtbootstrap3.client.ui.Button;
+import org.gwtbootstrap3.client.ui.ListGroup;
+import org.gwtbootstrap3.client.ui.ListGroupItem;
+import org.gwtbootstrap3.client.ui.constants.IconType;
+import org.jboss.errai.common.client.dom.ButtonInput;
+import org.jboss.errai.common.client.dom.CheckboxInput;
+import org.jboss.errai.common.client.dom.Div;
+import org.jboss.errai.ui.shared.api.annotations.DataField;
+import org.jboss.errai.ui.shared.api.annotations.EventHandler;
+import org.jboss.errai.ui.shared.api.annotations.Templated;
+
+@Templated
+public class DataObjectFieldPickerViewImpl extends Composite implements DataObjectFieldPickerView {
+
+    @Inject
+    @DataField("view")
+    Div view;
+
+    @DataField("comparatorCheckbox")
+    CheckboxInput comparatorCheckbox;
+
+    @DataField("fieldDiv")
+    Div fieldDiv;
+
+    @Inject
+    @DataField("fieldList")
+    ListGroup fieldList;
+
+    @Inject
+    @DataField("addFieldPickerItemButton")
+    Button addFieldPickerItemButton;
+
+    private Presenter presenter;
+
+    public DataObjectFieldPickerViewImpl() {
+
+    }
+
+    @Inject
+    public DataObjectFieldPickerViewImpl( final CheckboxInput comparatorCheckbox,
+                                          final Div fieldDiv ) {
+        this.comparatorCheckbox = comparatorCheckbox;
+        this.fieldDiv = fieldDiv;
+
+        comparatorCheckbox.setHidden( false );
+        fieldDiv.setHidden( true );
+    }
+
+    @Override
+    public void setPresenter( Presenter presenter ) {
+        this.presenter = presenter;
+    }
+
+    @Override
+    public void addFieldPickerItem( DataObjectFieldPickerItem fieldPickerItem ) {
+        ListGroupItem listGroupItem = new ListGroupItem();
+        listGroupItem.add( fieldPickerItem );
+        fieldList.add( listGroupItem );
+    }
+
+    @Override
+    public void removeFieldPickerItem( int position ) {
+        fieldList.remove( position );
+    }
+
+    @Override
+    public void displayFieldPicker( boolean display ) {
+        fieldDiv.setHidden( !display );
+    }
+
+    @Override
+    public void displayComparatorCheckbox( boolean display ) {
+        view.setHidden( !display );
+    }
+
+    @Override
+    public void setComparatorCheckboxValue( boolean checked ) {
+        comparatorCheckbox.setChecked( checked );
+    }
+
+    @Override
+    public void clear() {
+        fieldList.clear();
+        comparatorCheckbox.setChecked( false );
+    }
+
+    @Override
+    public void moveFieldItemUp( int currentPosition ) {
+        if ( currentPosition == 0 ) {
+            return;
+        }
+        Widget widget = fieldList.getWidget( currentPosition );
+        fieldList.remove( widget );
+        fieldList.insert( widget, currentPosition - 1 );
+    }
+
+    @Override
+    public void moveFieldItemDown( int currentPosition ) {
+        if ( currentPosition == fieldList.getWidgetCount() - 1 ) {
+            return;
+        }
+        Widget widget = fieldList.getWidget( currentPosition );
+        fieldList.remove( widget );
+        fieldList.insert( widget, currentPosition + 1 );
+    }
+
+    @EventHandler("addFieldPickerItemButton")
+    public void onAddFieldPickerItemButtonClicked( ClickEvent event ) {
+        presenter.addFieldPickerItem();
+    }
+
+    @EventHandler("comparatorCheckbox")
+    public void onComparatorCheckboxClicked( ChangeEvent event ) {
+        presenter.onComparatorSpecified( comparatorCheckbox.getChecked() );
+    }
+
+}

--- a/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-client/src/main/java/org/optaplanner/workbench/screens/domaineditor/client/widgets/planner/PlannerDataObjectEditorView.java
+++ b/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-client/src/main/java/org/optaplanner/workbench/screens/domaineditor/client/widgets/planner/PlannerDataObjectEditorView.java
@@ -18,6 +18,11 @@ package org.optaplanner.workbench.screens.domaineditor.client.widgets.planner;
 
 import java.util.List;
 
+import org.kie.workbench.common.services.datamodeller.core.DataModel;
+import org.kie.workbench.common.services.datamodeller.core.DataObject;
+import org.kie.workbench.common.services.datamodeller.core.ObjectProperty;
+import org.optaplanner.workbench.screens.domaineditor.model.ComparatorObject;
+import org.optaplanner.workbench.screens.domaineditor.model.ObjectPropertyPath;
 import org.uberfire.client.mvp.UberView;
 import org.uberfire.commons.data.Pair;
 
@@ -33,6 +38,10 @@ public interface PlannerDataObjectEditorView
         void onPlanningSolutionChange( );
 
         void onPlanningSolutionScoreTypeChange();
+
+        void objectPropertyPathChanged( List<ObjectPropertyPath> objectPropertyPaths );
+
+        void removeComparatorDefinition(DataObject dataObject, boolean resetPlanningEntityAnnotation);
     }
 
     void setNotInPlanningValue( boolean value );
@@ -56,6 +65,12 @@ public interface PlannerDataObjectEditorView
 
     void showPlanningSolutionScoreType( boolean show );
 
+    void showComparatorGroup( boolean show );
+
     void clear( );
+
+    void initFieldPicker( DataModel dataModel, DataObject rootDataObject, ComparatorObject comparatorObject );
+
+    void destroyFieldPicker();
 
 }

--- a/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-client/src/main/java/org/optaplanner/workbench/screens/domaineditor/client/widgets/planner/PlannerDataObjectEditorViewImpl.html
+++ b/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-client/src/main/java/org/optaplanner/workbench/screens/domaineditor/client/widgets/planner/PlannerDataObjectEditorViewImpl.html
@@ -32,6 +32,9 @@
                     <span id="planningSolutionScoreTypeSelector"></span>
                 </div>
             </div>
+            <div id="comparatorGroup">
+                <div id="fieldPicker"></div>
+            </div>
         </fieldset>
     </form>
 </div>

--- a/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-client/src/main/java/org/optaplanner/workbench/screens/domaineditor/client/widgets/planner/PlannerDataObjectEditorViewImpl.java
+++ b/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-client/src/main/java/org/optaplanner/workbench/screens/domaineditor/client/widgets/planner/PlannerDataObjectEditorViewImpl.java
@@ -30,7 +30,12 @@ import org.jboss.errai.ui.shared.api.annotations.DataField;
 import org.jboss.errai.ui.shared.api.annotations.EventHandler;
 import org.jboss.errai.ui.shared.api.annotations.Templated;
 import org.kie.workbench.common.screens.datamodeller.client.util.UIUtil;
+import org.kie.workbench.common.services.datamodeller.core.DataModel;
+import org.kie.workbench.common.services.datamodeller.core.DataObject;
+import org.optaplanner.workbench.screens.domaineditor.client.resources.i18n.DomainEditorConstants;
+import org.optaplanner.workbench.screens.domaineditor.model.ComparatorObject;
 import org.uberfire.commons.data.Pair;
+import org.uberfire.ext.widgets.common.client.common.popups.errors.ErrorPopup;
 
 @Dependent
 @Templated
@@ -57,6 +62,14 @@ public class PlannerDataObjectEditorViewImpl
     @Inject
     @DataField("planningSolutionScoreTypeSelector")
     Select planningSolutionScoreTypeSelector;
+
+    @Inject
+    @DataField("fieldPicker")
+    DataObjectFieldPicker fieldPicker;
+
+    @Inject
+    @DataField("comparatorGroup")
+    Div comparatorGroup;
 
     private Presenter presenter;
 
@@ -106,6 +119,21 @@ public class PlannerDataObjectEditorViewImpl
     }
 
     @Override
+    public void initFieldPicker( DataModel dataModel, DataObject rootDataObject, org.optaplanner.workbench.screens.domaineditor.model.ComparatorObject comparatorObject ) {
+        try {
+            fieldPicker.init( dataModel, rootDataObject, comparatorObject, presenter );
+        } catch ( Exception e ) {
+            ErrorPopup.showMessage( DomainEditorConstants.INSTANCE.UnexpectedErrorComparatorInit() + " " + e.getMessage() );
+            fieldPicker.destroy();
+        }
+    }
+
+    @Override
+    public void destroyFieldPicker() {
+        fieldPicker.destroy();
+    }
+
+    @Override
     public void initPlanningSolutionScoreTypeOptions( List<Pair<String, String>> options, String selectedScoreType ) {
         UIUtil.initList( planningSolutionScoreTypeSelector, options, selectedScoreType, false );
     }
@@ -121,23 +149,28 @@ public class PlannerDataObjectEditorViewImpl
     }
 
     @Override
+    public void showComparatorGroup( boolean show ) {
+        comparatorGroup.setHidden( !show );
+    }
+
+    @Override
     public void setPlanningSolutionScoreType( String scoreType ) {
         UIUtil.setSelectedValue( planningSolutionScoreTypeSelector, scoreType );
     }
 
     @EventHandler("notInPlanningRadioButton")
     void onNotInPlanningChange( ClickEvent event ) {
-        presenter.onNotInPlanningChange( );
+        presenter.onNotInPlanningChange();
     }
 
     @EventHandler("planningEntityRadioButton")
     void onPlanningEntityChange( ClickEvent event ) {
-        presenter.onPlanningEntityChange( );
+        presenter.onPlanningEntityChange();
     }
 
     @EventHandler("planningSolutionRadioButton")
     void onPlanningSolutionChange( ClickEvent event ) {
-        presenter.onPlanningSolutionChange( );
+        presenter.onPlanningSolutionChange();
     }
 
     @EventHandler("planningSolutionScoreTypeSelector")

--- a/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-client/src/main/resources/org/optaplanner/workbench/screens/domaineditor/client/resources/i18n/DomainEditorConstants.properties
+++ b/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-client/src/main/resources/org/optaplanner/workbench/screens/domaineditor/client/resources/i18n/DomainEditorConstants.properties
@@ -16,6 +16,8 @@
 
 
 planner_domain_screen_name=Planner
+UnexpectedErrorComparatorInit=Unexpected error encountered while initializing difficulty comparator. This is likely caused by inconsistent data model.
+UnexpectedErrorComparatorUpdate=Unexpected error encountered while updating difficulty comparator.
 
 PlannerDataObjectEditorViewImpl.PlannerSettingsLabel=Planner Settings
 PlannerDataObjectEditorViewImpl.NotInPlanningLabel=No selected
@@ -32,3 +34,12 @@ PlannerDataObjectFieldEditorViewImpl.PlanningVariableLabel=Planning Variable
 PlannerDataObjectFieldEditorViewImpl.ValueRangeProviderRefsLabel=valueRangeId
 
 PlannerDataObjectFieldEditorViewImpl.PlanningFieldPropertiesNotAvailableLabel=Planning field settings are available only if the class has been configured as Planning Solution or Planning Entity
+
+DataObjectFieldPickerViewImpl.AddCondition=Add condition
+DataObjectFieldPickerViewImpl.SpecifyComparator=Use difficulty comparator for sorting planning entities
+
+DataObjectFieldPickerItemViewImpl.AddField=Add field
+DataObjectFieldPickerItemViewImpl.Ascending=Ascending
+DataObjectFieldPickerItemViewImpl.Descending=Descending
+DataObjectFieldPickerItemViewImpl.Reverse=Reverse
+DataObjectFieldPickerItemViewImpl.SortOrder=Sort order

--- a/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-client/src/test/java/org/optaplanner/workbench/screens/domaineditor/client/widgets/planner/DataObjectFieldPickerItemTest.java
+++ b/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-client/src/test/java/org/optaplanner/workbench/screens/domaineditor/client/widgets/planner/DataObjectFieldPickerItemTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.screens.domaineditor.client.widgets.planner;
+
+import java.util.Arrays;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.services.datamodeller.core.DataModel;
+import org.kie.workbench.common.services.datamodeller.core.DataObject;
+import org.kie.workbench.common.services.datamodeller.core.ObjectProperty;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+
+import static org.mockito.Matchers.*;
+import static org.mockito.Mockito.*;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class DataObjectFieldPickerItemTest {
+
+    @Mock
+    private DataObjectFieldPickerItemView view;
+
+    @Mock
+    private DataModel dataModel;
+
+    @Mock
+    private DataObject dataObject;
+
+    @Mock
+    private DataObjectFieldPicker fieldPicker;
+
+    private DataObjectFieldPickerItem fieldPickerItem;
+
+    @Before
+    public void setUp() {
+        fieldPickerItem = new DataObjectFieldPickerItem( view );
+    }
+
+    @Test
+    public void setPresenter() {
+        verify( view, times( 1 ) ).setPresenter( fieldPickerItem );
+    }
+
+    @Test
+    public void init() {
+        fieldPickerItem.init( dataModel, dataObject, fieldPicker );
+        verify( view, times( 1 ) ).initSelectFieldDropdownOptions( anyList() );
+        verify( view, times( 1 ) ).addFieldItem( anyString(), any( ObjectProperty.class ), anyBoolean() );
+    }
+
+    @Test
+    public void onFieldAddedObjectType() {
+        fieldPickerItem.init( dataModel, dataObject, fieldPicker );
+
+        ObjectProperty objectProperty = mock( ObjectProperty.class );
+        when( objectProperty.getName() ).thenReturn( "testProperty" );
+        when( objectProperty.getClassName() ).thenReturn( "bar.foo.TestProperty" );
+        when( objectProperty.isBaseType() ).thenReturn( false );
+        when( objectProperty.isPrimitiveType() ).thenReturn( false );
+
+        DataObject nestedDataObject = mock( DataObject.class );
+        when( nestedDataObject.getProperties() ).thenReturn( Arrays.asList( mock( ObjectProperty.class ) ) );
+
+
+        when( dataObject.getProperty( "testProperty" ) ).thenReturn( objectProperty );
+        when( dataModel.getDataObject( "bar.foo.TestProperty" ) ).thenReturn( nestedDataObject );
+
+        Mockito.reset( view );
+
+        fieldPickerItem.onFieldAdded( "testProperty", true );
+
+        verify( view, times( 1 ) ).addFieldItem( "testProperty", objectProperty, false );
+        verify( view, times( 1 ) ).initSelectFieldDropdownOptions( anyList() );
+        verify( view, times( 1 ) ).displaySelectFieldButton( true );
+        verify( fieldPicker, times( 1 ) ).objectPropertyPathChanged();
+    }
+
+    @Test
+    public void onFieldAddedPrimitive() {
+        fieldPickerItem.init( dataModel, dataObject, fieldPicker );
+
+        ObjectProperty objectProperty = mock( ObjectProperty.class );
+        when( objectProperty.getName() ).thenReturn( "testProperty" );
+        when( objectProperty.getClassName() ).thenReturn( "java.lang.Integer" );
+        when( objectProperty.isBaseType() ).thenReturn( true );
+        when( objectProperty.isPrimitiveType() ).thenReturn( false );
+
+        when( dataObject.getProperty( "testProperty" ) ).thenReturn( objectProperty );
+
+        Mockito.reset( view );
+
+        fieldPickerItem.onFieldAdded( "testProperty", true );
+
+        verify( view, times( 1 ) ).addFieldItem( "testProperty", objectProperty, false );
+        verify( view, times( 0 ) ).initSelectFieldDropdownOptions( anyList() );
+        verify( view, times( 1 ) ).displaySelectFieldButton( false );
+        verify( fieldPicker, times( 1 ) ).objectPropertyPathChanged();
+    }
+
+    @Test
+    public void onFieldRemoved() {
+        fieldPickerItem.init( dataModel, dataObject, fieldPicker );
+
+        ObjectProperty objectProperty = mock( ObjectProperty.class );
+        when( objectProperty.getName() ).thenReturn( "testProperty" );
+        when( objectProperty.getClassName() ).thenReturn( "java.lang.Integer" );
+        when( objectProperty.isBaseType() ).thenReturn( true );
+        when( objectProperty.isPrimitiveType() ).thenReturn( false );
+
+        when( dataObject.getProperty( "testProperty" ) ).thenReturn( objectProperty );
+
+        fieldPickerItem.onFieldAdded( "testProperty", true );
+
+        Mockito.reset( view, fieldPicker );
+
+        fieldPickerItem.onFieldRemoved( objectProperty );
+
+        verify( view, times( 1 ) ).removeLastFieldItem();
+        verify( view, times( 1 ) ).displaySelectFieldButton( true );
+        verify( view, times( 1 ) ).initSelectFieldDropdownOptions( anyList() );
+        verify( fieldPicker, times( 1 ) ).objectPropertyPathChanged();
+    }
+}

--- a/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-client/src/test/java/org/optaplanner/workbench/screens/domaineditor/client/widgets/planner/DataObjectFieldPickerTest.java
+++ b/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-client/src/test/java/org/optaplanner/workbench/screens/domaineditor/client/widgets/planner/DataObjectFieldPickerTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.screens.domaineditor.client.widgets.planner;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.jboss.errai.ioc.client.api.ManagedInstance;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.services.datamodeller.core.DataModel;
+import org.kie.workbench.common.services.datamodeller.core.DataObject;
+import org.mockito.Mock;
+import org.optaplanner.workbench.screens.domaineditor.model.ComparatorObject;
+
+import static org.mockito.Matchers.*;
+import static org.mockito.Mockito.*;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class DataObjectFieldPickerTest {
+
+    @Mock
+    private DataObjectFieldPickerView view;
+
+    @Mock
+    private ManagedInstance<DataObjectFieldPickerItem> fieldPickerItemProducer;
+
+    @Mock
+    private PlannerDataObjectEditor editor;
+
+    private DataObjectFieldPicker fieldPicker;
+
+    @Before
+    public void setUp() {
+        fieldPicker = new DataObjectFieldPicker( view, fieldPickerItemProducer );
+    }
+
+    @Test
+    public void setPresenter() {
+        verify( view, times( 1 ) ).setPresenter( fieldPicker );
+    }
+
+    @Test
+    public void initWhenComparatorObjectSpecified() {
+        initFieldPicker();
+        verify( view, times( 1 ) ).displayComparatorCheckbox( true );
+        verify( view, times( 1 ) ).displayFieldPicker( true );
+        verify( view, times( 1 ) ).setComparatorCheckboxValue( true );
+        verify( view, times( 1 ) ).clear();
+    }
+
+    @Test
+    public void initWhenComparatorObjectNotSpecified() {
+        fieldPicker.init( mock( DataModel.class ), mock( DataObject.class ), null, editor );
+        verify( view, times( 1 ) ).displayComparatorCheckbox( true );
+        verify( view, times( 0 ) ).displayFieldPicker( anyBoolean() );
+        verify( view, times( 0 ) ).setComparatorCheckboxValue( anyBoolean() );
+        verify( view, times( 1 ) ).clear();
+    }
+
+    @Test
+    public void addFieldPickerItem() {
+        initFieldPicker();
+        when( fieldPickerItemProducer.get() ).thenReturn( mock( DataObjectFieldPickerItem.class ) );
+        fieldPicker.addFieldPickerItem();
+        verify( view, times( 1 ) ).addFieldPickerItem( any( DataObjectFieldPickerItem.class ) );
+    }
+
+    @Test
+    public void onFieldPickerItemRemoved() {
+        initFieldPicker();
+        DataObjectFieldPickerItem item = new DataObjectFieldPickerItem( mock( DataObjectFieldPickerItemView.class ) );
+        when( fieldPickerItemProducer.get() ).thenReturn( item );
+        fieldPicker.addFieldPickerItem();
+
+        fieldPicker.onFieldPickerItemRemoved( item );
+        verify( view, times( 1 ) ).removeFieldPickerItem( anyInt() );
+        verify( editor, times( 1 ) ).objectPropertyPathChanged( anyList() );
+    }
+
+    @Test
+    public void onMoveFieldPickerItemUp() {
+        initFieldPicker();
+        fieldPicker.onMoveFieldPickerItemUp( any( DataObjectFieldPickerItem.class ) );
+        verify( view, times( 1 ) ).moveFieldItemUp( anyInt() );
+    }
+
+    @Test
+    public void onMoveFieldPickerItemDown() {
+        initFieldPicker();
+        fieldPicker.onMoveFieldPickerItemDown( any( DataObjectFieldPickerItem.class ) );
+        verify( view, times( 1 ) ).moveFieldItemDown( anyInt() );
+    }
+
+    @Test
+    public void destroy() {
+        fieldPicker.destroy();
+        verify( view, times( 1 ) ).displayFieldPicker( false );
+        verify( view, times( 1 ) ).displayComparatorCheckbox( false );
+        verify( view, times( 1 ) ).clear();
+    }
+
+    private void initFieldPicker() {
+        fieldPicker.init( mock( DataModel.class ), mock( DataObject.class ), mock( ComparatorObject.class ), editor );
+    }
+}

--- a/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-client/src/test/java/org/optaplanner/workbench/screens/domaineditor/client/widgets/planner/PlannerDataObjectEditorTest.java
+++ b/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-client/src/test/java/org/optaplanner/workbench/screens/domaineditor/client/widgets/planner/PlannerDataObjectEditorTest.java
@@ -80,6 +80,8 @@ public class PlannerDataObjectEditorTest
         verify( view, times( 1 ) ).getPlanningEntityValue();
         assertNotNull( dataObject.getAnnotation( PlanningEntity.class.getName() ) );
 
+        verify( view, times( 1 ) ).initFieldPicker( context.getDataModel(), dataObject, null );
+
     }
 
     @Test
@@ -101,6 +103,8 @@ public class PlannerDataObjectEditorTest
         //the dataObject should have been now configured as a PlanningEntity
         verify( view, times( 1 ) ).getPlanningSolutionValue();
         verify( view, times( 1 ) ).showPlanningSolutionScoreType( true );
+        // loadDataObject + onPlanningSolutionChange
+        verify( view, times( 2 ) ).destroyFieldPicker();
 
         //the dataObject should have been now configured as a HardSoftCore PlanningSolution by default.
         assertNotNull( dataObject.getAnnotation( PlanningSolution.class.getName() ) );

--- a/optaplanner-wb-screens/optaplanner-wb-domain-editor/pom.xml
+++ b/optaplanner-wb-screens/optaplanner-wb-domain-editor/pom.xml
@@ -36,4 +36,19 @@
     <module>optaplanner-wb-domain-editor-client</module>
   </modules>
 
+  <dependencies>
+
+    <!-- dependencies added because of new illegal transitive dependency check -->
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-widgets-commons</artifactId>
+    </dependency>
+
+  </dependencies>
+
 </project>


### PR DESCRIPTION
Preview, further changes may come. Depends on https://github.com/droolsjbpm/kie-wb-common/pull/422.

This PR adds support for creating comparator objects for a data object (annotated with `@Planning entity`).

`ObjectPropertyPath` - defines a chain of object properties to be used for comparison, starting from a planning entity

`ComparatorObject` - represents comparator. Added as a nested static class to a planning entity. Contains definitions of selected object properties and `compare` method

`ComparatorDefinition` - annotation added to a planning entity. Contains definition of object properties used for comparison. e.g. property.nestedProperty.moreNestedProperty=asc. Avoids parsing  of `compare` method body

`DataObjectFieldPicker` - allows user to select object properties to compare on

ATM I'm working on handling consistency (e.g. alerting user when deleting fields that are used by `compare` method). As for the design, I'm waiting for feedback from UXD team. 

@Rikkola @csadilek Could you please have a look at the PR and share your thoughts? Thanks!
