### PR TITLE
Do not delete GWT unitCache during clean

### DIFF
--- a/optaplanner-wb-webapp/pom.xml
+++ b/optaplanner-wb-webapp/pom.xml
@@ -1146,8 +1146,7 @@
                 <include>src/main/webapp/org.optaplanner.workbench.OptaPlannerWorkbench/</include>
                 <include>src/main/webapp/WEB-INF/deploy/</include>
                 <include>src/main/webapp/WEB-INF/classes/</include>
-                <include>src/main/webapp/WEB-INF/lib/</include>
-                <include>**/gwt-unitCache/**</include>
+                <include>src/main/webapp/WEB-INF/lib/</include>                
                 <include>.errai/</include>
                 <include>.niogit/**</include>
               </includes>


### PR DESCRIPTION
Removing this line from the clean configuration makes SDM startup ~40 seconds faster (once the unitCache is in place):

GWT builds up a persistent compilation unit cache which we shouldn't delete every time we startup the WB. This should also improve startup from within intellij as our run configuration is set up to call "clean process-resources" before starting SDM.
