### PR TITLE
PLANNER-647 Workbench: Include ErraiApp.properties and score marshalling mappings in workbench-upstream-model module

### DIFF
--- a/optaplanner-wb-upstream-model/pom.xml
+++ b/optaplanner-wb-upstream-model/pom.xml
@@ -15,6 +15,18 @@
   <description>OptaPlanner Workbench - Upstream Model</description>
 
   <dependencies>
+
+    <!-- Transitive dependencies -->
+    <dependency>
+      <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-codegen</artifactId>
+    </dependency>
+
+    <!-- Regular dependencies -->
+    <dependency>
+      <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-marshalling</artifactId>
+    </dependency>
     <dependency>
       <groupId>org.optaplanner</groupId>
       <artifactId>optaplanner-core</artifactId>

--- a/optaplanner-wb-upstream-model/src/main/java/org/optaplanner/workbench/upstream/model/marshalling/BendableBigDecimalScoreMapper.java
+++ b/optaplanner-wb-upstream-model/src/main/java/org/optaplanner/workbench/upstream/model/marshalling/BendableBigDecimalScoreMapper.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.upstream.model.marshalling;
+
+import java.math.BigDecimal;
+
+import org.jboss.errai.codegen.meta.impl.java.JavaReflectionMethod;
+import org.jboss.errai.marshalling.rebind.api.CustomMapping;
+import org.jboss.errai.marshalling.rebind.api.model.MappingDefinition;
+import org.jboss.errai.marshalling.rebind.api.model.impl.ReadMapping;
+import org.jboss.errai.marshalling.rebind.api.model.impl.SimpleFactoryMapping;
+import org.optaplanner.core.api.score.buildin.bendablebigdecimal.BendableBigDecimalScore;
+
+@CustomMapping(BendableBigDecimalScore.class)
+public class BendableBigDecimalScoreMapper extends MappingDefinition {
+
+    public BendableBigDecimalScoreMapper() throws NoSuchMethodException {
+        super( BendableBigDecimalScore.class );
+
+        SimpleFactoryMapping factoryMapping = new SimpleFactoryMapping();
+        factoryMapping.setMethod( new JavaReflectionMethod( BendableBigDecimalScore.class.getMethod( "valueOf", int.class, BigDecimal[].class, BigDecimal[].class ) ) );
+        factoryMapping.mapParmToIndex( "initScore", 0, int.class );
+        factoryMapping.mapParmToIndex( "hardScores", 1, BigDecimal[].class );
+        factoryMapping.mapParmToIndex( "softScores", 2, BigDecimal[].class );
+
+        setInstantiationMapping( factoryMapping );
+
+        addMemberMapping( new ReadMapping( "initScore", int.class, "getInitScore" ) );
+        addMemberMapping( new ReadMapping( "hardScores", BigDecimal[].class, "getHardScores" ) );
+        addMemberMapping( new ReadMapping( "softScores", BigDecimal[].class, "getSoftScores" ) );
+    }
+
+}

--- a/optaplanner-wb-upstream-model/src/main/java/org/optaplanner/workbench/upstream/model/marshalling/BendableLongScoreMapper.java
+++ b/optaplanner-wb-upstream-model/src/main/java/org/optaplanner/workbench/upstream/model/marshalling/BendableLongScoreMapper.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.upstream.model.marshalling;
+
+import org.jboss.errai.codegen.meta.impl.java.JavaReflectionMethod;
+import org.jboss.errai.marshalling.rebind.api.CustomMapping;
+import org.jboss.errai.marshalling.rebind.api.model.MappingDefinition;
+import org.jboss.errai.marshalling.rebind.api.model.impl.ReadMapping;
+import org.jboss.errai.marshalling.rebind.api.model.impl.SimpleFactoryMapping;
+import org.optaplanner.core.api.score.buildin.bendablelong.BendableLongScore;
+
+@CustomMapping(BendableLongScore.class)
+public class BendableLongScoreMapper extends MappingDefinition {
+
+    public BendableLongScoreMapper() throws NoSuchMethodException {
+        super( BendableLongScore.class );
+
+        SimpleFactoryMapping factoryMapping = new SimpleFactoryMapping();
+        factoryMapping.setMethod( new JavaReflectionMethod( BendableLongScore.class.getMethod( "valueOf", int.class, long[].class, long[].class ) ) );
+        factoryMapping.mapParmToIndex( "initScore", 0, int.class );
+        factoryMapping.mapParmToIndex( "hardScores", 1, long[].class );
+        factoryMapping.mapParmToIndex( "softScores", 2, long[].class );
+
+        setInstantiationMapping( factoryMapping );
+
+        addMemberMapping( new ReadMapping( "initScore", int.class, "getInitScore" ) );
+        addMemberMapping( new ReadMapping( "hardScores", long[].class, "getHardScores" ) );
+        addMemberMapping( new ReadMapping( "softScores", long[].class, "getSoftScores" ) );
+    }
+
+}

--- a/optaplanner-wb-upstream-model/src/main/java/org/optaplanner/workbench/upstream/model/marshalling/BendableScoreMapper.java
+++ b/optaplanner-wb-upstream-model/src/main/java/org/optaplanner/workbench/upstream/model/marshalling/BendableScoreMapper.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.upstream.model.marshalling;
+
+import org.jboss.errai.codegen.meta.impl.java.JavaReflectionMethod;
+import org.jboss.errai.marshalling.rebind.api.CustomMapping;
+import org.jboss.errai.marshalling.rebind.api.model.MappingDefinition;
+import org.jboss.errai.marshalling.rebind.api.model.impl.ReadMapping;
+import org.jboss.errai.marshalling.rebind.api.model.impl.SimpleFactoryMapping;
+import org.optaplanner.core.api.score.buildin.bendable.BendableScore;
+
+@CustomMapping(BendableScore.class)
+public class BendableScoreMapper extends MappingDefinition {
+
+    public BendableScoreMapper() throws NoSuchMethodException {
+        super( BendableScore.class );
+
+        SimpleFactoryMapping factoryMapping = new SimpleFactoryMapping();
+        factoryMapping.setMethod( new JavaReflectionMethod( BendableScore.class.getMethod( "valueOf", int.class, int[].class, int[].class ) ) );
+        factoryMapping.mapParmToIndex( "initScore", 0, int.class );
+        factoryMapping.mapParmToIndex( "hardScores", 1, int[].class );
+        factoryMapping.mapParmToIndex( "softScores", 2, int[].class );
+
+        setInstantiationMapping( factoryMapping );
+
+        addMemberMapping( new ReadMapping( "initScore", int.class, "getInitScore" ) );
+        addMemberMapping( new ReadMapping( "hardScores", int[].class, "getHardScores" ) );
+        addMemberMapping( new ReadMapping( "softScores", int[].class, "getSoftScores" ) );
+    }
+
+}

--- a/optaplanner-wb-upstream-model/src/main/java/org/optaplanner/workbench/upstream/model/marshalling/HardMediumSoftLongScoreMapper.java
+++ b/optaplanner-wb-upstream-model/src/main/java/org/optaplanner/workbench/upstream/model/marshalling/HardMediumSoftLongScoreMapper.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.upstream.model.marshalling;
+
+import org.jboss.errai.codegen.meta.impl.java.JavaReflectionMethod;
+import org.jboss.errai.marshalling.rebind.api.CustomMapping;
+import org.jboss.errai.marshalling.rebind.api.model.MappingDefinition;
+import org.jboss.errai.marshalling.rebind.api.model.impl.ReadMapping;
+import org.jboss.errai.marshalling.rebind.api.model.impl.SimpleFactoryMapping;
+import org.optaplanner.core.api.score.buildin.hardmediumsoftlong.HardMediumSoftLongScore;
+
+@CustomMapping(HardMediumSoftLongScore.class)
+public class HardMediumSoftLongScoreMapper extends MappingDefinition {
+
+    public HardMediumSoftLongScoreMapper() throws NoSuchMethodException {
+        super( HardMediumSoftLongScore.class );
+
+        SimpleFactoryMapping factoryMapping = new SimpleFactoryMapping();
+        factoryMapping.setMethod( new JavaReflectionMethod( HardMediumSoftLongScore.class.getMethod( "valueOf", int.class, long.class, long.class, long.class ) ) );
+        factoryMapping.mapParmToIndex( "initScore", 0, int.class );
+        factoryMapping.mapParmToIndex( "hardScore", 1, long.class );
+        factoryMapping.mapParmToIndex( "mediumScore", 2, long.class );
+        factoryMapping.mapParmToIndex( "softScore", 3, long.class );
+
+        setInstantiationMapping( factoryMapping );
+
+        addMemberMapping( new ReadMapping( "initScore", int.class, "getInitScore" ) );
+        addMemberMapping( new ReadMapping( "hardScore", long.class, "getHardScore" ) );
+        addMemberMapping( new ReadMapping( "mediumScore", long.class, "getMediumScore" ) );
+        addMemberMapping( new ReadMapping( "softScore", long.class, "getSoftScore" ) );
+    }
+
+}

--- a/optaplanner-wb-upstream-model/src/main/java/org/optaplanner/workbench/upstream/model/marshalling/HardMediumSoftScoreMapper.java
+++ b/optaplanner-wb-upstream-model/src/main/java/org/optaplanner/workbench/upstream/model/marshalling/HardMediumSoftScoreMapper.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.upstream.model.marshalling;
+
+import org.jboss.errai.codegen.meta.impl.java.JavaReflectionMethod;
+import org.jboss.errai.marshalling.rebind.api.CustomMapping;
+import org.jboss.errai.marshalling.rebind.api.model.MappingDefinition;
+import org.jboss.errai.marshalling.rebind.api.model.impl.ReadMapping;
+import org.jboss.errai.marshalling.rebind.api.model.impl.SimpleFactoryMapping;
+import org.optaplanner.core.api.score.buildin.hardmediumsoft.HardMediumSoftScore;
+
+@CustomMapping(HardMediumSoftScore.class)
+public class HardMediumSoftScoreMapper extends MappingDefinition {
+
+    public HardMediumSoftScoreMapper() throws NoSuchMethodException {
+        super( HardMediumSoftScore.class );
+
+        SimpleFactoryMapping factoryMapping = new SimpleFactoryMapping();
+        factoryMapping.setMethod( new JavaReflectionMethod( HardMediumSoftScore.class.getMethod( "valueOf", int.class, int.class, int.class, int.class ) ) );
+        factoryMapping.mapParmToIndex( "initScore", 0, int.class );
+        factoryMapping.mapParmToIndex( "hardScore", 1, int.class );
+        factoryMapping.mapParmToIndex( "mediumScore", 2, int.class );
+        factoryMapping.mapParmToIndex( "softScore", 3, int.class );
+
+        setInstantiationMapping( factoryMapping );
+
+        addMemberMapping( new ReadMapping( "initScore", int.class, "getInitScore" ) );
+        addMemberMapping( new ReadMapping( "hardScore", int.class, "getHardScore" ) );
+        addMemberMapping( new ReadMapping( "mediumScore", int.class, "getMediumScore" ) );
+        addMemberMapping( new ReadMapping( "softScore", int.class, "getSoftScore" ) );
+    }
+
+}

--- a/optaplanner-wb-upstream-model/src/main/java/org/optaplanner/workbench/upstream/model/marshalling/HardSoftBigDecimalScoreMapper.java
+++ b/optaplanner-wb-upstream-model/src/main/java/org/optaplanner/workbench/upstream/model/marshalling/HardSoftBigDecimalScoreMapper.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.upstream.model.marshalling;
+
+import java.math.BigDecimal;
+
+import org.jboss.errai.codegen.meta.impl.java.JavaReflectionMethod;
+import org.jboss.errai.marshalling.rebind.api.CustomMapping;
+import org.jboss.errai.marshalling.rebind.api.model.MappingDefinition;
+import org.jboss.errai.marshalling.rebind.api.model.impl.ReadMapping;
+import org.jboss.errai.marshalling.rebind.api.model.impl.SimpleFactoryMapping;
+import org.optaplanner.core.api.score.buildin.hardsoftbigdecimal.HardSoftBigDecimalScore;
+
+@CustomMapping(HardSoftBigDecimalScore.class)
+public class HardSoftBigDecimalScoreMapper extends MappingDefinition {
+
+    public HardSoftBigDecimalScoreMapper() throws NoSuchMethodException {
+        super( HardSoftBigDecimalScore.class );
+
+        SimpleFactoryMapping factoryMapping = new SimpleFactoryMapping();
+        factoryMapping.setMethod( new JavaReflectionMethod( HardSoftBigDecimalScore.class.getMethod( "valueOf", int.class, BigDecimal.class, BigDecimal.class ) ) );
+        factoryMapping.mapParmToIndex( "initScore", 0, int.class );
+        factoryMapping.mapParmToIndex( "hardScore", 1, BigDecimal.class );
+        factoryMapping.mapParmToIndex( "softScore", 2, BigDecimal.class );
+
+        setInstantiationMapping( factoryMapping );
+
+        addMemberMapping( new ReadMapping( "initScore", int.class, "getInitScore" ) );
+        addMemberMapping( new ReadMapping( "hardScore", BigDecimal.class, "getHardScore" ) );
+        addMemberMapping( new ReadMapping( "softScore", BigDecimal.class, "getSoftScore" ) );
+    }
+
+}

--- a/optaplanner-wb-upstream-model/src/main/java/org/optaplanner/workbench/upstream/model/marshalling/HardSoftDoubleScoreMapper.java
+++ b/optaplanner-wb-upstream-model/src/main/java/org/optaplanner/workbench/upstream/model/marshalling/HardSoftDoubleScoreMapper.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.upstream.model.marshalling;
+
+import org.jboss.errai.codegen.meta.impl.java.JavaReflectionMethod;
+import org.jboss.errai.marshalling.rebind.api.CustomMapping;
+import org.jboss.errai.marshalling.rebind.api.model.MappingDefinition;
+import org.jboss.errai.marshalling.rebind.api.model.impl.ReadMapping;
+import org.jboss.errai.marshalling.rebind.api.model.impl.SimpleFactoryMapping;
+import org.optaplanner.core.api.score.buildin.hardsoftdouble.HardSoftDoubleScore;
+
+@CustomMapping(HardSoftDoubleScore.class)
+public class HardSoftDoubleScoreMapper extends MappingDefinition {
+
+    public HardSoftDoubleScoreMapper() throws NoSuchMethodException {
+        super( HardSoftDoubleScore.class );
+
+        SimpleFactoryMapping factoryMapping = new SimpleFactoryMapping();
+        factoryMapping.setMethod( new JavaReflectionMethod( HardSoftDoubleScore.class.getMethod( "valueOf", int.class, double.class, double.class ) ) );
+        factoryMapping.mapParmToIndex( "initScore", 0, int.class );
+        factoryMapping.mapParmToIndex( "hardScore", 1, double.class );
+        factoryMapping.mapParmToIndex( "softScore", 2, double.class );
+
+        setInstantiationMapping( factoryMapping );
+
+        addMemberMapping( new ReadMapping( "initScore", int.class, "getInitScore" ) );
+        addMemberMapping( new ReadMapping( "hardScore", double.class, "getHardScore" ) );
+        addMemberMapping( new ReadMapping( "softScore", double.class, "getSoftScore" ) );
+    }
+
+}

--- a/optaplanner-wb-upstream-model/src/main/java/org/optaplanner/workbench/upstream/model/marshalling/HardSoftLongScoreMapper.java
+++ b/optaplanner-wb-upstream-model/src/main/java/org/optaplanner/workbench/upstream/model/marshalling/HardSoftLongScoreMapper.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.upstream.model.marshalling;
+
+import org.jboss.errai.codegen.meta.impl.java.JavaReflectionMethod;
+import org.jboss.errai.marshalling.rebind.api.CustomMapping;
+import org.jboss.errai.marshalling.rebind.api.model.MappingDefinition;
+import org.jboss.errai.marshalling.rebind.api.model.impl.ReadMapping;
+import org.jboss.errai.marshalling.rebind.api.model.impl.SimpleFactoryMapping;
+import org.optaplanner.core.api.score.buildin.hardsoftlong.HardSoftLongScore;
+
+@CustomMapping(HardSoftLongScore.class)
+public class HardSoftLongScoreMapper extends MappingDefinition {
+
+    public HardSoftLongScoreMapper() throws NoSuchMethodException {
+        super( HardSoftLongScore.class );
+
+        SimpleFactoryMapping factoryMapping = new SimpleFactoryMapping();
+        factoryMapping.setMethod( new JavaReflectionMethod( HardSoftLongScore.class.getMethod( "valueOf", int.class, long.class, long.class ) ) );
+        factoryMapping.mapParmToIndex( "initScore", 0, int.class );
+        factoryMapping.mapParmToIndex( "hardScore", 1, long.class );
+        factoryMapping.mapParmToIndex( "softScore", 2, long.class );
+
+        setInstantiationMapping( factoryMapping );
+
+        addMemberMapping( new ReadMapping( "initScore", int.class, "getInitScore" ) );
+        addMemberMapping( new ReadMapping( "hardScore", long.class, "getHardScore" ) );
+        addMemberMapping( new ReadMapping( "softScore", long.class, "getSoftScore" ) );
+    }
+
+}

--- a/optaplanner-wb-upstream-model/src/main/java/org/optaplanner/workbench/upstream/model/marshalling/HardSoftScoreMapper.java
+++ b/optaplanner-wb-upstream-model/src/main/java/org/optaplanner/workbench/upstream/model/marshalling/HardSoftScoreMapper.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.upstream.model.marshalling;
+
+import org.jboss.errai.codegen.meta.impl.java.JavaReflectionMethod;
+import org.jboss.errai.marshalling.rebind.api.CustomMapping;
+import org.jboss.errai.marshalling.rebind.api.model.MappingDefinition;
+import org.jboss.errai.marshalling.rebind.api.model.impl.ReadMapping;
+import org.jboss.errai.marshalling.rebind.api.model.impl.SimpleFactoryMapping;
+import org.optaplanner.core.api.score.buildin.hardsoft.HardSoftScore;
+
+@CustomMapping(HardSoftScore.class)
+public class HardSoftScoreMapper extends MappingDefinition {
+
+    public HardSoftScoreMapper() throws NoSuchMethodException {
+        super( HardSoftScore.class );
+
+        SimpleFactoryMapping factoryMapping = new SimpleFactoryMapping();
+        factoryMapping.setMethod( new JavaReflectionMethod( HardSoftScore.class.getMethod( "valueOf", int.class, int.class, int.class ) ) );
+        factoryMapping.mapParmToIndex( "initScore", 0, int.class );
+        factoryMapping.mapParmToIndex( "hardScore", 1, int.class );
+        factoryMapping.mapParmToIndex( "softScore", 2, int.class );
+
+        setInstantiationMapping( factoryMapping );
+
+        addMemberMapping( new ReadMapping( "initScore", int.class, "getInitScore" ) );
+        addMemberMapping( new ReadMapping( "hardScore", int.class, "getHardScore" ) );
+        addMemberMapping( new ReadMapping( "softScore", int.class, "getSoftScore" ) );
+    }
+
+}

--- a/optaplanner-wb-upstream-model/src/main/java/org/optaplanner/workbench/upstream/model/marshalling/SimpleBigDecimalScoreMapper.java
+++ b/optaplanner-wb-upstream-model/src/main/java/org/optaplanner/workbench/upstream/model/marshalling/SimpleBigDecimalScoreMapper.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.upstream.model.marshalling;
+
+import java.math.BigDecimal;
+
+import org.jboss.errai.codegen.meta.impl.java.JavaReflectionMethod;
+import org.jboss.errai.marshalling.rebind.api.CustomMapping;
+import org.jboss.errai.marshalling.rebind.api.model.MappingDefinition;
+import org.jboss.errai.marshalling.rebind.api.model.impl.ReadMapping;
+import org.jboss.errai.marshalling.rebind.api.model.impl.SimpleFactoryMapping;
+import org.optaplanner.core.api.score.buildin.simplebigdecimal.SimpleBigDecimalScore;
+
+@CustomMapping(SimpleBigDecimalScore.class)
+public class SimpleBigDecimalScoreMapper extends MappingDefinition {
+
+    public SimpleBigDecimalScoreMapper() throws NoSuchMethodException {
+        super( SimpleBigDecimalScore.class );
+
+        SimpleFactoryMapping factoryMapping = new SimpleFactoryMapping();
+        factoryMapping.setMethod( new JavaReflectionMethod( SimpleBigDecimalScore.class.getMethod( "valueOf", int.class, BigDecimal.class ) ) );
+        factoryMapping.mapParmToIndex( "initScore", 0, int.class );
+        factoryMapping.mapParmToIndex( "score", 1, BigDecimal.class );
+
+        setInstantiationMapping( factoryMapping );
+
+        addMemberMapping( new ReadMapping( "initScore", int.class, "getInitScore" ) );
+        addMemberMapping( new ReadMapping( "score", BigDecimal.class, "getScore" ) );
+    }
+
+}

--- a/optaplanner-wb-upstream-model/src/main/java/org/optaplanner/workbench/upstream/model/marshalling/SimpleDoubleScoreMapper.java
+++ b/optaplanner-wb-upstream-model/src/main/java/org/optaplanner/workbench/upstream/model/marshalling/SimpleDoubleScoreMapper.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.upstream.model.marshalling;
+
+import org.jboss.errai.codegen.meta.impl.java.JavaReflectionMethod;
+import org.jboss.errai.marshalling.rebind.api.CustomMapping;
+import org.jboss.errai.marshalling.rebind.api.model.MappingDefinition;
+import org.jboss.errai.marshalling.rebind.api.model.impl.ReadMapping;
+import org.jboss.errai.marshalling.rebind.api.model.impl.SimpleFactoryMapping;
+import org.optaplanner.core.api.score.buildin.simpledouble.SimpleDoubleScore;
+
+@CustomMapping(SimpleDoubleScore.class)
+public class SimpleDoubleScoreMapper extends MappingDefinition {
+
+    public SimpleDoubleScoreMapper() throws NoSuchMethodException {
+        super( SimpleDoubleScore.class );
+
+        SimpleFactoryMapping factoryMapping = new SimpleFactoryMapping();
+        factoryMapping.setMethod( new JavaReflectionMethod( SimpleDoubleScore.class.getMethod( "valueOf", int.class, double.class ) ) );
+        factoryMapping.mapParmToIndex( "initScore", 0, int.class );
+        factoryMapping.mapParmToIndex( "score", 1, double.class );
+
+        setInstantiationMapping( factoryMapping );
+
+        addMemberMapping( new ReadMapping( "initScore", int.class, "getInitScore" ) );
+        addMemberMapping( new ReadMapping( "score", double.class, "getScore" ) );
+    }
+
+}

--- a/optaplanner-wb-upstream-model/src/main/java/org/optaplanner/workbench/upstream/model/marshalling/SimpleLongScoreMapper.java
+++ b/optaplanner-wb-upstream-model/src/main/java/org/optaplanner/workbench/upstream/model/marshalling/SimpleLongScoreMapper.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.upstream.model.marshalling;
+
+import org.jboss.errai.codegen.meta.impl.java.JavaReflectionMethod;
+import org.jboss.errai.marshalling.rebind.api.CustomMapping;
+import org.jboss.errai.marshalling.rebind.api.model.MappingDefinition;
+import org.jboss.errai.marshalling.rebind.api.model.impl.ReadMapping;
+import org.jboss.errai.marshalling.rebind.api.model.impl.SimpleFactoryMapping;
+import org.optaplanner.core.api.score.buildin.simplelong.SimpleLongScore;
+
+@CustomMapping(SimpleLongScore.class)
+public class SimpleLongScoreMapper extends MappingDefinition {
+
+    public SimpleLongScoreMapper() throws NoSuchMethodException {
+        super( SimpleLongScore.class );
+
+        SimpleFactoryMapping factoryMapping = new SimpleFactoryMapping();
+        factoryMapping.setMethod( new JavaReflectionMethod( SimpleLongScore.class.getMethod( "valueOf", int.class, long.class ) ) );
+        factoryMapping.mapParmToIndex( "initScore", 0, int.class );
+        factoryMapping.mapParmToIndex( "score", 1, long.class );
+
+        setInstantiationMapping( factoryMapping );
+
+        addMemberMapping( new ReadMapping( "initScore", int.class, "getInitScore" ) );
+        addMemberMapping( new ReadMapping( "score", long.class, "getScore" ) );
+    }
+
+}

--- a/optaplanner-wb-upstream-model/src/main/java/org/optaplanner/workbench/upstream/model/marshalling/SimpleScoreMapper.java
+++ b/optaplanner-wb-upstream-model/src/main/java/org/optaplanner/workbench/upstream/model/marshalling/SimpleScoreMapper.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.upstream.model.marshalling;
+
+import org.jboss.errai.codegen.meta.impl.java.JavaReflectionMethod;
+import org.jboss.errai.marshalling.rebind.api.CustomMapping;
+import org.jboss.errai.marshalling.rebind.api.model.MappingDefinition;
+import org.jboss.errai.marshalling.rebind.api.model.impl.ReadMapping;
+import org.jboss.errai.marshalling.rebind.api.model.impl.SimpleFactoryMapping;
+import org.optaplanner.core.api.score.buildin.simple.SimpleScore;
+
+@CustomMapping(SimpleScore.class)
+public class SimpleScoreMapper extends MappingDefinition {
+
+    public SimpleScoreMapper() throws NoSuchMethodException {
+        super( SimpleScore.class );
+
+        SimpleFactoryMapping factoryMapping = new SimpleFactoryMapping();
+        factoryMapping.setMethod( new JavaReflectionMethod( SimpleScore.class.getMethod( "valueOf", int.class, int.class ) ) );
+        factoryMapping.mapParmToIndex( "initScore", 0, int.class );
+        factoryMapping.mapParmToIndex( "score", 1, int.class );
+
+        setInstantiationMapping( factoryMapping );
+
+        addMemberMapping( new ReadMapping( "initScore", int.class, "getInitScore" ) );
+        addMemberMapping( new ReadMapping( "score", int.class, "getScore" ) );
+    }
+
+}

--- a/optaplanner-wb-upstream-model/src/main/resources/ErraiApp.properties
+++ b/optaplanner-wb-upstream-model/src/main/resources/ErraiApp.properties
@@ -1,0 +1,45 @@
+#
+# Copyright 2016 Red Hat, Inc. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# ErraiApp.properties
+#
+# Do not remove, even if empty!
+#
+
+# This is a marker file. When it is detected inside a JAR or at the
+# top of any classpath, the subdirectories are scanned for deployable
+# components. As such, all Errai application modules in a project
+# should contain an ErraiApp.properties at the root of all classpaths
+# that you wish to be scanned.
+#
+# There are also some configuration options that can be set in this
+# file, although it is rarely necessary. See the documentation at
+# https://docs.jboss.org/author/display/ERRAI/ErraiApp.properties
+# for details.
+
+errai.marshalling.serializableTypes=org.optaplanner.core.api.score.buildin.bendable.BendableScore \
+    org.optaplanner.core.api.score.buildin.bendablebigdecimal.BendableBigDecimalScore \
+    org.optaplanner.core.api.score.buildin.bendablelong.BendableLongScore \
+    org.optaplanner.core.api.score.buildin.hardmediumsoft.HardMediumSoftScore \
+    org.optaplanner.core.api.score.buildin.hardmediumsoftlong.HardMediumSoftLongScore \
+    org.optaplanner.core.api.score.buildin.hardsoft.HardSoftScore \
+    org.optaplanner.core.api.score.buildin.hardsoftbigdecimal.HardSoftBigDecimalScore \
+    org.optaplanner.core.api.score.buildin.hardsoftdouble.HardSoftDoubleScore \
+    org.optaplanner.core.api.score.buildin.hardsoftlong.HardSoftLongScore \
+    org.optaplanner.core.api.score.buildin.simple.SimpleScore \
+    org.optaplanner.core.api.score.buildin.simplebigdecimal.SimpleBigDecimalScore \
+    org.optaplanner.core.api.score.buildin.simpledouble.SimpleDoubleScore \
+    org.optaplanner.core.api.score.buildin.simplelong.SimpleLongScore


### PR DESCRIPTION
Custom mappings need to be defined for score types, as they can only be created via factory methods. 
