### PR TITLE
PLANNER-737: Workbench: scoreHolder global variable generation based on the PlanningSolution score type

### DIFF
--- a/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-backend/pom.xml
+++ b/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-backend/pom.xml
@@ -101,6 +101,16 @@
 
     <dependency>
       <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-commons-editor-backend</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-nio2-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.uberfire</groupId>
       <artifactId>uberfire-nio2-model</artifactId>
     </dependency>
 
@@ -113,6 +123,11 @@
     <dependency>
       <groupId>org.drools</groupId>
       <artifactId>drools-wb-drl-text-editor-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-wb-globals-editor-api</artifactId>
     </dependency>
 
     <dependency>

--- a/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-backend/src/main/java/org/optaplanner/workbench/screens/domaineditor/backend/server/helper/PlanningSolutionCopyHelper.java
+++ b/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-backend/src/main/java/org/optaplanner/workbench/screens/domaineditor/backend/server/helper/PlanningSolutionCopyHelper.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.screens.domaineditor.backend.server.helper;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import org.kie.workbench.common.screens.datamodeller.model.GenerationResult;
+import org.kie.workbench.common.screens.datamodeller.service.DataModelerService;
+import org.kie.workbench.common.services.datamodeller.core.DataObject;
+import org.kie.workbench.common.services.shared.project.KieProjectService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.uberfire.backend.server.util.Paths;
+import org.uberfire.backend.vfs.Path;
+import org.uberfire.ext.editor.commons.backend.service.helper.CopyHelper;
+import org.uberfire.io.IOService;
+import org.uberfire.java.nio.file.Files;
+
+import static org.optaplanner.workbench.screens.domaineditor.model.PlannerDomainAnnotations.PLANNING_SOLUTION_ANNOTATION;
+
+@ApplicationScoped
+public class PlanningSolutionCopyHelper implements CopyHelper {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger( PlanningSolutionCopyHelper.class );
+
+    private static final String SCORE_HOLDER_GLOBAL_FILE_SUFFIX = "ScoreHolderGlobal.gdrl";
+
+    private IOService ioService;
+
+    private DataModelerService dataModelerService;
+
+    private KieProjectService kieProjectService;
+
+    public PlanningSolutionCopyHelper() {
+    }
+
+    @Inject
+    public PlanningSolutionCopyHelper( @Named("ioStrategy") final IOService ioService,
+                                       final DataModelerService dataModelerService,
+                                       final KieProjectService kieProjectService ) {
+        this.ioService = ioService;
+        this.dataModelerService = dataModelerService;
+        this.kieProjectService = kieProjectService;
+    }
+
+    @Override
+    public boolean supports( Path path ) {
+        return path.getFileName().endsWith( ".java" );
+    }
+
+    @Override
+    public void postProcess( Path sourcePath,
+                             Path destinationPath ) {
+        String dataObjectSource = ioService.readAllString( Paths.convert( sourcePath ) );
+        GenerationResult generationResult = dataModelerService.loadDataObject( sourcePath,
+                                                                               dataObjectSource,
+                                                                               sourcePath );
+
+        if ( generationResult.hasErrors() ) {
+            LOGGER.warn( "Path " + sourcePath + " parsing as a data object has failed. Score holder global generation will be skipped." );
+        } else {
+            DataObject dataObject = generationResult.getDataObject();
+            if ( dataObject.getAnnotation( PLANNING_SOLUTION_ANNOTATION ) != null ) {
+                org.uberfire.java.nio.file.Path source = Paths.convert( kieProjectService.resolvePackage( sourcePath ).getPackageMainResourcesPath() );
+                org.uberfire.java.nio.file.Path sourcePackage = Files.isDirectory( source ) ? source : source.getParent();
+                String sourceDataObjectFileName = sourcePath.getFileName().substring( 0,
+                                                                                      sourcePath.getFileName().indexOf( "." ) );
+
+                org.uberfire.java.nio.file.Path destination = Paths.convert( kieProjectService.resolvePackage( destinationPath ).getPackageMainResourcesPath() );
+                org.uberfire.java.nio.file.Path destinationPackage = Files.isDirectory( destination ) ? destination : destination.getParent();
+                String destinationDataObjectFileName = destinationPath.getFileName().substring( 0,
+                                                                                                destinationPath.getFileName().indexOf( "." ) );
+
+                boolean scoreHolderGlobalFileExists = ioService.exists( sourcePackage.resolve( sourceDataObjectFileName + SCORE_HOLDER_GLOBAL_FILE_SUFFIX ) );
+
+                if ( scoreHolderGlobalFileExists ) {
+                    ioService.copy( sourcePackage.resolve( sourceDataObjectFileName + SCORE_HOLDER_GLOBAL_FILE_SUFFIX ),
+                                    destinationPackage.resolve( destinationDataObjectFileName + SCORE_HOLDER_GLOBAL_FILE_SUFFIX ) );
+                }
+            }
+        }
+    }
+}

--- a/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-backend/src/main/java/org/optaplanner/workbench/screens/domaineditor/backend/server/helper/PlanningSolutionDeleteHelper.java
+++ b/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-backend/src/main/java/org/optaplanner/workbench/screens/domaineditor/backend/server/helper/PlanningSolutionDeleteHelper.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.screens.domaineditor.backend.server.helper;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import org.kie.workbench.common.screens.datamodeller.model.GenerationResult;
+import org.kie.workbench.common.screens.datamodeller.service.DataModelerService;
+import org.kie.workbench.common.services.datamodeller.core.DataObject;
+import org.kie.workbench.common.services.shared.project.KieProjectService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.uberfire.backend.server.util.Paths;
+import org.uberfire.backend.vfs.Path;
+import org.uberfire.ext.editor.commons.backend.service.helper.DeleteHelper;
+import org.uberfire.io.IOService;
+import org.uberfire.java.nio.file.Files;
+
+import static org.optaplanner.workbench.screens.domaineditor.model.PlannerDomainAnnotations.PLANNING_SOLUTION_ANNOTATION;
+
+@ApplicationScoped
+public class PlanningSolutionDeleteHelper implements DeleteHelper {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger( PlanningSolutionDeleteHelper.class );
+
+    private static final String SCORE_HOLDER_GLOBAL_FILE_SUFFIX = "ScoreHolderGlobal.gdrl";
+
+    private IOService ioService;
+
+    private DataModelerService dataModelerService;
+
+    private KieProjectService kieProjectService;
+
+    public PlanningSolutionDeleteHelper() {
+    }
+
+    @Inject
+    public PlanningSolutionDeleteHelper( @Named("ioStrategy") final IOService ioService,
+                                         final DataModelerService dataModelerService,
+                                         final KieProjectService kieProjectService ) {
+        this.ioService = ioService;
+        this.dataModelerService = dataModelerService;
+        this.kieProjectService = kieProjectService;
+    }
+
+    @Override
+    public boolean supports( final Path path ) {
+        return path.getFileName().endsWith( ".java" );
+    }
+
+    @Override
+    public void postProcess( final Path path ) {
+        String dataObjectSource = ioService.readAllString( Paths.convert( path ) );
+        GenerationResult generationResult = dataModelerService.loadDataObject( path,
+                                                                               dataObjectSource,
+                                                                               path );
+
+        if ( generationResult.hasErrors() ) {
+            LOGGER.warn( "Path " + path + " parsing as a data object has failed. Score holder global generation will be skipped." );
+        } else {
+            DataObject dataObject = generationResult.getDataObject();
+            if ( dataObject.getAnnotation( PLANNING_SOLUTION_ANNOTATION ) != null ) {
+                org.uberfire.java.nio.file.Path source = Paths.convert( kieProjectService.resolvePackage( path ).getPackageMainResourcesPath() );
+                org.uberfire.java.nio.file.Path sourcePackage = Files.isDirectory( source ) ? source : source.getParent();
+
+                String dataObjectFileName = path.getFileName().substring( 0,
+                                                                          path.getFileName().indexOf( "." ) );
+
+                ioService.deleteIfExists( sourcePackage.resolve( dataObjectFileName + SCORE_HOLDER_GLOBAL_FILE_SUFFIX ) );
+            }
+        }
+    }
+}

--- a/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-backend/src/main/java/org/optaplanner/workbench/screens/domaineditor/backend/server/helper/PlanningSolutionRenameWorkaroundHelper.java
+++ b/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-backend/src/main/java/org/optaplanner/workbench/screens/domaineditor/backend/server/helper/PlanningSolutionRenameWorkaroundHelper.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.screens.domaineditor.backend.server.helper;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import org.kie.workbench.common.screens.datamodeller.backend.server.helper.DataModelerRenameWorkaroundHelper;
+import org.kie.workbench.common.screens.datamodeller.model.GenerationResult;
+import org.kie.workbench.common.screens.datamodeller.service.DataModelerService;
+import org.kie.workbench.common.services.datamodeller.core.DataObject;
+import org.kie.workbench.common.services.shared.project.KieProjectService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.uberfire.backend.server.util.Paths;
+import org.uberfire.backend.vfs.Path;
+import org.uberfire.io.IOService;
+import org.uberfire.java.nio.file.Files;
+
+import static org.optaplanner.workbench.screens.domaineditor.model.PlannerDomainAnnotations.PLANNING_SOLUTION_ANNOTATION;
+
+/**
+ * TODO Change to RenameHelper implementation once DataModelerServiceImpl.rename() uses RenameService instead of IOService.move()
+ */
+@ApplicationScoped
+public class PlanningSolutionRenameWorkaroundHelper implements DataModelerRenameWorkaroundHelper {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger( PlanningSolutionRenameWorkaroundHelper.class );
+
+    private static final String SCORE_HOLDER_GLOBAL_FILE_SUFFIX = "ScoreHolderGlobal.gdrl";
+
+    private IOService ioService;
+
+    private DataModelerService dataModelerService;
+
+    private KieProjectService kieProjectService;
+
+    public PlanningSolutionRenameWorkaroundHelper() {
+    }
+
+    @Inject
+    public PlanningSolutionRenameWorkaroundHelper( @Named("ioStrategy") final IOService ioService,
+                                                   final DataModelerService dataModelerService,
+                                                   final KieProjectService kieProjectService ) {
+        this.ioService = ioService;
+        this.dataModelerService = dataModelerService;
+        this.kieProjectService = kieProjectService;
+    }
+
+    @Override
+    public void postProcess( final Path sourcePath,
+                             final Path destinationPath ) {
+        String dataObjectSource = ioService.readAllString( Paths.convert( destinationPath ) );
+        GenerationResult generationResult = dataModelerService.loadDataObject( destinationPath,
+                                                                               dataObjectSource,
+                                                                               destinationPath );
+
+        if ( generationResult.hasErrors() ) {
+            LOGGER.warn( "Path " + sourcePath + " parsing as a data object has failed. Score holder global generation will be skipped." );
+        } else {
+            DataObject dataObject = generationResult.getDataObject();
+            if ( dataObject.getAnnotation( PLANNING_SOLUTION_ANNOTATION ) != null ) {
+                org.uberfire.java.nio.file.Path source = Paths.convert( kieProjectService.resolvePackage( sourcePath ).getPackageMainResourcesPath() );
+                org.uberfire.java.nio.file.Path sourcePackage = Files.isDirectory( source ) ? source : source.getParent();
+                String sourceDataObjectFileName = sourcePath.getFileName().substring( 0,
+                                                                                      sourcePath.getFileName().indexOf( "." ) );
+
+                org.uberfire.java.nio.file.Path destination = Paths.convert( kieProjectService.resolvePackage( destinationPath ).getPackageMainResourcesPath() );
+                org.uberfire.java.nio.file.Path destinationPackage = Files.isDirectory( destination ) ? destination : destination.getParent();
+                String destinationDataObjectFileName = destinationPath.getFileName().substring( 0,
+                                                                                                destinationPath.getFileName().indexOf( "." ) );
+
+                boolean scoreHolderGlobalFileExists = ioService.exists( sourcePackage.resolve( sourceDataObjectFileName + SCORE_HOLDER_GLOBAL_FILE_SUFFIX ) );
+
+                if ( scoreHolderGlobalFileExists ) {
+                    ioService.move( sourcePackage.resolve( sourceDataObjectFileName + SCORE_HOLDER_GLOBAL_FILE_SUFFIX ),
+                                    destinationPackage.resolve( destinationDataObjectFileName + SCORE_HOLDER_GLOBAL_FILE_SUFFIX ) );
+                }
+            }
+        }
+    }
+}

--- a/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-backend/src/main/java/org/optaplanner/workbench/screens/domaineditor/backend/server/helper/PlanningSolutionSaveHelper.java
+++ b/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-backend/src/main/java/org/optaplanner/workbench/screens/domaineditor/backend/server/helper/PlanningSolutionSaveHelper.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.screens.domaineditor.backend.server.helper;
+
+import java.util.Arrays;
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import org.drools.workbench.screens.globals.model.Global;
+import org.drools.workbench.screens.globals.model.GlobalsModel;
+import org.drools.workbench.screens.globals.service.GlobalsEditorService;
+import org.guvnor.common.services.shared.metadata.MetadataService;
+import org.kie.workbench.common.screens.datamodeller.backend.server.helper.DataModelerSaveHelper;
+import org.kie.workbench.common.screens.datamodeller.model.GenerationResult;
+import org.kie.workbench.common.screens.datamodeller.service.DataModelerService;
+import org.kie.workbench.common.services.datamodeller.core.DataObject;
+import org.kie.workbench.common.services.shared.project.KieProjectService;
+import org.optaplanner.workbench.screens.domaineditor.backend.server.validation.ScoreHolderUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.uberfire.backend.server.util.Paths;
+import org.uberfire.backend.vfs.Path;
+import org.uberfire.io.IOService;
+import org.uberfire.java.nio.file.Files;
+
+import static org.optaplanner.workbench.screens.domaineditor.model.PlannerDomainAnnotations.PLANNING_SOLUTION_ANNOTATION;
+
+@ApplicationScoped
+public class PlanningSolutionSaveHelper implements DataModelerSaveHelper {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger( PlanningSolutionSaveHelper.class );
+
+    private static final String SCORE_HOLDER = "scoreHolder";
+
+    private static final String SCORE_HOLDER_GLOBAL_FILE_SUFFIX = "ScoreHolderGlobal.gdrl";
+
+    private DataModelerService dataModelerService;
+
+    private IOService ioService;
+
+    private GlobalsEditorService globalsEditorService;
+
+    private KieProjectService kieProjectService;
+
+    private ScoreHolderUtils scoreHolderUtils;
+
+    private MetadataService metadataService;
+
+    public PlanningSolutionSaveHelper() {
+    }
+
+    @Inject
+    public PlanningSolutionSaveHelper( @Named("ioStrategy") final IOService ioService,
+                                       final DataModelerService dataModelerService,
+                                       final GlobalsEditorService globalsEditorService,
+                                       final KieProjectService kieProjectService,
+                                       final ScoreHolderUtils scoreHolderUtils,
+                                       final MetadataService metadataService ) {
+        this.ioService = ioService;
+        this.dataModelerService = dataModelerService;
+        this.globalsEditorService = globalsEditorService;
+        this.kieProjectService = kieProjectService;
+        this.scoreHolderUtils = scoreHolderUtils;
+        this.metadataService = metadataService;
+    }
+
+    @Override
+    public void postProcess( final Path sourcePath,
+                             final Path destinationPath ) {
+
+        String dataObjectSource = ioService.readAllString( Paths.convert( destinationPath ) );
+        GenerationResult generationResult = dataModelerService.loadDataObject( destinationPath,
+                                                                               dataObjectSource,
+                                                                               destinationPath );
+        org.uberfire.java.nio.file.Path source = Paths.convert( kieProjectService.resolvePackage( sourcePath ).getPackageMainResourcesPath() );
+        org.uberfire.java.nio.file.Path sourcePackage = Files.isDirectory( source ) ? source : source.getParent();
+
+        String sourceSolutionFileName = sourcePath.getFileName().substring( 0,
+                                                                            sourcePath.getFileName().indexOf( "." ) );
+        org.uberfire.java.nio.file.Path sourceScoreHolderGlobalPath = sourcePackage.resolve( sourceSolutionFileName + SCORE_HOLDER_GLOBAL_FILE_SUFFIX );
+
+        if ( generationResult.hasErrors() ) {
+            LOGGER.warn( "Path " + destinationPath + " parsing as a data object has failed. Score holder global generation will be skipped." );
+        } else {
+            DataObject dataObject = generationResult.getDataObject();
+            if ( dataObject.getAnnotation( PLANNING_SOLUTION_ANNOTATION ) != null ) {
+                String sourceScoreTypeFqn = scoreHolderUtils.extractScoreTypeFqn( dataObject,
+                                                                                  destinationPath );
+                String scoreHolderTypeFqn = scoreHolderUtils.getScoreHolderTypeFqn( sourceScoreTypeFqn );
+
+                if ( scoreHolderTypeFqn == null ) {
+                    LOGGER.warn( "'scoreHolder' global variable will not be generated, as the selected score type is not supported" );
+                    return;
+                }
+
+                if ( sourcePath.equals( destinationPath ) ) {
+                    boolean scoreHolderGlobalFileExists = ioService.exists( sourceScoreHolderGlobalPath );
+
+                    if ( scoreHolderGlobalFileExists ) {
+                        GlobalsModel globalsModel = globalsEditorService.load( Paths.convert( sourceScoreHolderGlobalPath ) );
+                        globalsModel.setGlobals( Arrays.asList( new Global( SCORE_HOLDER,
+                                                                            scoreHolderTypeFqn ) ) );
+                        globalsEditorService.save( Paths.convert( sourceScoreHolderGlobalPath ),
+                                                   globalsModel,
+                                                   metadataService.getMetadata( Paths.convert( sourceScoreHolderGlobalPath ) ),
+                                                   "Auto generate scoreHolder global" );
+                    } else {
+                        createScoreHolderGlobalFile( Paths.convert( sourcePackage ),
+                                                     scoreHolderTypeFqn,
+                                                     sourceSolutionFileName );
+                    }
+                } else {
+                    org.uberfire.java.nio.file.Path destination = Paths.convert( kieProjectService.resolvePackage( destinationPath ).getPackageMainResourcesPath() );
+                    org.uberfire.java.nio.file.Path destinationPackage = Files.isDirectory( destination ) ? destination : destination.getParent();
+
+                    ioService.deleteIfExists( sourceScoreHolderGlobalPath );
+
+                    String destinationScoreHolderFileSimpleName = destinationPath.getFileName().substring( 0,
+                                                                                                           destinationPath.getFileName().indexOf( "." ) );
+                    createScoreHolderGlobalFile( Paths.convert( destinationPackage ),
+                                                 scoreHolderTypeFqn,
+                                                 destinationScoreHolderFileSimpleName );
+                }
+            } else {
+                ioService.deleteIfExists( sourceScoreHolderGlobalPath );
+            }
+        }
+    }
+
+    private void createScoreHolderGlobalFile( final Path folderPath,
+                                              final String scoreHolderTypeFqn,
+                                              final String solutionFileName ) {
+        GlobalsModel globalsModel = new GlobalsModel();
+        globalsModel.setGlobals( Arrays.asList( new Global( SCORE_HOLDER,
+                                                            scoreHolderTypeFqn ) ) );
+        globalsEditorService.create( folderPath,
+                                     solutionFileName + SCORE_HOLDER_GLOBAL_FILE_SUFFIX,
+                                     globalsModel,
+                                     "Auto generate Score holder global variable based on a @PlanningSolution " + solutionFileName );
+    }
+}

--- a/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-backend/src/test/java/org/optaplanner/workbench/screens/domaineditor/backend/helper/PlanningSolutionCopyHelperTest.java
+++ b/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-backend/src/test/java/org/optaplanner/workbench/screens/domaineditor/backend/helper/PlanningSolutionCopyHelperTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.screens.domaineditor.backend.helper;
+
+import org.guvnor.common.services.project.model.Package;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.screens.datamodeller.model.GenerationResult;
+import org.kie.workbench.common.screens.datamodeller.service.DataModelerService;
+import org.kie.workbench.common.services.datamodeller.core.DataObject;
+import org.kie.workbench.common.services.datamodeller.core.impl.AnnotationImpl;
+import org.kie.workbench.common.services.datamodeller.core.impl.DataObjectImpl;
+import org.kie.workbench.common.services.datamodeller.util.DriverUtils;
+import org.kie.workbench.common.services.shared.project.KieProjectService;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.optaplanner.core.api.domain.solution.PlanningSolution;
+import org.optaplanner.workbench.screens.domaineditor.backend.server.helper.PlanningSolutionCopyHelper;
+import org.uberfire.backend.server.util.Paths;
+import org.uberfire.backend.vfs.Path;
+import org.uberfire.backend.vfs.PathFactory;
+import org.uberfire.io.IOService;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PlanningSolutionCopyHelperTest {
+
+    @Mock
+    private IOService ioService;
+
+    @Mock
+    private DataModelerService dataModelerService;
+
+    @Mock
+    private KieProjectService kieProjectService;
+
+    private PlanningSolutionCopyHelper copyHelper;
+
+    @Before
+    public void setUp() {
+        copyHelper = new PlanningSolutionCopyHelper( ioService,
+                                                     dataModelerService,
+                                                     kieProjectService );
+    }
+
+    @Test
+    public void postProcess() {
+        Path sourcePath = PathFactory.newPath( "TestSource.java",
+                                               "file:///dataObjects" );
+        Path destinationPath = PathFactory.newPath( "TestDestination.java",
+                                                    "file:///dataObjects" );
+
+        when( ioService.readAllString( Paths.convert( sourcePath ) ) ).thenReturn( "test source" );
+
+        DataObject dataObject = new DataObjectImpl( "test",
+                                                    "TestSource" );
+        dataObject.addAnnotation( new AnnotationImpl( DriverUtils.buildAnnotationDefinition( PlanningSolution.class ) ) );
+        GenerationResult generationResult = new GenerationResult();
+        generationResult.setDataObject( dataObject );
+        when( dataModelerService.loadDataObject( any(),
+                                                 anyString(),
+                                                 any() ) ).thenReturn( generationResult );
+
+        Package _package = mock( Package.class );
+        when( _package.getPackageMainResourcesPath() ).thenReturn( PathFactory.newPath( "dataObjects",
+                                                                                        "file:///dataObjects" ) );
+        when( kieProjectService.resolvePackage( sourcePath ) ).thenReturn( _package );
+
+        when( ioService.exists( any() ) ).thenReturn( true );
+
+        copyHelper.postProcess( sourcePath,
+                                destinationPath );
+
+        verify( ioService,
+                times( 1 ) ).copy( any( org.uberfire.java.nio.file.Path.class ),
+                                   any( org.uberfire.java.nio.file.Path.class ) );
+    }
+}

--- a/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-backend/src/test/java/org/optaplanner/workbench/screens/domaineditor/backend/helper/PlanningSolutionDeleteHelperTest.java
+++ b/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-backend/src/test/java/org/optaplanner/workbench/screens/domaineditor/backend/helper/PlanningSolutionDeleteHelperTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.screens.domaineditor.backend.helper;
+
+import org.guvnor.common.services.project.model.Package;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.screens.datamodeller.model.GenerationResult;
+import org.kie.workbench.common.screens.datamodeller.service.DataModelerService;
+import org.kie.workbench.common.services.datamodeller.core.DataObject;
+import org.kie.workbench.common.services.datamodeller.core.impl.AnnotationImpl;
+import org.kie.workbench.common.services.datamodeller.core.impl.DataObjectImpl;
+import org.kie.workbench.common.services.datamodeller.util.DriverUtils;
+import org.kie.workbench.common.services.shared.project.KieProjectService;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.optaplanner.core.api.domain.solution.PlanningSolution;
+import org.optaplanner.workbench.screens.domaineditor.backend.server.helper.PlanningSolutionDeleteHelper;
+import org.uberfire.backend.server.util.Paths;
+import org.uberfire.backend.vfs.Path;
+import org.uberfire.backend.vfs.PathFactory;
+import org.uberfire.io.IOService;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PlanningSolutionDeleteHelperTest {
+
+    @Mock
+    private IOService ioService;
+
+    @Mock
+    private DataModelerService dataModelerService;
+
+    @Mock
+    private KieProjectService kieProjectService;
+
+    private PlanningSolutionDeleteHelper deleteHelper;
+
+    @Before
+    public void setUp() {
+        deleteHelper = new PlanningSolutionDeleteHelper( ioService,
+                                                         dataModelerService,
+                                                         kieProjectService );
+    }
+
+    @Test
+    public void postProcess() {
+        Path sourcePath = PathFactory.newPath( "TestSource.java",
+                                               "file:///dataObjects" );
+
+        when( ioService.readAllString( Paths.convert( sourcePath ) ) ).thenReturn( "test source" );
+
+        DataObject dataObject = new DataObjectImpl( "test",
+                                                    "TestSource" );
+        dataObject.addAnnotation( new AnnotationImpl( DriverUtils.buildAnnotationDefinition( PlanningSolution.class ) ) );
+        GenerationResult generationResult = new GenerationResult();
+        generationResult.setDataObject( dataObject );
+        when( dataModelerService.loadDataObject( any(),
+                                                 anyString(),
+                                                 any() ) ).thenReturn( generationResult );
+
+        Package _package = mock( Package.class );
+        when( _package.getPackageMainResourcesPath() ).thenReturn( PathFactory.newPath( "dataObjects",
+                                                                                        "file:///dataObjects" ) );
+        when( kieProjectService.resolvePackage( sourcePath ) ).thenReturn( _package );
+
+        when( ioService.exists( any() ) ).thenReturn( true );
+
+        deleteHelper.postProcess( sourcePath );
+
+        verify( ioService,
+                times( 1 ) ).deleteIfExists( any( org.uberfire.java.nio.file.Path.class ) );
+    }
+}

--- a/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-backend/src/test/java/org/optaplanner/workbench/screens/domaineditor/backend/helper/PlanningSolutionRenameHelperTest.java
+++ b/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-backend/src/test/java/org/optaplanner/workbench/screens/domaineditor/backend/helper/PlanningSolutionRenameHelperTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.screens.domaineditor.backend.helper;
+
+import org.guvnor.common.services.project.model.Package;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.screens.datamodeller.model.GenerationResult;
+import org.kie.workbench.common.screens.datamodeller.service.DataModelerService;
+import org.kie.workbench.common.services.datamodeller.core.DataObject;
+import org.kie.workbench.common.services.datamodeller.core.impl.AnnotationImpl;
+import org.kie.workbench.common.services.datamodeller.core.impl.DataObjectImpl;
+import org.kie.workbench.common.services.datamodeller.util.DriverUtils;
+import org.kie.workbench.common.services.shared.project.KieProjectService;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.optaplanner.core.api.domain.solution.PlanningSolution;
+import org.optaplanner.workbench.screens.domaineditor.backend.server.helper.PlanningSolutionRenameWorkaroundHelper;
+import org.uberfire.backend.server.util.Paths;
+import org.uberfire.backend.vfs.Path;
+import org.uberfire.backend.vfs.PathFactory;
+import org.uberfire.io.IOService;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PlanningSolutionRenameHelperTest {
+
+    @Mock
+    private IOService ioService;
+
+    @Mock
+    private DataModelerService dataModelerService;
+
+    @Mock
+    private KieProjectService kieProjectService;
+
+    private PlanningSolutionRenameWorkaroundHelper renameHelper;
+
+    @Before
+    public void setUp() {
+        renameHelper = new PlanningSolutionRenameWorkaroundHelper( ioService,
+                                                                   dataModelerService,
+                                                                   kieProjectService );
+    }
+
+    @Test
+    public void postProcess() {
+        Path sourcePath = PathFactory.newPath( "TestSource.java",
+                                               "file:///dataObjects" );
+        Path destinationPath = PathFactory.newPath( "TestDestination.java",
+                                                    "file:///dataObjects" );
+
+        when( ioService.readAllString( Paths.convert( sourcePath ) ) ).thenReturn( "test source" );
+
+        DataObject dataObject = new DataObjectImpl( "test",
+                                                    "TestSource" );
+        dataObject.addAnnotation( new AnnotationImpl( DriverUtils.buildAnnotationDefinition( PlanningSolution.class ) ) );
+        GenerationResult generationResult = new GenerationResult();
+        generationResult.setDataObject( dataObject );
+        when( dataModelerService.loadDataObject( any(),
+                                                 anyString(),
+                                                 any() ) ).thenReturn( generationResult );
+
+        Package _package = mock( Package.class );
+        when( _package.getPackageMainResourcesPath() ).thenReturn( PathFactory.newPath( "dataObjects",
+                                                                                        "file:///dataObjects" ) );
+        when( kieProjectService.resolvePackage( sourcePath ) ).thenReturn( _package );
+
+        when( ioService.exists( any() ) ).thenReturn( true );
+
+        renameHelper.postProcess( sourcePath,
+                                  destinationPath );
+
+        verify( ioService,
+                times( 1 ) ).move( any( org.uberfire.java.nio.file.Path.class ),
+                                   any( org.uberfire.java.nio.file.Path.class ) );
+    }
+}

--- a/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-backend/src/test/java/org/optaplanner/workbench/screens/domaineditor/backend/helper/PlanningSolutionSaveHelperTest.java
+++ b/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-backend/src/test/java/org/optaplanner/workbench/screens/domaineditor/backend/helper/PlanningSolutionSaveHelperTest.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.screens.domaineditor.backend.helper;
+
+import org.drools.workbench.screens.globals.model.GlobalsModel;
+import org.drools.workbench.screens.globals.service.GlobalsEditorService;
+import org.guvnor.common.services.project.model.Package;
+import org.guvnor.common.services.shared.metadata.MetadataService;
+import org.guvnor.common.services.shared.metadata.model.Metadata;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.screens.datamodeller.model.GenerationResult;
+import org.kie.workbench.common.screens.datamodeller.service.DataModelerService;
+import org.kie.workbench.common.services.datamodeller.core.DataObject;
+import org.kie.workbench.common.services.datamodeller.core.impl.AnnotationImpl;
+import org.kie.workbench.common.services.datamodeller.core.impl.DataObjectImpl;
+import org.kie.workbench.common.services.datamodeller.util.DriverUtils;
+import org.kie.workbench.common.services.shared.project.KieProjectService;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.optaplanner.core.api.domain.solution.PlanningSolution;
+import org.optaplanner.core.api.score.buildin.hardsoft.HardSoftScore;
+import org.optaplanner.core.api.score.buildin.hardsoft.HardSoftScoreHolder;
+import org.optaplanner.workbench.screens.domaineditor.backend.server.helper.PlanningSolutionSaveHelper;
+import org.optaplanner.workbench.screens.domaineditor.backend.server.validation.ScoreHolderUtils;
+import org.uberfire.backend.server.util.Paths;
+import org.uberfire.backend.vfs.Path;
+import org.uberfire.backend.vfs.PathFactory;
+import org.uberfire.io.IOService;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PlanningSolutionSaveHelperTest {
+
+    @Mock
+    private IOService ioService;
+
+    @Mock
+    private DataModelerService dataModelerService;
+
+    @Mock
+    private GlobalsEditorService globalsEditorService;
+
+    @Mock
+    private KieProjectService kieProjectService;
+
+    @Mock
+    private ScoreHolderUtils scoreHolderUtils;
+
+    @Mock
+    private MetadataService metadataService;
+
+    private PlanningSolutionSaveHelper saveHelper;
+
+    @Before
+    public void setUp() {
+        saveHelper = new PlanningSolutionSaveHelper( ioService,
+                                                     dataModelerService,
+                                                     globalsEditorService,
+                                                     kieProjectService,
+                                                     scoreHolderUtils,
+                                                     metadataService );
+    }
+
+    @Test
+    public void scoreTypeChangedScoreHolderGlobalFileExisting() {
+        Path sourcePath = PathFactory.newPath( "TestSource.java",
+                                               "file:///dataObjects" );
+        Path destinationPath = PathFactory.newPath( "TestSource.java",
+                                                    "file:///dataObjects" );
+        testPlanningSolutionSaved( true,
+                                   sourcePath,
+                                   destinationPath );
+    }
+
+    @Test
+    public void scoreTypeChangedScoreHolderGlobalFileNonExisting() {
+        Path sourcePath = PathFactory.newPath( "TestSource.java",
+                                               "file:///dataObjects" );
+        Path destinationPath = PathFactory.newPath( "TestSource.java",
+                                                    "file:///dataObjects" );
+        testPlanningSolutionSaved( false,
+                                   sourcePath,
+                                   destinationPath );
+    }
+
+    @Test
+    public void planningSolutionDataObjectRenamed() {
+        Path sourcePath = PathFactory.newPath( "TestSource.java",
+                                               "file:///dataObjects1" );
+        Path destinationPath = PathFactory.newPath( "TestDestination.java",
+                                                    "file:///dataObjects2" );
+        testPlanningSolutionSaved( false,
+                                   sourcePath,
+                                   destinationPath );
+    }
+
+    private void testPlanningSolutionSaved( boolean scoreHolderGlobalFileExists,
+                                            Path sourcePath,
+                                            Path destinationPath ) {
+        when( ioService.readAllString( Paths.convert( sourcePath ) ) ).thenReturn( "test source" );
+
+        DataObject dataObject = new DataObjectImpl( "test",
+                                                    "TestSource" );
+        dataObject.addAnnotation( new AnnotationImpl( DriverUtils.buildAnnotationDefinition( PlanningSolution.class ) ) );
+        GenerationResult generationResult = new GenerationResult();
+        generationResult.setDataObject( dataObject );
+        when( dataModelerService.loadDataObject( any(),
+                                                 anyString(),
+                                                 any() ) ).thenReturn( generationResult );
+
+        Package _package = mock( Package.class );
+        when( _package.getPackageMainResourcesPath() ).thenReturn( PathFactory.newPath( "dataObjects",
+                                                                                        "file:///dataObjects" ) );
+        when( kieProjectService.resolvePackage( any( Path.class ) ) ).thenReturn( _package );
+
+        when( scoreHolderUtils.extractScoreTypeFqn( dataObject,
+                                                    destinationPath ) ).thenReturn( HardSoftScore.class.getName() );
+        when( scoreHolderUtils.getScoreHolderTypeFqn( HardSoftScore.class.getName() ) ).thenReturn( HardSoftScoreHolder.class.getName() );
+        when( ioService.exists( any() ) ).thenReturn( scoreHolderGlobalFileExists );
+        when( globalsEditorService.load( any( Path.class ) ) ).thenReturn( mock( GlobalsModel.class ) );
+
+        saveHelper.postProcess( sourcePath,
+                                destinationPath );
+
+        if ( sourcePath.equals( destinationPath ) ) {
+
+            if ( scoreHolderGlobalFileExists ) {
+                verify( globalsEditorService,
+                        times( 1 ) ).save( any( Path.class ),
+                                           any( GlobalsModel.class ),
+                                           any( Metadata.class ),
+                                           anyString() );
+            } else {
+                verify( globalsEditorService,
+                        times( 1 ) ).create( any( Path.class ),
+                                             anyString(),
+                                             any( GlobalsModel.class ),
+                                             anyString() );
+            }
+        } else {
+            verify( ioService ).deleteIfExists( any( org.uberfire.java.nio.file.Path.class ) );
+            verify( globalsEditorService,
+                    times( 1 ) ).create( any( Path.class ),
+                                         anyString(),
+                                         any( GlobalsModel.class ),
+                                         anyString() );
+        }
+    }
+
+    @Test
+    public void saveDataObjectNotAPlanningSolution() {
+        Path sourcePath = PathFactory.newPath( "TestSource.java",
+                                               "file:///dataObjects" );
+        Path destinationPath = PathFactory.newPath( "TestSource.java",
+                                                    "file:///dataObjects" );
+
+        when( ioService.readAllString( Paths.convert( sourcePath ) ) ).thenReturn( "test source" );
+
+        DataObject dataObject = new DataObjectImpl( "test",
+                                                    "TestSource" );
+        GenerationResult generationResult = new GenerationResult();
+        generationResult.setDataObject( dataObject );
+        when( dataModelerService.loadDataObject( any(),
+                                                 anyString(),
+                                                 any() ) ).thenReturn( generationResult );
+
+        Package _package = mock( Package.class );
+        when( _package.getPackageMainResourcesPath() ).thenReturn( PathFactory.newPath( "dataObjects",
+                                                                                        "file:///dataObjects" ) );
+        when( kieProjectService.resolvePackage( any( Path.class ) ) ).thenReturn( _package );
+
+        saveHelper.postProcess( sourcePath,
+                                destinationPath );
+
+        verify( ioService ).deleteIfExists( any( org.uberfire.java.nio.file.Path.class ) );
+    }
+}


### PR DESCRIPTION
Based on https://github.com/droolsjbpm/optaplanner-wb/pull/135 (not integrated yet), changes included in https://github.com/droolsjbpm/optaplanner-wb/commit/6ebaa7559605e663962d4da4d15a7b59710f3b68

Makes sure 'scoreHolder' global variable is generated for a Planning Solution (1-1 relationship). The type of the global corresponds to a score type defined in the Planning Solution.

Handles all CRUD operations on the Planning Solution.

Part of:
https://github.com/droolsjbpm/kie-wb-common/pull/699
https://github.com/droolsjbpm/optaplanner-wb/pull/136