### PR TITLE
PLANNER-350: Workbench: scoreHolder support in Guided Rule Editor

### DIFF
--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/.gitignore
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/.gitignore
@@ -1,0 +1,11 @@
+/target
+/local
+
+# Eclipse, Netbeans and IntelliJ files
+/.*
+/**/.*
+!.gitignore
+/nbproject
+/*.ipr
+/*.iws
+/*.iml

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-api/.gitignore
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-api/.gitignore
@@ -1,0 +1,11 @@
+/target
+/local
+
+# Eclipse, Netbeans and IntelliJ files
+/.*
+/**/.*
+!.gitignore
+/nbproject
+/*.ipr
+/*.iws
+/*.iml

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-api/pom.xml
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-api/pom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2017 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~       http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.optaplanner</groupId>
+    <artifactId>optaplanner-wb-guided-rule-editor</artifactId>
+    <version>7.1.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>optaplanner-wb-guided-rule-editor-api</artifactId>
+  <packaging>jar</packaging>
+
+  <name>OptaPlanner Workbench - Guided Rule Editor - API</name>
+  <description>OptaPlanner Workbench - Guided Rule Editor - API</description>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-workbench-models-datamodel-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-bus</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-common</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-api</artifactId>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-api/src/main/java/org/optaplanner/workbench/screens/guidedrule/model/AbstractActionBendableConstraintMatch.java
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-api/src/main/java/org/optaplanner/workbench/screens/guidedrule/model/AbstractActionBendableConstraintMatch.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.screens.guidedrule.model;
+
+public class AbstractActionBendableConstraintMatch extends AbstractActionConstraintMatch {
+
+    protected int position;
+
+    public AbstractActionBendableConstraintMatch() {
+    }
+
+    public AbstractActionBendableConstraintMatch(final String constraintMatch,
+                                                 final int position) {
+        super(constraintMatch);
+        this.position = position;
+    }
+
+    public int getPosition() {
+        return position;
+    }
+
+    public void setPosition(int position) {
+        this.position = position;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+
+        AbstractActionBendableConstraintMatch that = (AbstractActionBendableConstraintMatch) o;
+
+        return position == that.position;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = ~~result;
+        result = 31 * result + position;
+        result = ~~result;
+        return result;
+    }
+}

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-api/src/main/java/org/optaplanner/workbench/screens/guidedrule/model/AbstractActionConstraintMatch.java
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-api/src/main/java/org/optaplanner/workbench/screens/guidedrule/model/AbstractActionConstraintMatch.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.screens.guidedrule.model;
+
+public abstract class AbstractActionConstraintMatch implements ActionConstraintMatch {
+
+    private String constraintMatch;
+
+    public AbstractActionConstraintMatch() {
+    }
+
+    public AbstractActionConstraintMatch(final String constraintMatch) {
+        this.constraintMatch = constraintMatch;
+    }
+
+    public String getConstraintMatch() {
+        return constraintMatch;
+    }
+
+    public void setConstraintMatch(String constraintMatch) {
+        this.constraintMatch = constraintMatch;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        AbstractActionConstraintMatch that = (AbstractActionConstraintMatch) o;
+
+        return constraintMatch != null ? constraintMatch.equals(that.constraintMatch) : that.constraintMatch == null;
+    }
+
+    @Override
+    public int hashCode() {
+        return constraintMatch != null ? constraintMatch.hashCode() : 0;
+    }
+}

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-api/src/main/java/org/optaplanner/workbench/screens/guidedrule/model/AbstractActionMultiConstraintBendableMatch.java
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-api/src/main/java/org/optaplanner/workbench/screens/guidedrule/model/AbstractActionMultiConstraintBendableMatch.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.screens.guidedrule.model;
+
+import java.util.List;
+
+public abstract class AbstractActionMultiConstraintBendableMatch implements ActionConstraintMatch {
+
+    private List<ActionBendableHardConstraintMatch> actionBendableHardConstraintMatches;
+
+    private List<ActionBendableSoftConstraintMatch> actionBendableSoftConstraintMatches;
+
+    public AbstractActionMultiConstraintBendableMatch() {
+    }
+
+    public AbstractActionMultiConstraintBendableMatch(final List<ActionBendableHardConstraintMatch> actionBendableHardConstraintMatches,
+                                                      final List<ActionBendableSoftConstraintMatch> actionBendableSoftConstraintMatches) {
+        this.actionBendableHardConstraintMatches = actionBendableHardConstraintMatches;
+        this.actionBendableSoftConstraintMatches = actionBendableSoftConstraintMatches;
+    }
+
+    public List<ActionBendableHardConstraintMatch> getActionBendableHardConstraintMatches() {
+        return actionBendableHardConstraintMatches;
+    }
+
+    public void setActionBendableHardConstraintMatches(List<ActionBendableHardConstraintMatch> actionBendableHardConstraintMatches) {
+        this.actionBendableHardConstraintMatches = actionBendableHardConstraintMatches;
+    }
+
+    public List<ActionBendableSoftConstraintMatch> getActionBendableSoftConstraintMatches() {
+        return actionBendableSoftConstraintMatches;
+    }
+
+    public void setActionBendableSoftConstraintMatches(List<ActionBendableSoftConstraintMatch> actionBendableSoftConstraintMatches) {
+        this.actionBendableSoftConstraintMatches = actionBendableSoftConstraintMatches;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        AbstractActionMultiConstraintBendableMatch that = (AbstractActionMultiConstraintBendableMatch) o;
+
+        if (actionBendableHardConstraintMatches != null ? !actionBendableHardConstraintMatches.equals(that.actionBendableHardConstraintMatches) : that.actionBendableHardConstraintMatches != null) {
+            return false;
+        }
+        return actionBendableSoftConstraintMatches != null ? actionBendableSoftConstraintMatches.equals(that.actionBendableSoftConstraintMatches) : that.actionBendableSoftConstraintMatches == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = actionBendableHardConstraintMatches != null ? actionBendableHardConstraintMatches.hashCode() : 0;
+        result = ~~result;
+        result = 31 * result + (actionBendableSoftConstraintMatches != null ? actionBendableSoftConstraintMatches.hashCode() : 0);
+        result = ~~result;
+        return result;
+    }
+}

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-api/src/main/java/org/optaplanner/workbench/screens/guidedrule/model/ActionBendableHardConstraintMatch.java
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-api/src/main/java/org/optaplanner/workbench/screens/guidedrule/model/ActionBendableHardConstraintMatch.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.screens.guidedrule.model;
+
+import org.jboss.errai.common.client.api.annotations.Portable;
+
+@Portable
+public class ActionBendableHardConstraintMatch extends AbstractActionBendableConstraintMatch {
+
+    public ActionBendableHardConstraintMatch() {
+    }
+
+    public ActionBendableHardConstraintMatch( final int position,
+                                              final String constraintMatch ) {
+        super( constraintMatch,
+               position );
+    }
+
+    @Override
+    public boolean equals( Object o ) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( o == null || getClass() != o.getClass() ) {
+            return false;
+        }
+        if ( !super.equals( o ) ) {
+            return false;
+        }
+
+        ActionBendableHardConstraintMatch that = (ActionBendableHardConstraintMatch) o;
+
+        return position == that.position;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = ~~result;
+        result = 31 * result + position;
+        result = ~~result;
+        return result;
+    }
+}

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-api/src/main/java/org/optaplanner/workbench/screens/guidedrule/model/ActionBendableSoftConstraintMatch.java
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-api/src/main/java/org/optaplanner/workbench/screens/guidedrule/model/ActionBendableSoftConstraintMatch.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.screens.guidedrule.model;
+
+import org.jboss.errai.common.client.api.annotations.Portable;
+
+@Portable
+public class ActionBendableSoftConstraintMatch extends AbstractActionBendableConstraintMatch {
+
+    public ActionBendableSoftConstraintMatch() {
+    }
+
+    public ActionBendableSoftConstraintMatch(final int position,
+                                             final String constraintMatch) {
+        super(constraintMatch,
+              position);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+
+        ActionBendableSoftConstraintMatch that = (ActionBendableSoftConstraintMatch) o;
+
+        return position == that.position;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = ~~result;
+        result = 31 * result + position;
+        result = ~~result;
+        return result;
+    }
+}

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-api/src/main/java/org/optaplanner/workbench/screens/guidedrule/model/ActionConstraintMatch.java
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-api/src/main/java/org/optaplanner/workbench/screens/guidedrule/model/ActionConstraintMatch.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.screens.guidedrule.model;
+
+import org.drools.workbench.models.datamodel.rule.IAction;
+
+public interface ActionConstraintMatch extends IAction {
+
+}

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-api/src/main/java/org/optaplanner/workbench/screens/guidedrule/model/ActionHardConstraintMatch.java
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-api/src/main/java/org/optaplanner/workbench/screens/guidedrule/model/ActionHardConstraintMatch.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.optaplanner.workbench.screens.guidedrule.model;
+
+import org.jboss.errai.common.client.api.annotations.Portable;
+
+@Portable
+public class ActionHardConstraintMatch extends AbstractActionConstraintMatch {
+
+    public ActionHardConstraintMatch() {
+    }
+
+    public ActionHardConstraintMatch(final String constraintMatch) {
+        super(constraintMatch);
+    }
+}

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-api/src/main/java/org/optaplanner/workbench/screens/guidedrule/model/ActionMediumConstraintMatch.java
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-api/src/main/java/org/optaplanner/workbench/screens/guidedrule/model/ActionMediumConstraintMatch.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.screens.guidedrule.model;
+
+import org.jboss.errai.common.client.api.annotations.Portable;
+
+@Portable
+public class ActionMediumConstraintMatch extends AbstractActionConstraintMatch {
+
+    public ActionMediumConstraintMatch() {
+    }
+
+    public ActionMediumConstraintMatch(final String constraintMatch) {
+        super(constraintMatch);
+    }
+}

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-api/src/main/java/org/optaplanner/workbench/screens/guidedrule/model/ActionMultiConstraintBendableBigDecimalMatch.java
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-api/src/main/java/org/optaplanner/workbench/screens/guidedrule/model/ActionMultiConstraintBendableBigDecimalMatch.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.screens.guidedrule.model;
+
+import java.util.List;
+
+import org.jboss.errai.common.client.api.annotations.Portable;
+
+@Portable
+public class ActionMultiConstraintBendableBigDecimalMatch extends AbstractActionMultiConstraintBendableMatch {
+
+    public ActionMultiConstraintBendableBigDecimalMatch() {
+    }
+
+    public ActionMultiConstraintBendableBigDecimalMatch(final List<ActionBendableHardConstraintMatch> actionBendableHardConstraintMatches,
+                                                        final List<ActionBendableSoftConstraintMatch> actionBendableSoftConstraintMatches) {
+        super(actionBendableHardConstraintMatches,
+              actionBendableSoftConstraintMatches);
+    }
+}

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-api/src/main/java/org/optaplanner/workbench/screens/guidedrule/model/ActionMultiConstraintBendableLongMatch.java
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-api/src/main/java/org/optaplanner/workbench/screens/guidedrule/model/ActionMultiConstraintBendableLongMatch.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.screens.guidedrule.model;
+
+import java.util.List;
+
+import org.jboss.errai.common.client.api.annotations.Portable;
+
+@Portable
+public class ActionMultiConstraintBendableLongMatch extends AbstractActionMultiConstraintBendableMatch {
+
+    public ActionMultiConstraintBendableLongMatch() {
+    }
+
+    public ActionMultiConstraintBendableLongMatch(final List<ActionBendableHardConstraintMatch> actionBendableHardConstraintMatches,
+                                                  final List<ActionBendableSoftConstraintMatch> actionBendableSoftConstraintMatches) {
+        super(actionBendableHardConstraintMatches,
+              actionBendableSoftConstraintMatches);
+    }
+}

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-api/src/main/java/org/optaplanner/workbench/screens/guidedrule/model/ActionMultiConstraintBendableMatch.java
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-api/src/main/java/org/optaplanner/workbench/screens/guidedrule/model/ActionMultiConstraintBendableMatch.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.screens.guidedrule.model;
+
+import java.util.List;
+
+import org.jboss.errai.common.client.api.annotations.Portable;
+
+@Portable
+public class ActionMultiConstraintBendableMatch extends AbstractActionMultiConstraintBendableMatch {
+
+    public ActionMultiConstraintBendableMatch() {
+    }
+
+    public ActionMultiConstraintBendableMatch(final List<ActionBendableHardConstraintMatch> actionBendableHardConstraintMatches,
+                                              final List<ActionBendableSoftConstraintMatch> actionBendableSoftConstraintMatches) {
+        super(actionBendableHardConstraintMatches,
+              actionBendableSoftConstraintMatches);
+    }
+}

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-api/src/main/java/org/optaplanner/workbench/screens/guidedrule/model/ActionMultiConstraintHardMediumSoftMatch.java
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-api/src/main/java/org/optaplanner/workbench/screens/guidedrule/model/ActionMultiConstraintHardMediumSoftMatch.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.screens.guidedrule.model;
+
+import org.jboss.errai.common.client.api.annotations.Portable;
+
+@Portable
+public class ActionMultiConstraintHardMediumSoftMatch implements ActionConstraintMatch {
+
+    private ActionHardConstraintMatch actionHardConstraintMatch;
+
+    private ActionMediumConstraintMatch actionMediumConstraintMatch;
+
+    private ActionSoftConstraintMatch actionSoftConstraintMatch;
+
+    public ActionMultiConstraintHardMediumSoftMatch() {
+    }
+
+    public ActionMultiConstraintHardMediumSoftMatch(final ActionHardConstraintMatch actionHardConstraintMatch,
+                                                    final ActionMediumConstraintMatch actionMediumConstraintMatch,
+                                                    final ActionSoftConstraintMatch actionSoftConstraintMatch) {
+        this.actionHardConstraintMatch = actionHardConstraintMatch;
+        this.actionMediumConstraintMatch = actionMediumConstraintMatch;
+        this.actionSoftConstraintMatch = actionSoftConstraintMatch;
+    }
+
+    public ActionHardConstraintMatch getActionHardConstraintMatch() {
+        return actionHardConstraintMatch;
+    }
+
+    public void setActionHardConstraintMatch(ActionHardConstraintMatch actionHardConstraintMatch) {
+        this.actionHardConstraintMatch = actionHardConstraintMatch;
+    }
+
+    public ActionMediumConstraintMatch getActionMediumConstraintMatch() {
+        return actionMediumConstraintMatch;
+    }
+
+    public void setActionMediumConstraintMatch(ActionMediumConstraintMatch actionMediumConstraintMatch) {
+        this.actionMediumConstraintMatch = actionMediumConstraintMatch;
+    }
+
+    public ActionSoftConstraintMatch getActionSoftConstraintMatch() {
+        return actionSoftConstraintMatch;
+    }
+
+    public void setActionSoftConstraintMatch(ActionSoftConstraintMatch actionSoftConstraintMatch) {
+        this.actionSoftConstraintMatch = actionSoftConstraintMatch;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        ActionMultiConstraintHardMediumSoftMatch that = (ActionMultiConstraintHardMediumSoftMatch) o;
+
+        if (actionHardConstraintMatch != null ? !actionHardConstraintMatch.equals(that.actionHardConstraintMatch) : that.actionHardConstraintMatch != null) {
+            return false;
+        }
+        if (actionMediumConstraintMatch != null ? !actionMediumConstraintMatch.equals(that.actionMediumConstraintMatch) : that.actionMediumConstraintMatch != null) {
+            return false;
+        }
+        return actionSoftConstraintMatch != null ? actionSoftConstraintMatch.equals(that.actionSoftConstraintMatch) : that.actionSoftConstraintMatch == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = actionHardConstraintMatch != null ? actionHardConstraintMatch.hashCode() : 0;
+        result = ~~result;
+        result = 31 * result + (actionMediumConstraintMatch != null ? actionMediumConstraintMatch.hashCode() : 0);
+        result = ~~result;
+        result = 31 * result + (actionSoftConstraintMatch != null ? actionSoftConstraintMatch.hashCode() : 0);
+        result = ~~result;
+        return result;
+    }
+}

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-api/src/main/java/org/optaplanner/workbench/screens/guidedrule/model/ActionMultiConstraintHardSoftMatch.java
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-api/src/main/java/org/optaplanner/workbench/screens/guidedrule/model/ActionMultiConstraintHardSoftMatch.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.screens.guidedrule.model;
+
+import org.jboss.errai.common.client.api.annotations.Portable;
+
+@Portable
+public class ActionMultiConstraintHardSoftMatch implements ActionConstraintMatch {
+
+    private ActionHardConstraintMatch actionHardConstraintMatch;
+
+    private ActionSoftConstraintMatch actionSoftConstraintMatch;
+
+    public ActionMultiConstraintHardSoftMatch() {
+    }
+
+    public ActionMultiConstraintHardSoftMatch(final ActionHardConstraintMatch actionHardConstraintMatch,
+                                              final ActionSoftConstraintMatch actionSoftConstraintMatch) {
+        this.actionHardConstraintMatch = actionHardConstraintMatch;
+        this.actionSoftConstraintMatch = actionSoftConstraintMatch;
+    }
+
+    public ActionHardConstraintMatch getActionHardConstraintMatch() {
+        return actionHardConstraintMatch;
+    }
+
+    public ActionSoftConstraintMatch getActionSoftConstraintMatch() {
+        return actionSoftConstraintMatch;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        ActionMultiConstraintHardSoftMatch that = (ActionMultiConstraintHardSoftMatch) o;
+
+        if (actionHardConstraintMatch != null ? !actionHardConstraintMatch.equals(that.actionHardConstraintMatch) : that.actionHardConstraintMatch != null) {
+            return false;
+        }
+        return actionSoftConstraintMatch != null ? actionSoftConstraintMatch.equals(that.actionSoftConstraintMatch) : that.actionSoftConstraintMatch == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = actionHardConstraintMatch != null ? actionHardConstraintMatch.hashCode() : 0;
+        result = ~~result;
+        result = 31 * result + (actionSoftConstraintMatch != null ? actionSoftConstraintMatch.hashCode() : 0);
+        result = ~~result;
+        return result;
+    }
+}

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-api/src/main/java/org/optaplanner/workbench/screens/guidedrule/model/ActionSimpleConstraintMatch.java
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-api/src/main/java/org/optaplanner/workbench/screens/guidedrule/model/ActionSimpleConstraintMatch.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.screens.guidedrule.model;
+
+import org.jboss.errai.common.client.api.annotations.Portable;
+
+@Portable
+public class ActionSimpleConstraintMatch extends AbstractActionConstraintMatch {
+
+    public ActionSimpleConstraintMatch() {
+    }
+
+    public ActionSimpleConstraintMatch(final String constraintMatch) {
+        super(constraintMatch);
+    }
+}

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-api/src/main/java/org/optaplanner/workbench/screens/guidedrule/model/ActionSoftConstraintMatch.java
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-api/src/main/java/org/optaplanner/workbench/screens/guidedrule/model/ActionSoftConstraintMatch.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.screens.guidedrule.model;
+
+import org.jboss.errai.common.client.api.annotations.Portable;
+
+@Portable
+public class ActionSoftConstraintMatch extends AbstractActionConstraintMatch {
+
+    public ActionSoftConstraintMatch() {
+    }
+
+    public ActionSoftConstraintMatch(final String constraintMatch) {
+        super(constraintMatch);
+    }
+}

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-api/src/main/java/org/optaplanner/workbench/screens/guidedrule/model/BendableScoreLevelsWrapper.java
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-api/src/main/java/org/optaplanner/workbench/screens/guidedrule/model/BendableScoreLevelsWrapper.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.screens.guidedrule.model;
+
+import org.jboss.errai.common.client.api.annotations.Portable;
+
+@Portable
+public final class BendableScoreLevelsWrapper {
+
+    private int hardScoreLevels;
+
+    private int softScoreLevels;
+
+    public BendableScoreLevelsWrapper() {
+    }
+
+    public BendableScoreLevelsWrapper(final int hardScoreLevels,
+                                      final int softScoreLevels) {
+        this.hardScoreLevels = hardScoreLevels;
+        this.softScoreLevels = softScoreLevels;
+    }
+
+    public int getHardScoreLevels() {
+        return hardScoreLevels;
+    }
+
+    public int getSoftScoreLevels() {
+        return softScoreLevels;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        BendableScoreLevelsWrapper that = (BendableScoreLevelsWrapper) o;
+
+        if (hardScoreLevels != that.hardScoreLevels) {
+            return false;
+        }
+        return softScoreLevels == that.softScoreLevels;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = hardScoreLevels;
+        result = ~~result;
+        result = 31 * result + softScoreLevels;
+        result = ~~result;
+        return result;
+    }
+}

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-api/src/main/java/org/optaplanner/workbench/screens/guidedrule/model/ScoreInformation.java
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-api/src/main/java/org/optaplanner/workbench/screens/guidedrule/model/ScoreInformation.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.screens.guidedrule.model;
+
+import java.util.Collection;
+
+import org.jboss.errai.common.client.api.annotations.Portable;
+
+@Portable
+public final class ScoreInformation {
+
+    private Collection<String> scoreHolderFqnTypeFqns;
+
+    private Collection<BendableScoreLevelsWrapper> bendableScoreLevelsWrappers;
+
+    public ScoreInformation() {
+    }
+
+    public ScoreInformation(final Collection<String> scoreHolderFqnTypeFqns,
+                            final Collection<BendableScoreLevelsWrapper> bendableScoreLevelsWrappers) {
+        this.scoreHolderFqnTypeFqns = scoreHolderFqnTypeFqns;
+        this.bendableScoreLevelsWrappers = bendableScoreLevelsWrappers;
+    }
+
+    public Collection<String> getScoreHolderFqnTypeFqns() {
+        return scoreHolderFqnTypeFqns;
+    }
+
+    public Collection<BendableScoreLevelsWrapper> getBendableScoreLevelsWrappers() {
+        return bendableScoreLevelsWrappers;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        ScoreInformation that = (ScoreInformation) o;
+
+        if (scoreHolderFqnTypeFqns != null ? !scoreHolderFqnTypeFqns.equals(that.scoreHolderFqnTypeFqns) : that.scoreHolderFqnTypeFqns != null) {
+            return false;
+        }
+        return bendableScoreLevelsWrappers != null ? bendableScoreLevelsWrappers.equals(that.bendableScoreLevelsWrappers) : that.bendableScoreLevelsWrappers == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = scoreHolderFqnTypeFqns != null ? scoreHolderFqnTypeFqns.hashCode() : 0;
+        result = ~~result;
+        result = 31 * result + (bendableScoreLevelsWrappers != null ? bendableScoreLevelsWrappers.hashCode() : 0);
+        result = ~~result;
+        return result;
+    }
+}

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-api/src/main/java/org/optaplanner/workbench/screens/guidedrule/service/ScoreHolderService.java
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-api/src/main/java/org/optaplanner/workbench/screens/guidedrule/service/ScoreHolderService.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.screens.guidedrule.service;
+
+import org.jboss.errai.bus.server.annotations.Remote;
+import org.optaplanner.workbench.screens.guidedrule.model.ScoreInformation;
+import org.uberfire.backend.vfs.Path;
+
+@Remote
+public interface ScoreHolderService {
+
+    ScoreInformation getProjectScoreInformation(final Path projectPath);
+}

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-api/src/main/resources/ErraiApp.properties
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-api/src/main/resources/ErraiApp.properties
@@ -1,0 +1,31 @@
+#
+# Copyright 2012 Red Hat, Inc. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# ErraiApp.properties
+#
+# Do not remove, even if empty!
+#
+
+# This is a marker file. When it is detected inside a JAR or at the
+# top of any classpath, the subdirectories are scanned for deployable
+# components. As such, all Errai application modules in a project
+# should contain an ErraiApp.properties at the root of all classpaths
+# that you wish to be scanned.
+#
+# There are also some configuration options that can be set in this
+# file, although it is rarely necessary. See the documentation at
+# https://docs.jboss.org/author/display/ERRAI/ErraiApp.properties
+# for details.

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-api/src/main/resources/org/optaplanner/workbench/screens/guidedrule/OptaPlannerWorkbenchGuidedRuleEditorAPI.gwt.xml
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-api/src/main/resources/org/optaplanner/workbench/screens/guidedrule/OptaPlannerWorkbenchGuidedRuleEditorAPI.gwt.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+  ~ Copyright 2015 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~       http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.7.0//EN"
+    "http://www.gwtproject.org/doctype/2.7.0/gwt-module.dtd">
+<module>
+
+  <source path="model"/>
+  <source path="service"/>
+
+</module>

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-backend/.gitignore
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-backend/.gitignore
@@ -1,0 +1,11 @@
+/target
+/local
+
+# Eclipse, Netbeans and IntelliJ files
+/.*
+/**/.*
+!.gitignore
+/nbproject
+/*.ipr
+/*.iws
+/*.iml

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-backend/pom.xml
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-backend/pom.xml
@@ -1,0 +1,133 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2017 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~       http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.optaplanner</groupId>
+    <artifactId>optaplanner-wb-guided-rule-editor</artifactId>
+    <version>7.1.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>optaplanner-wb-guided-rule-editor-backend</artifactId>
+  <packaging>jar</packaging>
+
+  <name>OptaPlanner Workbench - Guided Rule Editor - Backend</name>
+  <description>OptaPlanner Workbench - Guided Rule Editor - Backend</description>
+
+  <dependencies>
+    <!-- Regular dependencies -->
+    <dependency>
+      <groupId>org.optaplanner</groupId>
+      <artifactId>optaplanner-wb-guided-rule-editor-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-wb-globals-editor-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-workbench-models-commons</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-ioc</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.kie.workbench.screens</groupId>
+      <artifactId>kie-wb-common-data-modeller-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.kie.workbench.services</groupId>
+      <artifactId>kie-wb-common-services-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.kie.workbench.services</groupId>
+      <artifactId>kie-wb-common-services-backend</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.optaplanner</groupId>
+      <artifactId>optaplanner-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-io</artifactId>
+    </dependency>
+
+    <!-- Transitive dependencies -->
+    <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-workbench-models-datamodel-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.guvnor</groupId>
+      <artifactId>guvnor-project-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.kie.workbench.screens</groupId>
+      <artifactId>kie-wb-common-java-editor-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.kie.workbench.services</groupId>
+      <artifactId>kie-wb-common-data-modeller-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-backend-server</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-nio2-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-nio2-model</artifactId>
+    </dependency>
+
+  </dependencies>
+
+</project>

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-backend/src/main/java/org/optaplanner/workbench/screens/guidedrule/backend/server/plugin/HardConstraintMatchPersistenceExtension.java
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-backend/src/main/java/org/optaplanner/workbench/screens/guidedrule/backend/server/plugin/HardConstraintMatchPersistenceExtension.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.screens.guidedrule.backend.server.plugin;
+
+import java.util.List;
+import java.util.regex.Pattern;
+import javax.enterprise.context.ApplicationScoped;
+
+import org.drools.core.util.StringUtils;
+import org.drools.workbench.models.commons.backend.rule.RuleModelIActionPersistenceExtension;
+import org.drools.workbench.models.datamodel.rule.FreeFormLine;
+import org.drools.workbench.models.datamodel.rule.IAction;
+import org.optaplanner.workbench.screens.guidedrule.model.ActionBendableHardConstraintMatch;
+import org.optaplanner.workbench.screens.guidedrule.model.ActionHardConstraintMatch;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@ApplicationScoped
+public class HardConstraintMatchPersistenceExtension implements RuleModelIActionPersistenceExtension {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger( HardConstraintMatchPersistenceExtension.class );
+
+    private static final Pattern CONSTRAINT_MATCH_PATTERN = Pattern.compile( "scoreHolder\\.addHardConstraintMatch\\(\\s*kcontext\\s*,.+\\);" );
+
+    @Override
+    public boolean accept( final IAction iAction ) {
+        return iAction instanceof ActionHardConstraintMatch || iAction instanceof ActionBendableHardConstraintMatch;
+    }
+
+    @Override
+    public String marshal( final IAction iAction ) {
+        if ( iAction instanceof ActionHardConstraintMatch ) {
+            ActionHardConstraintMatch actionConstraintMatch = (ActionHardConstraintMatch) iAction;
+            return String.format( "scoreHolder.addHardConstraintMatch(kcontext, %s);",
+                                  actionConstraintMatch.getConstraintMatch() );
+        } else if ( iAction instanceof ActionBendableHardConstraintMatch ) {
+            ActionBendableHardConstraintMatch actionConstraintMatch = (ActionBendableHardConstraintMatch) iAction;
+            return String.format( "scoreHolder.addHardConstraintMatch(kcontext, %s, %s);",
+                                  actionConstraintMatch.getPosition(),
+                                  actionConstraintMatch.getConstraintMatch() );
+        }
+        throw new IllegalArgumentException( "Action " + iAction + " is not supported by this extension" );
+    }
+
+    @Override
+    public boolean accept( final String iActionString ) {
+        return CONSTRAINT_MATCH_PATTERN.matcher( iActionString ).matches();
+    }
+
+    @Override
+    public IAction unmarshal( final String iActionString ) {
+        List<String> parameters = StringUtils.splitArgumentsList( PersistenceExtensionUtils.unwrapParenthesis( iActionString ) );
+
+        if ( !parameters.isEmpty() && "kcontext".equals( parameters.get( 0 ) ) ) {
+            if ( parameters.size() == 2 ) {
+                return new ActionHardConstraintMatch( PersistenceExtensionUtils.extractConstraintMatchValue( parameters.get( 1 ) ) );
+            }
+            if ( parameters.size() == 3 ) {
+                try {
+                    int bendableScoreLevel = Integer.parseInt( parameters.get( 1 ) );
+
+                    return new ActionBendableHardConstraintMatch( bendableScoreLevel,
+                                                                  PersistenceExtensionUtils.extractConstraintMatchValue( parameters.get( 2 ) ) );
+                } catch ( NumberFormatException e ) {
+                    LOGGER.debug( "Could not parse bendable score level parameter " + parameters.get( 1 ) + " as an Integer, returning a FreeFormLine" );
+                }
+            }
+        }
+
+        // Line can't be parsed as an ActionHardConstraintMatch, return a FreeFormLine
+        FreeFormLine freeFormLine = new FreeFormLine();
+        freeFormLine.setText( iActionString );
+
+        return freeFormLine;
+    }
+}

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-backend/src/main/java/org/optaplanner/workbench/screens/guidedrule/backend/server/plugin/MediumConstraintMatchPersistenceExtension.java
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-backend/src/main/java/org/optaplanner/workbench/screens/guidedrule/backend/server/plugin/MediumConstraintMatchPersistenceExtension.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.screens.guidedrule.backend.server.plugin;
+
+import java.util.regex.Pattern;
+import javax.enterprise.context.ApplicationScoped;
+
+import org.drools.workbench.models.commons.backend.rule.RuleModelIActionPersistenceExtension;
+import org.drools.workbench.models.datamodel.rule.FreeFormLine;
+import org.drools.workbench.models.datamodel.rule.IAction;
+import org.optaplanner.workbench.screens.guidedrule.model.ActionMediumConstraintMatch;
+
+@ApplicationScoped
+public class MediumConstraintMatchPersistenceExtension implements RuleModelIActionPersistenceExtension {
+
+    private static final Pattern CONSTRAINT_MATCH_PATTERN = Pattern.compile( "scoreHolder\\.addMediumConstraintMatch\\(\\s*kcontext\\s*,.+\\);" );
+
+    @Override
+    public boolean accept( final IAction iAction ) {
+        return iAction instanceof ActionMediumConstraintMatch;
+    }
+
+    @Override
+    public String marshal( final IAction iAction ) {
+        if ( iAction instanceof ActionMediumConstraintMatch ) {
+            ActionMediumConstraintMatch actionConstraintMatch = (ActionMediumConstraintMatch) iAction;
+            return String.format("scoreHolder.addMediumConstraintMatch(kcontext, %s);",
+                                 actionConstraintMatch.getConstraintMatch());
+        }
+        throw new IllegalArgumentException( "Action " + iAction + " is not supported by this extension" );
+    }
+
+    @Override
+    public boolean accept( final String iActionString ) {
+        return CONSTRAINT_MATCH_PATTERN.matcher( iActionString ).matches();
+    }
+
+    @Override
+    public IAction unmarshal( final String iActionString ) {
+        String[] parameters = PersistenceExtensionUtils.unwrapParenthesis( iActionString ).split( "\\s*,\\s*" );
+
+        if ( "kcontext".equals( parameters[0] ) ) {
+            if ( parameters.length == 2 ) {
+                return new ActionMediumConstraintMatch( PersistenceExtensionUtils.extractConstraintMatchValue( parameters[1] ) );
+            }
+        }
+
+        // Line can't be parsed as an ActionMediumConstraintMatch, return a FreeFormLine
+        FreeFormLine freeFormLine = new FreeFormLine();
+        freeFormLine.setText( iActionString );
+
+        return freeFormLine;
+    }
+}

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-backend/src/main/java/org/optaplanner/workbench/screens/guidedrule/backend/server/plugin/MultiConstraintHardSoftMatchPersistenceExtension.java
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-backend/src/main/java/org/optaplanner/workbench/screens/guidedrule/backend/server/plugin/MultiConstraintHardSoftMatchPersistenceExtension.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.screens.guidedrule.backend.server.plugin;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import javax.enterprise.context.ApplicationScoped;
+
+import org.drools.core.util.StringUtils;
+import org.drools.workbench.models.commons.backend.rule.RuleModelIActionPersistenceExtension;
+import org.drools.workbench.models.datamodel.rule.FreeFormLine;
+import org.drools.workbench.models.datamodel.rule.IAction;
+import org.optaplanner.workbench.screens.guidedrule.model.ActionBendableHardConstraintMatch;
+import org.optaplanner.workbench.screens.guidedrule.model.ActionBendableSoftConstraintMatch;
+import org.optaplanner.workbench.screens.guidedrule.model.ActionHardConstraintMatch;
+import org.optaplanner.workbench.screens.guidedrule.model.ActionMediumConstraintMatch;
+import org.optaplanner.workbench.screens.guidedrule.model.ActionMultiConstraintBendableBigDecimalMatch;
+import org.optaplanner.workbench.screens.guidedrule.model.ActionMultiConstraintBendableLongMatch;
+import org.optaplanner.workbench.screens.guidedrule.model.ActionMultiConstraintBendableMatch;
+import org.optaplanner.workbench.screens.guidedrule.model.ActionMultiConstraintHardMediumSoftMatch;
+import org.optaplanner.workbench.screens.guidedrule.model.ActionMultiConstraintHardSoftMatch;
+import org.optaplanner.workbench.screens.guidedrule.model.ActionSoftConstraintMatch;
+
+@ApplicationScoped
+public class MultiConstraintHardSoftMatchPersistenceExtension implements RuleModelIActionPersistenceExtension {
+
+    private static final Pattern CONSTRAINT_MATCH_PATTERN = Pattern.compile( "scoreHolder\\.addMultiConstraintMatch\\(\\s*kcontext\\s*,.+\\);" );
+
+    private static final Pattern ARRAY_PATTERN = Pattern.compile( "new\\s+\\b(int|long|BigDecimal|java\\.math\\.BigDecimal)\\b\\s*\\[\\s*\\]\\s*\\{.*\\}" );
+
+    @Override
+    public boolean accept( final IAction iAction ) {
+        return iAction instanceof ActionMultiConstraintHardSoftMatch
+                || iAction instanceof ActionMultiConstraintHardMediumSoftMatch
+                || iAction instanceof ActionMultiConstraintBendableMatch
+                || iAction instanceof ActionMultiConstraintBendableLongMatch
+                || iAction instanceof ActionMultiConstraintBendableBigDecimalMatch;
+    }
+
+    @Override
+    public String marshal( final IAction iAction ) {
+        if ( iAction instanceof ActionMultiConstraintHardSoftMatch ) {
+            ActionMultiConstraintHardSoftMatch actionConstraintMatch = (ActionMultiConstraintHardSoftMatch) iAction;
+            return String.format( "scoreHolder.addMultiConstraintMatch(kcontext, %s, %s);",
+                                  actionConstraintMatch.getActionHardConstraintMatch().getConstraintMatch(),
+                                  actionConstraintMatch.getActionSoftConstraintMatch().getConstraintMatch() );
+        } else if ( iAction instanceof ActionMultiConstraintHardMediumSoftMatch ) {
+            ActionMultiConstraintHardMediumSoftMatch actionConstraintMatch = (ActionMultiConstraintHardMediumSoftMatch) iAction;
+            return String.format( "scoreHolder.addMultiConstraintMatch(kcontext, %s, %s, %s);",
+                                  actionConstraintMatch.getActionHardConstraintMatch().getConstraintMatch(),
+                                  actionConstraintMatch.getActionMediumConstraintMatch().getConstraintMatch(),
+                                  actionConstraintMatch.getActionSoftConstraintMatch().getConstraintMatch() );
+        } else if ( iAction instanceof ActionMultiConstraintBendableMatch ) {
+            ActionMultiConstraintBendableMatch actionConstraintMatch = (ActionMultiConstraintBendableMatch) iAction;
+            return String.format( "scoreHolder.addMultiConstraintMatch(kcontext, new int[] {%s}, new int[] {%s});",
+                                  actionConstraintMatch.getActionBendableHardConstraintMatches().stream().map( m -> m.getConstraintMatch() ).collect( Collectors.joining( ", " ) ),
+                                  actionConstraintMatch.getActionBendableSoftConstraintMatches().stream().map( m -> m.getConstraintMatch() ).collect( Collectors.joining( ", " ) ) );
+        } else if ( iAction instanceof ActionMultiConstraintBendableLongMatch ) {
+            ActionMultiConstraintBendableLongMatch actionConstraintMatch = (ActionMultiConstraintBendableLongMatch) iAction;
+            return String.format( "scoreHolder.addMultiConstraintMatch(kcontext, new long[] {%s}, new long[] {%s});",
+                                  actionConstraintMatch.getActionBendableHardConstraintMatches().stream().map( m -> m.getConstraintMatch() ).collect( Collectors.joining( ", " ) ),
+                                  actionConstraintMatch.getActionBendableSoftConstraintMatches().stream().map( m -> m.getConstraintMatch() ).collect( Collectors.joining( ", " ) ) );
+        } else if ( iAction instanceof ActionMultiConstraintBendableBigDecimalMatch ) {
+            ActionMultiConstraintBendableBigDecimalMatch actionConstraintMatch = (ActionMultiConstraintBendableBigDecimalMatch) iAction;
+            return String.format( "scoreHolder.addMultiConstraintMatch(kcontext, new java.math.BigDecimal[] {%s}, new java.math.BigDecimal[] {%s});",
+                                  actionConstraintMatch.getActionBendableHardConstraintMatches().stream().map( m -> m.getConstraintMatch() ).collect( Collectors.joining( ", " ) ),
+                                  actionConstraintMatch.getActionBendableSoftConstraintMatches().stream().map( m -> m.getConstraintMatch() ).collect( Collectors.joining( ", " ) ) );
+        }
+        throw new IllegalArgumentException( "Action " + iAction + " is not supported by this extension" );
+    }
+
+    @Override
+    public boolean accept( final String iActionString ) {
+        return CONSTRAINT_MATCH_PATTERN.matcher( iActionString ).matches();
+    }
+
+    @Override
+    public IAction unmarshal( final String iActionString ) {
+        List<String> parameters = StringUtils.splitArgumentsList( PersistenceExtensionUtils.unwrapParenthesis( iActionString ) );
+
+        if ( !parameters.isEmpty() && "kcontext".equals( parameters.get( 0 ) ) ) {
+            if ( parameters.size() == 3 ) {
+                boolean hardConstraintIsArray = false;
+                String hardConstraintType = null;
+                String hardConstraint = parameters.get( 1 );
+                Matcher hardConstraintMatcher = ARRAY_PATTERN.matcher( hardConstraint );
+                if ( hardConstraintMatcher.matches() ) {
+                    hardConstraintIsArray = true;
+                    hardConstraintType = hardConstraintMatcher.group( 1 );
+                }
+
+                boolean softConstraintIsArray = false;
+                String softConstraintType = null;
+                String softConstraint = parameters.get( 2 );
+                Matcher softConstraintMatcher = ARRAY_PATTERN.matcher( softConstraint );
+                if ( softConstraintMatcher.matches() ) {
+                    softConstraintIsArray = true;
+                    softConstraintType = softConstraintMatcher.group( 1 );
+                }
+
+                if ( hardConstraintIsArray && softConstraintIsArray && hardConstraintType.equals( softConstraintType ) ) {
+                    List<String> hardConstraints = StringUtils.splitArgumentsList( unwrapCurlyBrackets( hardConstraint ) );
+                    List<ActionBendableHardConstraintMatch> bendableHardConstraintMatches = new ArrayList<>( hardConstraints.size() );
+                    for ( int i = 0; i < hardConstraints.size(); i++ ) {
+                        bendableHardConstraintMatches.add( new ActionBendableHardConstraintMatch( i,
+                                                                                                  PersistenceExtensionUtils.extractConstraintMatchValue( hardConstraints.get( i ) ) ) );
+                    }
+
+                    List<String> softConstraints = StringUtils.splitArgumentsList( unwrapCurlyBrackets( softConstraint ) );
+                    List<ActionBendableSoftConstraintMatch> bendableSoftConstraintMatches = new ArrayList<>( softConstraints.size() );
+                    for ( int i = 0; i < softConstraints.size(); i++ ) {
+                        bendableSoftConstraintMatches.add( new ActionBendableSoftConstraintMatch( i,
+                                                                                                  PersistenceExtensionUtils.extractConstraintMatchValue( softConstraints.get( i ) ) ) );
+                    }
+
+                    switch ( hardConstraintType ) {
+                        case "int":
+                            return new ActionMultiConstraintBendableMatch( bendableHardConstraintMatches,
+                                                                           bendableSoftConstraintMatches );
+                        case "long":
+                            return new ActionMultiConstraintBendableLongMatch( bendableHardConstraintMatches,
+                                                                               bendableSoftConstraintMatches );
+                        case "BigDecimal":
+                        case "java.math.BigDecimal":
+                            return new ActionMultiConstraintBendableBigDecimalMatch( bendableHardConstraintMatches,
+                                                                                     bendableSoftConstraintMatches );
+                    }
+                } else if ( !hardConstraintIsArray && !softConstraintIsArray ) {
+                    ActionHardConstraintMatch hardConstraintMatch = new ActionHardConstraintMatch( PersistenceExtensionUtils.extractConstraintMatchValue( parameters.get( 1 ) ) );
+                    ActionSoftConstraintMatch softConstraintMatch = new ActionSoftConstraintMatch( PersistenceExtensionUtils.extractConstraintMatchValue( parameters.get( 2 ) ) );
+                    return new ActionMultiConstraintHardSoftMatch( hardConstraintMatch,
+                                                                   softConstraintMatch );
+                }
+            }
+            if ( parameters.size() == 4 ) {
+                ActionHardConstraintMatch hardConstraintMatch = new ActionHardConstraintMatch( PersistenceExtensionUtils.extractConstraintMatchValue( parameters.get( 1 ) ) );
+                ActionMediumConstraintMatch mediumConstraintMatch = new ActionMediumConstraintMatch( PersistenceExtensionUtils.extractConstraintMatchValue( parameters.get( 2 ) ) );
+                ActionSoftConstraintMatch softConstraintMatch = new ActionSoftConstraintMatch( PersistenceExtensionUtils.extractConstraintMatchValue( parameters.get( 3 ) ) );
+
+                return new ActionMultiConstraintHardMediumSoftMatch( hardConstraintMatch,
+                                                                     mediumConstraintMatch,
+                                                                     softConstraintMatch );
+            }
+        }
+
+        // Line can't be parsed as ActionMultiConstraint*Match, return a FreeFormLine
+        FreeFormLine freeFormLine = new FreeFormLine();
+        freeFormLine.setText( iActionString );
+
+        return freeFormLine;
+    }
+
+    private String unwrapCurlyBrackets( final String s ) {
+        int start = s.indexOf( '{' );
+        int end = s.lastIndexOf( '}' );
+        if ( start < 0 || end < 0 ) {
+            return s;
+        }
+        return s.substring( start + 1,
+                            end ).trim();
+    }
+}

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-backend/src/main/java/org/optaplanner/workbench/screens/guidedrule/backend/server/plugin/PersistenceExtensionUtils.java
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-backend/src/main/java/org/optaplanner/workbench/screens/guidedrule/backend/server/plugin/PersistenceExtensionUtils.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.screens.guidedrule.backend.server.plugin;
+
+public final class PersistenceExtensionUtils {
+
+    private PersistenceExtensionUtils() {
+    }
+
+    public static String unwrapParenthesis(final String s) {
+        int start = s.indexOf('(');
+        int end = s.lastIndexOf(')');
+        if (start < 0 || end < 0) {
+            return s;
+        }
+        return s.substring(start + 1,
+                           end).trim();
+    }
+
+    public static String extractConstraintMatchValue(final String s) {
+        return s.equals("null") ? null : s;
+    }
+}

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-backend/src/main/java/org/optaplanner/workbench/screens/guidedrule/backend/server/plugin/SimpleConstraintMatchPersistenceExtension.java
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-backend/src/main/java/org/optaplanner/workbench/screens/guidedrule/backend/server/plugin/SimpleConstraintMatchPersistenceExtension.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.screens.guidedrule.backend.server.plugin;
+
+import java.util.regex.Pattern;
+import javax.enterprise.context.ApplicationScoped;
+
+import org.drools.workbench.models.commons.backend.rule.RuleModelIActionPersistenceExtension;
+import org.drools.workbench.models.datamodel.rule.FreeFormLine;
+import org.drools.workbench.models.datamodel.rule.IAction;
+import org.optaplanner.workbench.screens.guidedrule.model.ActionSimpleConstraintMatch;
+
+@ApplicationScoped
+public class SimpleConstraintMatchPersistenceExtension implements RuleModelIActionPersistenceExtension {
+
+    private static final Pattern CONSTRAINT_MATCH_PATTERN = Pattern.compile( "scoreHolder\\.addConstraintMatch\\(\\s*kcontext\\s*,.+\\);" );
+
+    @Override
+    public boolean accept( final IAction iAction ) {
+        return iAction instanceof ActionSimpleConstraintMatch;
+    }
+
+    @Override
+    public String marshal( final IAction iAction ) {
+        if ( iAction instanceof ActionSimpleConstraintMatch ) {
+            ActionSimpleConstraintMatch actionConstraintMatch = (ActionSimpleConstraintMatch) iAction;
+            return String.format("scoreHolder.addConstraintMatch(kcontext, %s);",
+                                 actionConstraintMatch.getConstraintMatch());
+        }
+        throw new IllegalArgumentException( "Action " + iAction + " is not supported by this extension" );
+    }
+
+    @Override
+    public boolean accept( final String iActionString ) {
+        return CONSTRAINT_MATCH_PATTERN.matcher( iActionString ).matches();
+    }
+
+    @Override
+    public IAction unmarshal( final String iActionString ) {
+        String[] parameters = PersistenceExtensionUtils.unwrapParenthesis( iActionString ).split( "\\s*,\\s*" );
+
+        if ( "kcontext".equals( parameters[0] ) ) {
+            if ( parameters.length == 2 ) {
+                return new ActionSimpleConstraintMatch( PersistenceExtensionUtils.extractConstraintMatchValue( parameters[1] ) );
+            }
+        }
+
+        // Line can't be parsed as an ActionSimpleConstraintMatch, return a FreeFormLine
+        FreeFormLine freeFormLine = new FreeFormLine();
+        freeFormLine.setText( iActionString );
+
+        return freeFormLine;
+    }
+}

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-backend/src/main/java/org/optaplanner/workbench/screens/guidedrule/backend/server/plugin/SoftConstraintMatchPersistenceExtension.java
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-backend/src/main/java/org/optaplanner/workbench/screens/guidedrule/backend/server/plugin/SoftConstraintMatchPersistenceExtension.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.screens.guidedrule.backend.server.plugin;
+
+import java.util.regex.Pattern;
+import javax.enterprise.context.ApplicationScoped;
+
+import org.drools.workbench.models.commons.backend.rule.RuleModelIActionPersistenceExtension;
+import org.drools.workbench.models.datamodel.rule.FreeFormLine;
+import org.drools.workbench.models.datamodel.rule.IAction;
+import org.optaplanner.workbench.screens.guidedrule.model.ActionBendableSoftConstraintMatch;
+import org.optaplanner.workbench.screens.guidedrule.model.ActionSoftConstraintMatch;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@ApplicationScoped
+public class SoftConstraintMatchPersistenceExtension implements RuleModelIActionPersistenceExtension {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger( SoftConstraintMatchPersistenceExtension.class );
+
+    private static final Pattern CONSTRAINT_MATCH_PATTERN = Pattern.compile( "scoreHolder\\.addSoftConstraintMatch\\(\\s*kcontext\\s*,.+\\);" );
+
+    @Override
+    public boolean accept( final IAction iAction ) {
+        return iAction instanceof ActionSoftConstraintMatch || iAction instanceof ActionBendableSoftConstraintMatch;
+    }
+
+    @Override
+    public String marshal( final IAction iAction ) {
+        if ( iAction instanceof ActionSoftConstraintMatch ) {
+            ActionSoftConstraintMatch actionConstraintMatch = (ActionSoftConstraintMatch) iAction;
+            return String.format( "scoreHolder.addSoftConstraintMatch(kcontext, %s);",
+                                  actionConstraintMatch.getConstraintMatch() );
+        } else if ( iAction instanceof ActionBendableSoftConstraintMatch ) {
+            ActionBendableSoftConstraintMatch actionConstraintMatch = (ActionBendableSoftConstraintMatch) iAction;
+            return String.format( "scoreHolder.addSoftConstraintMatch(kcontext, %s, %s);",
+                                  actionConstraintMatch.getPosition(),
+                                  actionConstraintMatch.getConstraintMatch() );
+        }
+        throw new IllegalArgumentException( "Action " + iAction + " is not supported by this extension" );
+    }
+
+    @Override
+    public boolean accept( final String iActionString ) {
+        return CONSTRAINT_MATCH_PATTERN.matcher( iActionString ).matches();
+    }
+
+    @Override
+    public IAction unmarshal( final String iActionString ) {
+        String[] parameters = PersistenceExtensionUtils.unwrapParenthesis( iActionString ).split( "\\s*,\\s*" );
+
+        if ( "kcontext".equals( parameters[0] ) ) {
+            if ( parameters.length == 2 ) {
+                return new ActionSoftConstraintMatch( PersistenceExtensionUtils.extractConstraintMatchValue( parameters[1] ) );
+            }
+            if ( parameters.length == 3 ) {
+                try {
+                    int bendableScoreLevel = Integer.parseInt( parameters[1] );
+
+                    return new ActionBendableSoftConstraintMatch( bendableScoreLevel,
+                                                                  PersistenceExtensionUtils.extractConstraintMatchValue( parameters[2] ) );
+                } catch ( NumberFormatException e ) {
+                    LOGGER.debug( "Could not parse bendable score level parameter " + parameters[1] + " as an Integer, returning a FreeFormLine" );
+                }
+            }
+        }
+
+        // Line can't be parsed as an ActionSoftConstraintMatch, return a FreeFormLine
+        FreeFormLine freeFormLine = new FreeFormLine();
+        freeFormLine.setText( iActionString );
+
+        return freeFormLine;
+    }
+}

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-backend/src/main/java/org/optaplanner/workbench/screens/guidedrule/backend/server/service/ScoreHolderServiceImpl.java
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-backend/src/main/java/org/optaplanner/workbench/screens/guidedrule/backend/server/service/ScoreHolderServiceImpl.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.screens.guidedrule.backend.server.service;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import org.drools.workbench.screens.globals.model.Global;
+import org.drools.workbench.screens.globals.model.GlobalsModel;
+import org.drools.workbench.screens.globals.service.GlobalsEditorService;
+import org.kie.workbench.common.screens.datamodeller.model.GenerationResult;
+import org.kie.workbench.common.screens.datamodeller.service.DataModelerService;
+import org.kie.workbench.common.screens.javaeditor.type.JavaResourceTypeDefinition;
+import org.kie.workbench.common.services.datamodeller.core.Annotation;
+import org.kie.workbench.common.services.datamodeller.core.DataObject;
+import org.kie.workbench.common.services.datamodeller.core.Method;
+import org.kie.workbench.common.services.datamodeller.core.Type;
+import org.kie.workbench.common.services.shared.project.KieProjectService;
+import org.optaplanner.core.api.domain.solution.PlanningScore;
+import org.optaplanner.core.api.domain.solution.PlanningSolution;
+import org.optaplanner.core.api.score.buildin.bendable.BendableScore;
+import org.optaplanner.core.api.score.buildin.bendablebigdecimal.BendableBigDecimalScore;
+import org.optaplanner.core.api.score.buildin.bendablelong.BendableLongScore;
+import org.optaplanner.workbench.screens.guidedrule.model.BendableScoreLevelsWrapper;
+import org.optaplanner.workbench.screens.guidedrule.model.ScoreInformation;
+import org.optaplanner.workbench.screens.guidedrule.service.ScoreHolderService;
+import org.uberfire.backend.server.util.Paths;
+import org.uberfire.backend.vfs.Path;
+import org.uberfire.io.IOService;
+import org.uberfire.java.nio.file.Files;
+
+public class ScoreHolderServiceImpl implements ScoreHolderService {
+
+    private static final String SCORE_HOLDER_GLOBAL_FILE_SUFFIX = "ScoreHolderGlobal.gdrl";
+
+    private KieProjectService kieProjectService;
+
+    private IOService ioService;
+
+    private GlobalsEditorService globalsEditorService;
+
+    private DataModelerService dataModelerService;
+
+    private JavaResourceTypeDefinition javaResourceTypeDefinition;
+
+    public ScoreHolderServiceImpl() {
+    }
+
+    @Inject
+    public ScoreHolderServiceImpl(final KieProjectService kieProjectService,
+                                  @Named("ioStrategy") final IOService ioService,
+                                  final GlobalsEditorService globalsEditorService,
+                                  final DataModelerService dataModelerService,
+                                  final JavaResourceTypeDefinition javaResourceTypeDefinition) {
+        this.kieProjectService = kieProjectService;
+        this.ioService = ioService;
+        this.globalsEditorService = globalsEditorService;
+        this.dataModelerService = dataModelerService;
+        this.javaResourceTypeDefinition = javaResourceTypeDefinition;
+    }
+
+    @Override
+    public ScoreInformation getProjectScoreInformation(final Path projectPath) {
+        List<Path> classUsages = dataModelerService.findClassUsages(projectPath,
+                                                                    PlanningSolution.class.getName());
+
+        return new ScoreInformation(extractProjectScoreTypeFqns(classUsages),
+                                    getBendableScoreLevelsSize(classUsages));
+    }
+
+    private Collection<String> extractProjectScoreTypeFqns(final List<Path> classUsages) {
+        return classUsages.stream().filter(this.javaResourceTypeDefinition::accept).flatMap(p -> extractSolutionScoreTypeFqns(p).stream()).collect(Collectors.toList());
+    }
+
+    private Collection<BendableScoreLevelsWrapper> getBendableScoreLevelsSize(final List<Path> classUsages) {
+        return classUsages.stream().filter(this.javaResourceTypeDefinition::accept).map(p -> extractSolutionBendableScoreLevelsSize(p)).collect(Collectors.toList());
+    }
+
+    private Collection<String> extractSolutionScoreTypeFqns(final Path solutionObjectPath) {
+        org.uberfire.java.nio.file.Path source = Paths.convert(kieProjectService.resolvePackage(solutionObjectPath).getPackageMainResourcesPath());
+        org.uberfire.java.nio.file.Path sourcePackage = Files.isDirectory(source) ? source : source.getParent();
+
+        String sourceSolutionFileName = solutionObjectPath.getFileName().substring(0,
+                                                                                   solutionObjectPath.getFileName().indexOf("."));
+        org.uberfire.java.nio.file.Path sourceScoreHolderGlobalPath = sourcePackage.resolve(sourceSolutionFileName + SCORE_HOLDER_GLOBAL_FILE_SUFFIX);
+
+        boolean scoreHolderGlobalFileExists = ioService.exists(sourceScoreHolderGlobalPath);
+
+        if (scoreHolderGlobalFileExists) {
+            GlobalsModel globalsModel = globalsEditorService.load(Paths.convert(sourceScoreHolderGlobalPath));
+            return globalsModel.getGlobals().stream()
+                    .filter(global -> "scoreHolder".equals(global.getAlias()))
+                    .map(Global::getClassName)
+                    .collect(Collectors.toList());
+        }
+        return Collections.emptyList();
+    }
+
+    public BendableScoreLevelsWrapper extractSolutionBendableScoreLevelsSize(final Path solutionPath) {
+        String solutionString = ioService.readAllString(Paths.convert(solutionPath));
+
+        GenerationResult generationResult = dataModelerService.loadDataObject(solutionPath,
+                                                                              solutionString,
+                                                                              solutionPath);
+        if (!generationResult.hasErrors()) {
+            DataObject dataObject = generationResult.getDataObject();
+
+            Method getScoreMethod = dataObject.getMethod("getScore",
+                                                         Collections.emptyList());
+            if (getScoreMethod != null) {
+                Type getScoreMethodReturnType = getScoreMethod.getReturnType();
+                if (getScoreMethodReturnType != null && isBendableScore(getScoreMethod.getReturnType().getName())) {
+                    Annotation annotation = getScoreMethod.getAnnotation(PlanningScore.class.getName());
+                    if (annotation != null) {
+                        Object hardLevelsSize = annotation.getValue("bendableHardLevelsSize");
+                        Object softLevelsSize = annotation.getValue("bendableSoftLevelsSize");
+                        return new BendableScoreLevelsWrapper(hardLevelsSize == null ? 0 : (int) hardLevelsSize,
+                                                              softLevelsSize == null ? 0 : (int) softLevelsSize);
+                    }
+                }
+            }
+        }
+        return new BendableScoreLevelsWrapper();
+    }
+
+    private boolean isBendableScore(final String planningSolutionScoreType) {
+        return BendableScore.class.getName().equals(planningSolutionScoreType)
+                || BendableLongScore.class.getName().equals(planningSolutionScoreType)
+                || BendableBigDecimalScore.class.getName().equals(planningSolutionScoreType);
+    }
+}

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-backend/src/main/resources/ErraiApp.properties
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-backend/src/main/resources/ErraiApp.properties
@@ -1,0 +1,31 @@
+#
+# Copyright 2012 Red Hat, Inc. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# ErraiApp.properties
+#
+# Do not remove, even if empty!
+#
+
+# This is a marker file. When it is detected inside a JAR or at the
+# top of any classpath, the subdirectories are scanned for deployable
+# components. As such, all Errai application modules in a project
+# should contain an ErraiApp.properties at the root of all classpaths
+# that you wish to be scanned.
+#
+# There are also some configuration options that can be set in this
+# file, although it is rarely necessary. See the documentation at
+# https://docs.jboss.org/author/display/ERRAI/ErraiApp.properties
+# for details.

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-backend/src/main/resources/META-INF/services/org.uberfire.java.nio.file.spi.FileSystemProvider
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-backend/src/main/resources/META-INF/services/org.uberfire.java.nio.file.spi.FileSystemProvider
@@ -1,0 +1,18 @@
+#
+#  Copyright 2017 Red Hat, Inc. and/or its affiliates.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+org.uberfire.java.nio.fs.file.SimpleFileSystemProvider  # file system provider, also default (1st)
+org.uberfire.java.nio.fs.jgit.JGitFileSystemProvider

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-backend/src/test/java/org/optaplanner/workbench/screens/guidedrule/backend/server/plugin/HardConstraintMatchPersistenceExtensionTest.java
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-backend/src/test/java/org/optaplanner/workbench/screens/guidedrule/backend/server/plugin/HardConstraintMatchPersistenceExtensionTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.screens.guidedrule.backend.server.plugin;
+
+import org.drools.workbench.models.datamodel.rule.IAction;
+import org.junit.Test;
+import org.optaplanner.workbench.screens.guidedrule.model.ActionBendableHardConstraintMatch;
+import org.optaplanner.workbench.screens.guidedrule.model.ActionHardConstraintMatch;
+
+import static org.junit.Assert.*;
+
+public class HardConstraintMatchPersistenceExtensionTest {
+
+    private HardConstraintMatchPersistenceExtension extension = new HardConstraintMatchPersistenceExtension();
+
+    @Test
+    public void acceptIAction() {
+        assertTrue(extension.accept(new ActionHardConstraintMatch()));
+        assertTrue(extension.accept(new ActionBendableHardConstraintMatch()));
+
+        assertFalse(extension.accept(new UnknownIAction()));
+    }
+
+    @Test
+    public void marshalActionHardConstraintMatch() {
+        ActionHardConstraintMatch action = new ActionHardConstraintMatch("-1");
+
+        String marshaledAction = extension.marshal(action);
+
+        assertEquals("scoreHolder.addHardConstraintMatch(kcontext, -1);",
+                     marshaledAction);
+    }
+
+    @Test
+    public void marshalActionBendableHardConstraintMatch() {
+        ActionBendableHardConstraintMatch action = new ActionBendableHardConstraintMatch(1,
+                                                                                         "-1");
+
+        String marshaledAction = extension.marshal(action);
+
+        assertEquals("scoreHolder.addHardConstraintMatch(kcontext, 1, -1);",
+                     marshaledAction);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void marshalUnknownIAction() {
+        extension.marshal(new UnknownIAction());
+    }
+
+    @Test
+    public void acceptString() {
+        assertTrue(extension.accept("scoreHolder.addHardConstraintMatch(kcontext, -1);"));
+        assertTrue(extension.accept("scoreHolder.addHardConstraintMatch(kcontext, 1, -1);"));
+
+        assertFalse(extension.accept("unknownString"));
+    }
+
+    @Test
+    public void unmarshalHardConstraintMatch() {
+        String actionString = "scoreHolder.addHardConstraintMatch(kcontext, -1);";
+
+        IAction action = extension.unmarshal(actionString);
+
+        assertTrue(action instanceof ActionHardConstraintMatch);
+
+        ActionHardConstraintMatch actionHardConstraintMatch = (ActionHardConstraintMatch) action;
+
+        assertEquals("-1",
+                     actionHardConstraintMatch.getConstraintMatch());
+    }
+
+    @Test
+    public void unmarshalActionBendableHardConstraintMatch() {
+        String actionString = "scoreHolder.addHardConstraintMatch(kcontext, 1, -1);";
+
+        IAction action = extension.unmarshal(actionString);
+
+        assertTrue(action instanceof ActionBendableHardConstraintMatch);
+
+        ActionBendableHardConstraintMatch actionHardConstraintMatch = (ActionBendableHardConstraintMatch) action;
+
+        assertEquals(1,
+                     actionHardConstraintMatch.getPosition());
+        assertEquals("-1",
+                     actionHardConstraintMatch.getConstraintMatch());
+    }
+}

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-backend/src/test/java/org/optaplanner/workbench/screens/guidedrule/backend/server/plugin/MediumConstraintMatchPersistenceExtensionTest.java
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-backend/src/test/java/org/optaplanner/workbench/screens/guidedrule/backend/server/plugin/MediumConstraintMatchPersistenceExtensionTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.screens.guidedrule.backend.server.plugin;
+
+import org.drools.workbench.models.datamodel.rule.IAction;
+import org.junit.Test;
+import org.optaplanner.workbench.screens.guidedrule.model.ActionMediumConstraintMatch;
+
+import static org.junit.Assert.*;
+
+public class MediumConstraintMatchPersistenceExtensionTest {
+
+    private MediumConstraintMatchPersistenceExtension extension = new MediumConstraintMatchPersistenceExtension();
+
+    @Test
+    public void acceptIAction() {
+        assertTrue(extension.accept(new ActionMediumConstraintMatch()));
+
+        assertFalse(extension.accept(new UnknownIAction()));
+    }
+
+    @Test
+    public void marshalActionMediumConstraintMatch() {
+        ActionMediumConstraintMatch action = new ActionMediumConstraintMatch("-1");
+
+        String marshaledAction = extension.marshal(action);
+
+        assertEquals("scoreHolder.addMediumConstraintMatch(kcontext, -1);",
+                     marshaledAction);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void marshalUnknownIAction() {
+        extension.marshal(new UnknownIAction());
+    }
+
+    @Test
+    public void acceptString() {
+        assertTrue(extension.accept("scoreHolder.addMediumConstraintMatch(kcontext, -1);"));
+
+        assertFalse(extension.accept("unknownString"));
+    }
+
+    @Test
+    public void unmarshalMediumConstraintMatch() {
+        String actionString = "scoreHolder.addMediumConstraintMatch(kcontext, -1);";
+
+        IAction action = extension.unmarshal(actionString);
+
+        assertTrue(action instanceof ActionMediumConstraintMatch);
+
+        ActionMediumConstraintMatch actionMediumConstraintMatch = (ActionMediumConstraintMatch) action;
+
+        assertEquals("-1",
+                     actionMediumConstraintMatch.getConstraintMatch());
+    }
+}

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-backend/src/test/java/org/optaplanner/workbench/screens/guidedrule/backend/server/plugin/MultiConstraintMatchPersistenceExtensionTest.java
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-backend/src/test/java/org/optaplanner/workbench/screens/guidedrule/backend/server/plugin/MultiConstraintMatchPersistenceExtensionTest.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.screens.guidedrule.backend.server.plugin;
+
+import java.util.Arrays;
+
+import org.drools.workbench.models.datamodel.rule.IAction;
+import org.junit.Test;
+import org.optaplanner.workbench.screens.guidedrule.model.ActionBendableHardConstraintMatch;
+import org.optaplanner.workbench.screens.guidedrule.model.ActionBendableSoftConstraintMatch;
+import org.optaplanner.workbench.screens.guidedrule.model.ActionHardConstraintMatch;
+import org.optaplanner.workbench.screens.guidedrule.model.ActionMediumConstraintMatch;
+import org.optaplanner.workbench.screens.guidedrule.model.ActionMultiConstraintBendableBigDecimalMatch;
+import org.optaplanner.workbench.screens.guidedrule.model.ActionMultiConstraintBendableLongMatch;
+import org.optaplanner.workbench.screens.guidedrule.model.ActionMultiConstraintBendableMatch;
+import org.optaplanner.workbench.screens.guidedrule.model.ActionMultiConstraintHardMediumSoftMatch;
+import org.optaplanner.workbench.screens.guidedrule.model.ActionMultiConstraintHardSoftMatch;
+import org.optaplanner.workbench.screens.guidedrule.model.ActionSoftConstraintMatch;
+
+import static org.junit.Assert.*;
+
+public class MultiConstraintMatchPersistenceExtensionTest {
+
+    private MultiConstraintHardSoftMatchPersistenceExtension extension = new MultiConstraintHardSoftMatchPersistenceExtension();
+
+    @Test
+    public void acceptIAction() {
+        assertTrue(extension.accept(new ActionMultiConstraintHardSoftMatch()));
+        assertTrue(extension.accept(new ActionMultiConstraintHardMediumSoftMatch()));
+        assertTrue(extension.accept(new ActionMultiConstraintBendableMatch()));
+        assertTrue(extension.accept(new ActionMultiConstraintBendableLongMatch()));
+        assertTrue(extension.accept(new ActionMultiConstraintBendableBigDecimalMatch()));
+
+        assertFalse(extension.accept(new UnknownIAction()));
+    }
+
+    @Test
+    public void marshalActionMultiConstraintHardSoftMatch() {
+        ActionMultiConstraintHardSoftMatch action = new ActionMultiConstraintHardSoftMatch(new ActionHardConstraintMatch("-1"),
+                                                                                           new ActionSoftConstraintMatch("-2"));
+
+        String marshaledAction = extension.marshal(action);
+
+        assertEquals("scoreHolder.addMultiConstraintMatch(kcontext, -1, -2);",
+                     marshaledAction);
+    }
+
+    @Test
+    public void marshalActionMultiConstraintHardMediumSoftMatch() {
+        ActionMultiConstraintHardMediumSoftMatch action = new ActionMultiConstraintHardMediumSoftMatch(new ActionHardConstraintMatch("-1"),
+                                                                                                       new ActionMediumConstraintMatch("-2"),
+                                                                                                       new ActionSoftConstraintMatch("-3"));
+
+        String marshaledAction = extension.marshal(action);
+
+        assertEquals("scoreHolder.addMultiConstraintMatch(kcontext, -1, -2, -3);",
+                     marshaledAction);
+    }
+
+    @Test
+    public void marshalActionMultiConstraintBendableMatch() {
+        ActionMultiConstraintBendableMatch action = new ActionMultiConstraintBendableMatch(Arrays.asList(new ActionBendableHardConstraintMatch(0,
+                                                                                                                                               "-1"),
+                                                                                                         new ActionBendableHardConstraintMatch(1,
+                                                                                                                                               "-2")),
+                                                                                           Arrays.asList(new ActionBendableSoftConstraintMatch(0,
+                                                                                                                                               "-3"),
+                                                                                                         new ActionBendableSoftConstraintMatch(1,
+                                                                                                                                               "-4")));
+
+        String marshaledAction = extension.marshal(action);
+
+        assertEquals("scoreHolder.addMultiConstraintMatch(kcontext, new int[] {-1, -2}, new int[] {-3, -4});",
+                     marshaledAction);
+    }
+
+    @Test
+    public void marshalActionMultiConstraintBendableLongMatch() {
+        ActionMultiConstraintBendableLongMatch action = new ActionMultiConstraintBendableLongMatch(Arrays.asList(new ActionBendableHardConstraintMatch(0,
+                                                                                                                                                       "-1l"),
+                                                                                                                 new ActionBendableHardConstraintMatch(1,
+                                                                                                                                                       "-2l")),
+                                                                                                   Arrays.asList(new ActionBendableSoftConstraintMatch(0,
+                                                                                                                                                       "-3l"),
+                                                                                                                 new ActionBendableSoftConstraintMatch(1,
+                                                                                                                                                       "-4l")));
+
+        String marshaledAction = extension.marshal(action);
+
+        assertEquals("scoreHolder.addMultiConstraintMatch(kcontext, new long[] {-1l, -2l}, new long[] {-3l, -4l});",
+                     marshaledAction);
+    }
+
+    @Test
+    public void marshalActionMultiConstraintBendableBigDecimalMatch() {
+        ActionMultiConstraintBendableBigDecimalMatch action = new ActionMultiConstraintBendableBigDecimalMatch(Arrays.asList(new ActionBendableHardConstraintMatch(0,
+                                                                                                                                                                   "new java.math.BigDecimal(-1)"),
+                                                                                                                             new ActionBendableHardConstraintMatch(1,
+                                                                                                                                                                   "new java.math.BigDecimal(-2)")),
+                                                                                                               Arrays.asList(new ActionBendableSoftConstraintMatch(0,
+                                                                                                                                                                   "new java.math.BigDecimal(-3)"),
+                                                                                                                             new ActionBendableSoftConstraintMatch(1,
+                                                                                                                                                                   "new java.math.BigDecimal(-4)")));
+
+        String marshaledAction = extension.marshal(action);
+
+        assertEquals("scoreHolder.addMultiConstraintMatch(kcontext, new java.math.BigDecimal[] {new java.math.BigDecimal(-1), new java.math.BigDecimal(-2)}, new java.math.BigDecimal[] {new java.math.BigDecimal(-3), new java.math.BigDecimal(-4)});",
+                     marshaledAction);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void marshalUnknownIAction() {
+        extension.marshal(new UnknownIAction());
+    }
+
+    @Test
+    public void acceptString() {
+        assertTrue(extension.accept("scoreHolder.addMultiConstraintMatch(kcontext, -1, -2);"));
+        assertTrue(extension.accept("scoreHolder.addMultiConstraintMatch(kcontext, -1, -2, -3);"));
+        assertTrue(extension.accept("scoreHolder.addMultiConstraintMatch(kcontext, new int[] {-1, -2}, new int[] {-3, -4});"));
+        assertTrue(extension.accept("scoreHolder.addMultiConstraintMatch(kcontext, new long[] {-1l, -2l}, new long[] {-3l, -4l});"));
+        assertTrue(extension.accept("scoreHolder.addMultiConstraintMatch(kcontext, new java.math.BigDecimal[] {new java.math.BigDecimal(-1), new java.math.BigDecimal(-2)}, new java.math.BigDecimal[] {new java.math.BigDecimal(-3), new java.math.BigDecimal(-4)});"));
+
+        assertFalse(extension.accept("unknownString"));
+    }
+
+    @Test
+    public void unmarshalActionMultiConstraintHardSoftMatch() {
+        String actionString = "scoreHolder.addMultiConstraintMatch(kcontext, -1, -2);";
+
+        IAction action = extension.unmarshal(actionString);
+
+        assertTrue(action instanceof ActionMultiConstraintHardSoftMatch);
+
+        ActionMultiConstraintHardSoftMatch actionActionMultiConstraintHardSoftMatch = (ActionMultiConstraintHardSoftMatch) action;
+
+        assertEquals("-1",
+                     actionActionMultiConstraintHardSoftMatch.getActionHardConstraintMatch().getConstraintMatch());
+        assertEquals("-2",
+                     actionActionMultiConstraintHardSoftMatch.getActionSoftConstraintMatch().getConstraintMatch());
+    }
+
+    @Test
+    public void unmarshalActionMultiConstraintHardMediumSoftMatch() {
+        String actionString = "scoreHolder.addMultiConstraintMatch(kcontext, -1, -2, -3);";
+
+        IAction action = extension.unmarshal(actionString);
+
+        assertTrue(action instanceof ActionMultiConstraintHardMediumSoftMatch);
+
+        ActionMultiConstraintHardMediumSoftMatch actionActionMultiConstraintHardMediumSoftMatch = (ActionMultiConstraintHardMediumSoftMatch) action;
+
+        assertEquals("-1",
+                     actionActionMultiConstraintHardMediumSoftMatch.getActionHardConstraintMatch().getConstraintMatch());
+        assertEquals("-2",
+                     actionActionMultiConstraintHardMediumSoftMatch.getActionMediumConstraintMatch().getConstraintMatch());
+        assertEquals("-3",
+                     actionActionMultiConstraintHardMediumSoftMatch.getActionSoftConstraintMatch().getConstraintMatch());
+    }
+
+    @Test
+    public void unmarshalActionMultiConstraintBendableMatch() {
+        String actionString = "scoreHolder.addMultiConstraintMatch(kcontext, new int[] {-1, -2}, new int[] {-3, -4});";
+
+        IAction action = extension.unmarshal(actionString);
+
+        ActionMultiConstraintBendableMatch expectedAction = new ActionMultiConstraintBendableMatch(Arrays.asList(new ActionBendableHardConstraintMatch(0,
+                                                                                                                                                       "-1"),
+                                                                                                                 new ActionBendableHardConstraintMatch(1,
+                                                                                                                                                       "-2")),
+                                                                                                   Arrays.asList(new ActionBendableSoftConstraintMatch(0,
+                                                                                                                                                       "-3"),
+                                                                                                                 new ActionBendableSoftConstraintMatch(1,
+                                                                                                                                                       "-4")));
+
+        assertEquals(expectedAction,
+                     action);
+    }
+
+    @Test
+    public void unmarshalActionMultiConstraintBendableLongMatch() {
+        String actionString = "scoreHolder.addMultiConstraintMatch(kcontext, new long[] {-1l, -2l}, new long[] {-3l, -4l});";
+
+        IAction action = extension.unmarshal(actionString);
+
+        ActionMultiConstraintBendableLongMatch expectedAction = new ActionMultiConstraintBendableLongMatch(Arrays.asList(new ActionBendableHardConstraintMatch(0,
+                                                                                                                                                               "-1l"),
+                                                                                                                         new ActionBendableHardConstraintMatch(1,
+                                                                                                                                                               "-2l")),
+                                                                                                           Arrays.asList(new ActionBendableSoftConstraintMatch(0,
+                                                                                                                                                               "-3l"),
+                                                                                                                         new ActionBendableSoftConstraintMatch(1,
+                                                                                                                                                               "-4l")));
+
+        assertEquals(expectedAction,
+                     action);
+    }
+
+    @Test
+    public void unmarshalActionMultiConstraintBendableBigDecimalMatch() {
+        String actionString = "scoreHolder.addMultiConstraintMatch(kcontext, new java.math.BigDecimal[] {new java.math.BigDecimal(-1), new java.math.BigDecimal(-2)}, new java.math.BigDecimal[] {new java.math.BigDecimal(-3), new java.math.BigDecimal(-4)});";
+
+        IAction action = extension.unmarshal(actionString);
+
+        ActionMultiConstraintBendableBigDecimalMatch expectedAction = new ActionMultiConstraintBendableBigDecimalMatch(Arrays.asList(new ActionBendableHardConstraintMatch(0,
+                                                                                                                                                                           "new java.math.BigDecimal(-1)"),
+                                                                                                                                     new ActionBendableHardConstraintMatch(1,
+                                                                                                                                                                           "new java.math.BigDecimal(-2)")),
+                                                                                                                       Arrays.asList(new ActionBendableSoftConstraintMatch(0,
+                                                                                                                                                                           "new java.math.BigDecimal(-3)"),
+                                                                                                                                     new ActionBendableSoftConstraintMatch(1,
+                                                                                                                                                                           "new java.math.BigDecimal(-4)")));
+
+        assertEquals(expectedAction,
+                     action);
+    }
+}

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-backend/src/test/java/org/optaplanner/workbench/screens/guidedrule/backend/server/plugin/SimpleConstraintMatchPersistenceExtensionTest.java
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-backend/src/test/java/org/optaplanner/workbench/screens/guidedrule/backend/server/plugin/SimpleConstraintMatchPersistenceExtensionTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.screens.guidedrule.backend.server.plugin;
+
+import org.drools.workbench.models.datamodel.rule.IAction;
+import org.junit.Test;
+import org.optaplanner.workbench.screens.guidedrule.model.ActionSimpleConstraintMatch;
+
+import static org.junit.Assert.*;
+
+public class SimpleConstraintMatchPersistenceExtensionTest {
+
+    private SimpleConstraintMatchPersistenceExtension extension = new SimpleConstraintMatchPersistenceExtension();
+
+    @Test
+    public void acceptIAction() {
+        assertTrue(extension.accept(new ActionSimpleConstraintMatch()));
+
+        assertFalse(extension.accept(new UnknownIAction()));
+    }
+
+    @Test
+    public void marshalActionSimpleConstraintMatch() {
+        ActionSimpleConstraintMatch action = new ActionSimpleConstraintMatch("-1");
+
+        String marshaledAction = extension.marshal(action);
+
+        assertEquals("scoreHolder.addConstraintMatch(kcontext, -1);",
+                     marshaledAction);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void marshalUnknownIAction() {
+        extension.marshal(new UnknownIAction());
+    }
+
+    @Test
+    public void acceptString() {
+        assertTrue(extension.accept("scoreHolder.addConstraintMatch(kcontext, -1);"));
+
+        assertFalse(extension.accept("unknownString"));
+    }
+
+    @Test
+    public void unmarshalSimpleConstraintMatch() {
+        String actionString = "scoreHolder.addConstraintMatch(kcontext, -1);";
+
+        IAction action = extension.unmarshal(actionString);
+
+        assertTrue(action instanceof ActionSimpleConstraintMatch);
+
+        ActionSimpleConstraintMatch actionSimpleConstraintMatch = (ActionSimpleConstraintMatch) action;
+
+        assertEquals("-1",
+                     actionSimpleConstraintMatch.getConstraintMatch());
+    }
+}

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-backend/src/test/java/org/optaplanner/workbench/screens/guidedrule/backend/server/plugin/SoftConstraintMatchPersistenceExtensionTest.java
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-backend/src/test/java/org/optaplanner/workbench/screens/guidedrule/backend/server/plugin/SoftConstraintMatchPersistenceExtensionTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.screens.guidedrule.backend.server.plugin;
+
+import org.drools.workbench.models.datamodel.rule.IAction;
+import org.junit.Test;
+import org.optaplanner.workbench.screens.guidedrule.model.ActionBendableSoftConstraintMatch;
+import org.optaplanner.workbench.screens.guidedrule.model.ActionSoftConstraintMatch;
+
+import static org.junit.Assert.*;
+
+public class SoftConstraintMatchPersistenceExtensionTest {
+
+    private SoftConstraintMatchPersistenceExtension extension = new SoftConstraintMatchPersistenceExtension();
+
+    @Test
+    public void acceptIAction() {
+        assertTrue(extension.accept(new ActionSoftConstraintMatch()));
+        assertTrue(extension.accept(new ActionBendableSoftConstraintMatch()));
+
+        assertFalse(extension.accept(new UnknownIAction()));
+    }
+
+    @Test
+    public void marshalActionSoftConstraintMatch() {
+        ActionSoftConstraintMatch action = new ActionSoftConstraintMatch("-1");
+
+        String marshaledAction = extension.marshal(action);
+
+        assertEquals("scoreHolder.addSoftConstraintMatch(kcontext, -1);",
+                     marshaledAction);
+    }
+
+    @Test
+    public void marshalActionBendableSoftConstraintMatch() {
+        ActionBendableSoftConstraintMatch action = new ActionBendableSoftConstraintMatch(1,
+                                                                                         "-1");
+
+        String marshaledAction = extension.marshal(action);
+
+        assertEquals("scoreHolder.addSoftConstraintMatch(kcontext, 1, -1);",
+                     marshaledAction);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void marshalUnknownIAction() {
+        extension.marshal(new UnknownIAction());
+    }
+
+    @Test
+    public void acceptString() {
+        assertTrue(extension.accept("scoreHolder.addSoftConstraintMatch(kcontext, -1);"));
+        assertTrue(extension.accept("scoreHolder.addSoftConstraintMatch(kcontext, 1, -1);"));
+
+        assertFalse(extension.accept("unknownString"));
+    }
+
+    @Test
+    public void unmarshalSoftConstraintMatch() {
+        String actionString = "scoreHolder.addSoftConstraintMatch(kcontext, -1);";
+
+        IAction action = extension.unmarshal(actionString);
+
+        assertTrue(action instanceof ActionSoftConstraintMatch);
+
+        ActionSoftConstraintMatch actionSoftConstraintMatch = (ActionSoftConstraintMatch) action;
+
+        assertEquals("-1",
+                     actionSoftConstraintMatch.getConstraintMatch());
+    }
+
+    @Test
+    public void unmarshalActionBendableSoftConstraintMatch() {
+        String actionString = "scoreHolder.addSoftConstraintMatch(kcontext, 1, -1);";
+
+        IAction action = extension.unmarshal(actionString);
+
+        assertTrue(action instanceof ActionBendableSoftConstraintMatch);
+
+        ActionBendableSoftConstraintMatch actionSoftConstraintMatch = (ActionBendableSoftConstraintMatch) action;
+
+        assertEquals(1,
+                     actionSoftConstraintMatch.getPosition());
+        assertEquals("-1",
+                     actionSoftConstraintMatch.getConstraintMatch());
+    }
+}

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-backend/src/test/java/org/optaplanner/workbench/screens/guidedrule/backend/server/plugin/UnknownIAction.java
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-backend/src/test/java/org/optaplanner/workbench/screens/guidedrule/backend/server/plugin/UnknownIAction.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.screens.guidedrule.backend.server.plugin;
+
+import org.drools.workbench.models.datamodel.rule.IAction;
+
+public class UnknownIAction implements IAction {
+
+}

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-backend/src/test/java/org/optaplanner/workbench/screens/guidedrule/backend/server/service/ScoreHolderServiceImplTest.java
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-backend/src/test/java/org/optaplanner/workbench/screens/guidedrule/backend/server/service/ScoreHolderServiceImplTest.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.screens.guidedrule.backend.server.service;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+
+import org.drools.workbench.screens.globals.model.Global;
+import org.drools.workbench.screens.globals.model.GlobalsModel;
+import org.drools.workbench.screens.globals.service.GlobalsEditorService;
+import org.guvnor.common.services.project.model.Package;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.screens.datamodeller.model.GenerationResult;
+import org.kie.workbench.common.screens.datamodeller.service.DataModelerService;
+import org.kie.workbench.common.screens.javaeditor.type.JavaResourceTypeDefinition;
+import org.kie.workbench.common.services.datamodeller.core.DataObject;
+import org.kie.workbench.common.services.datamodeller.core.Method;
+import org.kie.workbench.common.services.datamodeller.core.Visibility;
+import org.kie.workbench.common.services.datamodeller.core.impl.AnnotationImpl;
+import org.kie.workbench.common.services.datamodeller.core.impl.DataObjectImpl;
+import org.kie.workbench.common.services.datamodeller.core.impl.MethodImpl;
+import org.kie.workbench.common.services.datamodeller.core.impl.TypeImpl;
+import org.kie.workbench.common.services.datamodeller.util.DriverUtils;
+import org.kie.workbench.common.services.shared.project.KieProjectService;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.optaplanner.core.api.domain.solution.PlanningScore;
+import org.optaplanner.core.api.domain.solution.PlanningSolution;
+import org.optaplanner.core.api.score.buildin.bendable.BendableScore;
+import org.optaplanner.workbench.screens.guidedrule.model.BendableScoreLevelsWrapper;
+import org.optaplanner.workbench.screens.guidedrule.model.ScoreInformation;
+import org.uberfire.backend.server.util.Paths;
+import org.uberfire.backend.vfs.Path;
+import org.uberfire.backend.vfs.PathFactory;
+import org.uberfire.io.IOService;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ScoreHolderServiceImplTest {
+
+    @Mock
+    private KieProjectService kieProjectService;
+
+    @Mock
+    private IOService ioService;
+
+    @Mock
+    private GlobalsEditorService globalsEditorService;
+
+    @Mock
+    private DataModelerService dataModelerService;
+
+    @Mock
+    private JavaResourceTypeDefinition javaResourceTypeDefinition;
+
+    @InjectMocks
+    private ScoreHolderServiceImpl scoreHolderService;
+
+    @Test
+    public void getProjectScoreInformation() {
+        Path dataObjectPath = PathFactory.newPath("Test.java",
+                                                  "file:///dataObjects");
+        when(dataModelerService.findClassUsages(dataObjectPath,
+                                                PlanningSolution.class.getName())).thenReturn(Arrays.asList(dataObjectPath));
+        when(javaResourceTypeDefinition.accept(dataObjectPath)).thenReturn(true);
+
+        // scoreHolder definitions
+        Package resourcesPackage = mock(Package.class);
+        when(resourcesPackage.getPackageMainResourcesPath()).thenReturn(PathFactory.newPath("Test.java",
+                                                                                            "file:///dataObjects"));
+        when(kieProjectService.resolvePackage(dataObjectPath)).thenReturn(resourcesPackage);
+        when(ioService.exists(any(org.uberfire.java.nio.file.Path.class))).thenReturn(true);
+
+        GlobalsModel globalsModel = new GlobalsModel();
+        globalsModel.setGlobals(Arrays.asList(new Global("scoreHolder",
+                                                         BendableScore.class.getName())));
+        when(globalsEditorService.load(any(Path.class))).thenReturn(globalsModel);
+
+        // Bendable score information
+        when(ioService.readAllString(Paths.convert(dataObjectPath))).thenReturn("testContent");
+        GenerationResult generationResult = new GenerationResult();
+        generationResult.setDataObject(createPlanningSolution());
+        when(dataModelerService.loadDataObject(dataObjectPath,
+                                               "testContent",
+                                               dataObjectPath)).thenReturn(generationResult);
+
+        ScoreInformation scoreInformation = scoreHolderService.getProjectScoreInformation(dataObjectPath);
+
+        assertNotNull(scoreInformation);
+        Collection<String> scoreHolderFqnTypeFqns = scoreInformation.getScoreHolderFqnTypeFqns();
+        assertNotNull(scoreHolderFqnTypeFqns);
+        assertEquals(1,
+                     scoreHolderFqnTypeFqns.size());
+        assertEquals(BendableScore.class.getName(),
+                     scoreHolderFqnTypeFqns.iterator().next());
+
+        Collection<BendableScoreLevelsWrapper> bendableScoreLevelsWrappers = scoreInformation.getBendableScoreLevelsWrappers();
+        assertNotNull(bendableScoreLevelsWrappers);
+        assertEquals(1,
+                     bendableScoreLevelsWrappers.size());
+        BendableScoreLevelsWrapper bendableScoreLevelsWrapper = bendableScoreLevelsWrappers.iterator().next();
+        assertEquals(1,
+                     bendableScoreLevelsWrapper.getHardScoreLevels());
+        assertEquals(2,
+                     bendableScoreLevelsWrapper.getSoftScoreLevels());
+    }
+
+    private DataObject createPlanningSolution() {
+        DataObject dataObject = new DataObjectImpl("test",
+                                                   "TestSolution");
+
+        AnnotationImpl planningSolutionAnnotation = new AnnotationImpl(DriverUtils.buildAnnotationDefinition(PlanningSolution.class));
+        dataObject.addAnnotation(planningSolutionAnnotation);
+
+        Method getScoreMethod = new MethodImpl("getScore",
+                                               Collections.EMPTY_LIST,
+                                               "return score;",
+                                               new TypeImpl(BendableScore.class.getName()),
+                                               Visibility.PUBLIC);
+        dataObject.addMethod(getScoreMethod);
+
+        AnnotationImpl planningScoreAnnotation = new AnnotationImpl(DriverUtils.buildAnnotationDefinition(PlanningScore.class));
+        planningScoreAnnotation.setValue("bendableHardLevelsSize",
+                                         1);
+        planningScoreAnnotation.setValue("bendableSoftLevelsSize",
+                                         2);
+        getScoreMethod.addAnnotation(planningScoreAnnotation);
+
+        return dataObject;
+    }
+}

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/.gitignore
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/.gitignore
@@ -1,0 +1,11 @@
+/target
+/local
+
+# Eclipse, Netbeans and IntelliJ files
+/.*
+/**/.*
+!.gitignore
+/nbproject
+/*.ipr
+/*.iws
+/*.iml

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/pom.xml
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/pom.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2017 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~       http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.optaplanner</groupId>
+    <artifactId>optaplanner-wb-guided-rule-editor</artifactId>
+    <version>7.1.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>optaplanner-wb-guided-rule-editor-client</artifactId>
+  <packaging>jar</packaging>
+
+  <name>OptaPlanner Workbench - Guided Rule Editor - Client</name>
+  <description>OptaPlanner Workbench - Guided Rule Editor - Client</description>
+
+  <dependencies>
+
+    <!-- Regular dependencies -->
+    <dependency>
+      <groupId>org.optaplanner</groupId>
+      <artifactId>optaplanner-wb-guided-rule-editor-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-wb-guided-rule-editor-client</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-ioc</artifactId>
+    </dependency>
+
+    <!-- Transitive dependencies -->
+    <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-workbench-models-datamodel-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-common</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-ui</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-workbench-client-views-patternfly</artifactId>
+    </dependency>
+
+    <!-- GWT and GWT Extensions -->
+    <dependency>
+      <groupId>com.google.gwt</groupId>
+      <artifactId>gwt-user</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <!-- Test dependencies -->
+    <dependency>
+      <groupId>org.optaplanner</groupId>
+      <artifactId>optaplanner-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-testing-utils</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.gwt.gwtmockito</groupId>
+      <artifactId>gwtmockito</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+  </dependencies>
+
+</project>

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/GuidedRuleEditorEntryPoint.java
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/GuidedRuleEditorEntryPoint.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.screens.guidedrule.client;
+
+import org.jboss.errai.ioc.client.api.AfterInitialization;
+import org.jboss.errai.ioc.client.api.EntryPoint;
+import org.jboss.errai.ui.shared.api.annotations.Bundle;
+import org.optaplanner.workbench.screens.guidedrule.client.resources.GuidedRuleEditorResources;
+
+@EntryPoint
+@Bundle("resources/i18n/GuidedRuleEditorConstants.properties")
+public class GuidedRuleEditorEntryPoint {
+
+    @AfterInitialization
+    public void startApp() {
+        GuidedRuleEditorResources.INSTANCE.css().ensureInjected();
+    }
+}

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/plugin/ActionPluginClientService.java
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/plugin/ActionPluginClientService.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.screens.guidedrule.client.plugin;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.function.Consumer;
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.drools.workbench.screens.guided.rule.client.editor.RuleModeller;
+import org.jboss.errai.common.client.api.Caller;
+import org.jboss.errai.ui.client.local.spi.TranslationService;
+import org.optaplanner.workbench.screens.guidedrule.client.resources.i18n.GuidedRuleEditorConstants;
+import org.optaplanner.workbench.screens.guidedrule.client.widget.ScoreHolderGlobalAware;
+import org.optaplanner.workbench.screens.guidedrule.model.AbstractActionMultiConstraintBendableMatch;
+import org.optaplanner.workbench.screens.guidedrule.model.ActionBendableHardConstraintMatch;
+import org.optaplanner.workbench.screens.guidedrule.model.ActionBendableSoftConstraintMatch;
+import org.optaplanner.workbench.screens.guidedrule.model.BendableScoreLevelsWrapper;
+import org.optaplanner.workbench.screens.guidedrule.model.ScoreInformation;
+import org.optaplanner.workbench.screens.guidedrule.service.ScoreHolderService;
+import org.uberfire.mvp.Command;
+
+@ApplicationScoped
+public class ActionPluginClientService {
+
+    static final String SCORE_INFORMATION = ActionPluginClientService.class.getName() + ".score.information";
+
+    private Caller<ScoreHolderService> scoreHolderService;
+
+    private TranslationService translationService;
+
+    @Inject
+    public ActionPluginClientService(final Caller<ScoreHolderService> scoreHolderService,
+                                     final TranslationService translationService) {
+        this.scoreHolderService = scoreHolderService;
+        this.translationService = translationService;
+    }
+
+    public void invokeScoreInformationCachedOperation(final RuleModeller ruleModeller,
+                                                      final Consumer<ScoreInformation> scoreInformationConsumer) {
+
+        Object scoreInformationObject = ruleModeller.getServiceInvocationCache().get(SCORE_INFORMATION);
+
+        if (!(scoreInformationObject instanceof ScoreInformation)) {
+            scoreHolderService.call(scoreInformation -> {
+                ruleModeller.getServiceInvocationCache().put(SCORE_INFORMATION,
+                                                             scoreInformation);
+                scoreInformationConsumer.accept((ScoreInformation) scoreInformation);
+            }).getProjectScoreInformation(ruleModeller.getPath());
+        } else {
+            ScoreInformation scoreInformation = (ScoreInformation) ruleModeller.getServiceInvocationCache().get(SCORE_INFORMATION);
+            scoreInformationConsumer.accept(scoreInformation);
+        }
+    }
+
+    public void initScoreHolderAwarePlugin(final RuleModeller ruleModeller,
+                                           final ScoreHolderGlobalAware scoreHolderGlobalAware,
+                                           final Collection supportedScoreHolderTypes) {
+        invokeScoreInformationCachedOperation(ruleModeller,
+                                              scoreInformation -> {
+                                                  Collection<String> scoreHolderFqns = scoreInformation.getScoreHolderFqnTypeFqns();
+                                                  if (scoreHolderFqns.isEmpty()) {
+                                                      scoreHolderGlobalAware.scoreHolderGlobalIssueDetected(translationService.getTranslation(GuidedRuleEditorConstants.ActionPluginClientServiceScoreHolderGlobalNotFound));
+                                                  } else if (scoreHolderFqns.size() > 1) {
+                                                      scoreHolderGlobalAware.scoreHolderGlobalIssueDetected(translationService.getTranslation(translationService.getTranslation(GuidedRuleEditorConstants.ActionPluginClientServiceMultipleScoreHolderGlobals)));
+                                                  } else if (scoreHolderFqns.size() == 1) {
+                                                      if (!supportedScoreHolderTypes.containsAll(scoreHolderFqns)) {
+                                                          scoreHolderGlobalAware.scoreHolderGlobalIssueDetected(translationService.getTranslation(GuidedRuleEditorConstants.ActionPluginClientServiceScoreTypeNotSupported));
+                                                      } else {
+                                                          scoreHolderGlobalAware.scoreHolderGlobalLoadedCorrectly();
+                                                      }
+                                                  }
+                                              });
+    }
+
+    public void addPluginToActionList(final RuleModeller ruleModeller,
+                                      final Command addCommand,
+                                      final Collection supportedScoreHolderTypes) {
+        invokeScoreInformationCachedOperation(ruleModeller,
+                                              scoreInformation -> {
+                                                  Collection<String> scoreHolderFqns = scoreInformation.getScoreHolderFqnTypeFqns();
+                                                  if (scoreHolderFqns.size() == 1 && supportedScoreHolderTypes.containsAll(scoreHolderFqns)) {
+                                                      addCommand.execute();
+                                                  }
+                                              });
+    }
+
+    public void initBendableScoreLevels(final RuleModeller ruleModeller,
+                                        final AbstractActionMultiConstraintBendableMatch constraintMatch) {
+        invokeScoreInformationCachedOperation(ruleModeller,
+                                              scoreInformation -> {
+                                                  Collection<BendableScoreLevelsWrapper> scoreLevels = scoreInformation.getBendableScoreLevelsWrappers();
+                                                  if (scoreLevels.size() == 1) {
+                                                      BendableScoreLevelsWrapper scoreLevelsWrapper = scoreLevels.iterator().next();
+
+                                                      ArrayList<ActionBendableHardConstraintMatch> hardConstraints = new ArrayList<>(scoreLevelsWrapper.getHardScoreLevels());
+                                                      for (int i = 0; i < scoreLevelsWrapper.getHardScoreLevels(); i++) {
+                                                          hardConstraints.add(new ActionBendableHardConstraintMatch(i,
+                                                                                                                    null));
+                                                      }
+                                                      constraintMatch.setActionBendableHardConstraintMatches(hardConstraints);
+
+                                                      ArrayList<ActionBendableSoftConstraintMatch> softConstraints = new ArrayList<>(scoreLevelsWrapper.getSoftScoreLevels());
+                                                      for (int i = 0; i < scoreLevelsWrapper.getSoftScoreLevels(); i++) {
+                                                          softConstraints.add(new ActionBendableSoftConstraintMatch(i,
+                                                                                                                    null));
+                                                      }
+                                                      constraintMatch.setActionBendableSoftConstraintMatches(softConstraints);
+                                                  }
+                                              });
+    }
+}

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/plugin/BendableHardConstraintMatchRuleModellerActionPlugin.java
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/plugin/BendableHardConstraintMatchRuleModellerActionPlugin.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.screens.guidedrule.client.plugin;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import com.google.gwt.event.shared.EventBus;
+import org.drools.workbench.models.datamodel.rule.IAction;
+import org.drools.workbench.screens.guided.rule.client.editor.RuleModeller;
+import org.drools.workbench.screens.guided.rule.client.editor.plugin.RuleModellerActionPlugin;
+import org.drools.workbench.screens.guided.rule.client.widget.RuleModellerWidget;
+import org.jboss.errai.common.client.api.Caller;
+import org.jboss.errai.ui.client.local.spi.TranslationService;
+import org.optaplanner.workbench.screens.guidedrule.client.resources.i18n.GuidedRuleEditorConstants;
+import org.optaplanner.workbench.screens.guidedrule.client.widget.BendableConstraintMatchRuleModellerWidget;
+import org.optaplanner.workbench.screens.guidedrule.model.ActionBendableHardConstraintMatch;
+import org.optaplanner.workbench.screens.guidedrule.model.BendableScoreLevelsWrapper;
+import org.optaplanner.workbench.screens.guidedrule.service.ScoreHolderService;
+import org.uberfire.mvp.Command;
+
+@ApplicationScoped
+public class BendableHardConstraintMatchRuleModellerActionPlugin implements RuleModellerActionPlugin {
+
+    private static final Set<String> SUPPORTED_SCORE_HOLDER_TYPES;
+
+    static {
+        SUPPORTED_SCORE_HOLDER_TYPES = new HashSet<>(3);
+        SUPPORTED_SCORE_HOLDER_TYPES.add("org.optaplanner.core.api.score.buildin.bendable.BendableScoreHolder");
+        SUPPORTED_SCORE_HOLDER_TYPES.add("org.optaplanner.core.api.score.buildin.bendablelong.BendableLongScoreHolder");
+        SUPPORTED_SCORE_HOLDER_TYPES.add("org.optaplanner.core.api.score.buildin.bendablebigdecimal.BendableBigDecimalScoreHolder");
+    }
+
+    @Inject
+    private Caller<ScoreHolderService> scoreHolderService;
+
+    @Inject
+    private ActionPluginClientService actionPluginClientService;
+
+    @Inject
+    private TranslationService translationService;
+
+    public BendableHardConstraintMatchRuleModellerActionPlugin() {
+    }
+
+    @Override
+    public boolean accept(final IAction iAction) {
+        return iAction instanceof ActionBendableHardConstraintMatch;
+    }
+
+    @Override
+    public void addPluginToActionList(final RuleModeller ruleModeller,
+                                      final Command addCommand) {
+        actionPluginClientService.addPluginToActionList(ruleModeller,
+                                                        addCommand,
+                                                        SUPPORTED_SCORE_HOLDER_TYPES);
+    }
+
+    @Override
+    public IAction createIAction(final RuleModeller ruleModeller) {
+        return new ActionBendableHardConstraintMatch();
+    }
+
+    @Override
+    public String getId() {
+        return "BENDABLE_HARD_CONSTRAINT_MATCH";
+    }
+
+    @Override
+    public String getActionAddDescription() {
+        return translationService.getTranslation(GuidedRuleEditorConstants.RuleModellerActionPluginModifyHardScore);
+    }
+
+    @Override
+    public RuleModellerWidget createWidget(final RuleModeller ruleModeller,
+                                           final EventBus eventBus,
+                                           final IAction iAction,
+                                           final Boolean readOnly) {
+        BendableConstraintMatchRuleModellerWidget widget = new BendableConstraintMatchRuleModellerWidget(ruleModeller,
+                                                                                                         eventBus,
+                                                                                                         (ActionBendableHardConstraintMatch) iAction,
+                                                                                                         translationService,
+                                                                                                         readOnly,
+                                                                                                         GuidedRuleEditorConstants.RuleModellerActionPluginHardScore);
+        actionPluginClientService.initScoreHolderAwarePlugin(ruleModeller,
+                                                             widget,
+                                                             SUPPORTED_SCORE_HOLDER_TYPES);
+
+        actionPluginClientService.invokeScoreInformationCachedOperation(ruleModeller,
+                                                                        scoreInformation -> {
+                                                                            Collection<BendableScoreLevelsWrapper> scoreLevels = scoreInformation.getBendableScoreLevelsWrappers();
+                                                                            if (scoreLevels.size() == 1) {
+                                                                                widget.setScoreLevels(scoreLevels.iterator().next().getHardScoreLevels());
+                                                                            }
+                                                                        });
+
+        return widget;
+    }
+}

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/plugin/BendableSoftConstraintMatchRuleModellerActionPlugin.java
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/plugin/BendableSoftConstraintMatchRuleModellerActionPlugin.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.screens.guidedrule.client.plugin;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import com.google.gwt.event.shared.EventBus;
+import org.drools.workbench.models.datamodel.rule.IAction;
+import org.drools.workbench.screens.guided.rule.client.editor.RuleModeller;
+import org.drools.workbench.screens.guided.rule.client.editor.plugin.RuleModellerActionPlugin;
+import org.drools.workbench.screens.guided.rule.client.widget.RuleModellerWidget;
+import org.jboss.errai.common.client.api.Caller;
+import org.jboss.errai.ui.client.local.spi.TranslationService;
+import org.optaplanner.workbench.screens.guidedrule.client.resources.i18n.GuidedRuleEditorConstants;
+import org.optaplanner.workbench.screens.guidedrule.client.widget.BendableConstraintMatchRuleModellerWidget;
+import org.optaplanner.workbench.screens.guidedrule.model.ActionBendableSoftConstraintMatch;
+import org.optaplanner.workbench.screens.guidedrule.model.BendableScoreLevelsWrapper;
+import org.optaplanner.workbench.screens.guidedrule.service.ScoreHolderService;
+import org.uberfire.mvp.Command;
+
+@ApplicationScoped
+public class BendableSoftConstraintMatchRuleModellerActionPlugin implements RuleModellerActionPlugin {
+
+    private static final Set<String> SUPPORTED_SCORE_HOLDER_TYPES;
+
+    static {
+        SUPPORTED_SCORE_HOLDER_TYPES = new HashSet<>(3);
+        SUPPORTED_SCORE_HOLDER_TYPES.add("org.optaplanner.core.api.score.buildin.bendable.BendableScoreHolder");
+        SUPPORTED_SCORE_HOLDER_TYPES.add("org.optaplanner.core.api.score.buildin.bendablelong.BendableLongScoreHolder");
+        SUPPORTED_SCORE_HOLDER_TYPES.add("org.optaplanner.core.api.score.buildin.bendablebigdecimal.BendableBigDecimalScoreHolder");
+    }
+
+    @Inject
+    private Caller<ScoreHolderService> scoreHolderService;
+
+    @Inject
+    private ActionPluginClientService actionPluginClientService;
+
+    @Inject
+    private TranslationService translationService;
+
+    public BendableSoftConstraintMatchRuleModellerActionPlugin() {
+    }
+
+    @Override
+    public boolean accept(final IAction iAction) {
+        return iAction instanceof ActionBendableSoftConstraintMatch;
+    }
+
+    @Override
+    public void addPluginToActionList(final RuleModeller ruleModeller,
+                                      final Command addCommand) {
+        actionPluginClientService.addPluginToActionList(ruleModeller,
+                                                        addCommand,
+                                                        SUPPORTED_SCORE_HOLDER_TYPES);
+    }
+
+    @Override
+    public IAction createIAction(final RuleModeller ruleModeller) {
+        return new ActionBendableSoftConstraintMatch();
+    }
+
+    @Override
+    public String getId() {
+        return "BENDABLE_SOFT_CONSTRAINT_MATCH";
+    }
+
+    @Override
+    public String getActionAddDescription() {
+        return translationService.getTranslation(GuidedRuleEditorConstants.RuleModellerActionPluginModifySoftScore);
+    }
+
+    @Override
+    public RuleModellerWidget createWidget(final RuleModeller ruleModeller,
+                                           final EventBus eventBus,
+                                           final IAction iAction,
+                                           final Boolean readOnly) {
+        BendableConstraintMatchRuleModellerWidget widget = new BendableConstraintMatchRuleModellerWidget(ruleModeller,
+                                                                                                         eventBus,
+                                                                                                         (ActionBendableSoftConstraintMatch) iAction,
+                                                                                                         translationService,
+                                                                                                         readOnly,
+                                                                                                         GuidedRuleEditorConstants.RuleModellerActionPluginSoftScore);
+        actionPluginClientService.initScoreHolderAwarePlugin(ruleModeller,
+                                                             widget,
+                                                             SUPPORTED_SCORE_HOLDER_TYPES);
+
+        actionPluginClientService.invokeScoreInformationCachedOperation(ruleModeller,
+                                                                        scoreInformation -> {
+                                                                            Collection<BendableScoreLevelsWrapper> scoreLevels = scoreInformation.getBendableScoreLevelsWrappers();
+                                                                            if (scoreLevels.size() == 1) {
+                                                                                widget.setScoreLevels(scoreLevels.iterator().next().getSoftScoreLevels());
+                                                                            }
+                                                                        });
+
+        return widget;
+    }
+}

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/plugin/HardConstraintMatchRuleModellerActionPlugin.java
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/plugin/HardConstraintMatchRuleModellerActionPlugin.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.optaplanner.workbench.screens.guidedrule.client.plugin;
+
+import java.util.HashSet;
+import java.util.Set;
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import com.google.gwt.event.shared.EventBus;
+import org.drools.workbench.models.datamodel.rule.IAction;
+import org.drools.workbench.screens.guided.rule.client.editor.RuleModeller;
+import org.drools.workbench.screens.guided.rule.client.editor.plugin.RuleModellerActionPlugin;
+import org.drools.workbench.screens.guided.rule.client.widget.RuleModellerWidget;
+import org.jboss.errai.common.client.api.Caller;
+import org.jboss.errai.ui.client.local.spi.TranslationService;
+import org.optaplanner.workbench.screens.guidedrule.client.resources.i18n.GuidedRuleEditorConstants;
+import org.optaplanner.workbench.screens.guidedrule.client.widget.ConstraintMatchRuleModellerWidget;
+import org.optaplanner.workbench.screens.guidedrule.model.ActionHardConstraintMatch;
+import org.optaplanner.workbench.screens.guidedrule.service.ScoreHolderService;
+import org.uberfire.mvp.Command;
+
+@ApplicationScoped
+public class HardConstraintMatchRuleModellerActionPlugin implements RuleModellerActionPlugin {
+
+    private static final Set<String> SUPPORTED_SCORE_HOLDER_TYPES;
+
+    static {
+        SUPPORTED_SCORE_HOLDER_TYPES = new HashSet<>(2);
+        SUPPORTED_SCORE_HOLDER_TYPES.add("org.optaplanner.core.api.score.buildin.hardsoft.HardSoftScoreHolder");
+        SUPPORTED_SCORE_HOLDER_TYPES.add("org.optaplanner.core.api.score.buildin.hardmediumsoft.HardMediumSoftScoreHolder");
+    }
+
+    @Inject
+    private Caller<ScoreHolderService> scoreHolderService;
+
+    @Inject
+    private ActionPluginClientService actionPluginClientService;
+
+    @Inject
+    private TranslationService translationService;
+
+    public HardConstraintMatchRuleModellerActionPlugin() {
+    }
+
+    @Override
+    public boolean accept(final IAction iAction) {
+        return iAction instanceof ActionHardConstraintMatch;
+    }
+
+    @Override
+    public void addPluginToActionList(final RuleModeller ruleModeller,
+                                      final Command addCommand) {
+        actionPluginClientService.addPluginToActionList(ruleModeller,
+                                                        addCommand,
+                                                        SUPPORTED_SCORE_HOLDER_TYPES);
+    }
+
+    @Override
+    public IAction createIAction(final RuleModeller ruleModeller) {
+        return new ActionHardConstraintMatch();
+    }
+
+    @Override
+    public String getId() {
+        return "HARD_CONSTRAINT_MATCH";
+    }
+
+    @Override
+    public String getActionAddDescription() {
+        return translationService.getTranslation(GuidedRuleEditorConstants.RuleModellerActionPluginModifyHardScore);
+    }
+
+    @Override
+    public RuleModellerWidget createWidget(final RuleModeller ruleModeller,
+                                           final EventBus eventBus,
+                                           final IAction iAction,
+                                           final Boolean readOnly) {
+        ConstraintMatchRuleModellerWidget widget = new ConstraintMatchRuleModellerWidget(ruleModeller,
+                                                                                         eventBus,
+                                                                                         (ActionHardConstraintMatch) iAction,
+                                                                                         translationService,
+                                                                                         readOnly,
+                                                                                         GuidedRuleEditorConstants.RuleModellerActionPluginHardScore);
+        actionPluginClientService.initScoreHolderAwarePlugin(ruleModeller,
+                                                             widget,
+                                                             SUPPORTED_SCORE_HOLDER_TYPES);
+
+        return widget;
+    }
+}

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/plugin/MediumConstraintMatchRuleModellerActionPlugin.java
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/plugin/MediumConstraintMatchRuleModellerActionPlugin.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.screens.guidedrule.client.plugin;
+
+import java.util.HashSet;
+import java.util.Set;
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import com.google.gwt.event.shared.EventBus;
+import org.drools.workbench.models.datamodel.rule.IAction;
+import org.drools.workbench.screens.guided.rule.client.editor.RuleModeller;
+import org.drools.workbench.screens.guided.rule.client.editor.plugin.RuleModellerActionPlugin;
+import org.drools.workbench.screens.guided.rule.client.widget.RuleModellerWidget;
+import org.jboss.errai.common.client.api.Caller;
+import org.jboss.errai.ui.client.local.spi.TranslationService;
+import org.optaplanner.workbench.screens.guidedrule.client.resources.i18n.GuidedRuleEditorConstants;
+import org.optaplanner.workbench.screens.guidedrule.client.widget.ConstraintMatchRuleModellerWidget;
+import org.optaplanner.workbench.screens.guidedrule.model.ActionMediumConstraintMatch;
+import org.optaplanner.workbench.screens.guidedrule.service.ScoreHolderService;
+import org.uberfire.mvp.Command;
+
+@ApplicationScoped
+public class MediumConstraintMatchRuleModellerActionPlugin implements RuleModellerActionPlugin {
+
+    private static final Set<String> SUPPORTED_SCORE_HOLDER_TYPES;
+
+    static {
+        SUPPORTED_SCORE_HOLDER_TYPES = new HashSet<>(1);
+        SUPPORTED_SCORE_HOLDER_TYPES.add("org.optaplanner.core.api.score.buildin.hardmediumsoft.HardMediumSoftScoreHolder");
+    }
+
+    @Inject
+    private Caller<ScoreHolderService> scoreHolderService;
+
+    @Inject
+    private ActionPluginClientService actionPluginClientService;
+
+    @Inject
+    private TranslationService translationService;
+
+    public MediumConstraintMatchRuleModellerActionPlugin() {
+    }
+
+    @Override
+    public boolean accept(final IAction iAction) {
+        return iAction instanceof ActionMediumConstraintMatch;
+    }
+
+    @Override
+    public void addPluginToActionList(final RuleModeller ruleModeller,
+                                      final Command addCommand) {
+        actionPluginClientService.addPluginToActionList(ruleModeller,
+                                                        addCommand,
+                                                        SUPPORTED_SCORE_HOLDER_TYPES);
+    }
+
+    @Override
+    public IAction createIAction(final RuleModeller ruleModeller) {
+        return new ActionMediumConstraintMatch();
+    }
+
+    @Override
+    public String getId() {
+        return "MEDIUM_CONSTRAINT_MATCH";
+    }
+
+    @Override
+    public String getActionAddDescription() {
+        return translationService.getTranslation(GuidedRuleEditorConstants.RuleModellerActionPluginModifyMediumScore);
+    }
+
+    @Override
+    public RuleModellerWidget createWidget(final RuleModeller ruleModeller,
+                                           final EventBus eventBus,
+                                           final IAction iAction,
+                                           final Boolean readOnly) {
+
+        ConstraintMatchRuleModellerWidget widget = new ConstraintMatchRuleModellerWidget(ruleModeller,
+                                                                                         eventBus,
+                                                                                         (ActionMediumConstraintMatch) iAction,
+                                                                                         translationService,
+                                                                                         readOnly,
+                                                                                         GuidedRuleEditorConstants.RuleModellerActionPluginMediumScore);
+        actionPluginClientService.initScoreHolderAwarePlugin(ruleModeller,
+                                                             widget,
+                                                             SUPPORTED_SCORE_HOLDER_TYPES);
+
+        return widget;
+    }
+}

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/plugin/MultiConstraintBendableBigDecimalMatchRuleModellerActionPlugin.java
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/plugin/MultiConstraintBendableBigDecimalMatchRuleModellerActionPlugin.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.screens.guidedrule.client.plugin;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import com.google.gwt.event.shared.EventBus;
+import org.drools.workbench.models.datamodel.rule.IAction;
+import org.drools.workbench.screens.guided.rule.client.editor.RuleModeller;
+import org.drools.workbench.screens.guided.rule.client.editor.plugin.RuleModellerActionPlugin;
+import org.drools.workbench.screens.guided.rule.client.widget.RuleModellerWidget;
+import org.jboss.errai.common.client.api.Caller;
+import org.jboss.errai.ui.client.local.spi.TranslationService;
+import org.optaplanner.workbench.screens.guidedrule.client.resources.i18n.GuidedRuleEditorConstants;
+import org.optaplanner.workbench.screens.guidedrule.client.widget.MultiConstraintBendableMatchRuleModellerWidget;
+import org.optaplanner.workbench.screens.guidedrule.model.ActionMultiConstraintBendableBigDecimalMatch;
+import org.optaplanner.workbench.screens.guidedrule.model.BendableScoreLevelsWrapper;
+import org.optaplanner.workbench.screens.guidedrule.service.ScoreHolderService;
+import org.uberfire.mvp.Command;
+
+@ApplicationScoped
+public class MultiConstraintBendableBigDecimalMatchRuleModellerActionPlugin implements RuleModellerActionPlugin {
+
+    private static final Set<String> SUPPORTED_SCORE_HOLDER_TYPES;
+
+    static {
+        SUPPORTED_SCORE_HOLDER_TYPES = new HashSet<>(1);
+        SUPPORTED_SCORE_HOLDER_TYPES.add("org.optaplanner.core.api.score.buildin.bendablebigdecimal.BendableBigDecimalScoreHolder");
+    }
+
+    @Inject
+    private Caller<ScoreHolderService> scoreHolderService;
+
+    @Inject
+    private ActionPluginClientService actionPluginClientService;
+
+    @Inject
+    private TranslationService translationService;
+
+    public MultiConstraintBendableBigDecimalMatchRuleModellerActionPlugin() {
+    }
+
+    @Override
+    public boolean accept(final IAction iAction) {
+        return iAction instanceof ActionMultiConstraintBendableBigDecimalMatch;
+    }
+
+    @Override
+    public void addPluginToActionList(final RuleModeller ruleModeller,
+                                      final Command addCommand) {
+        actionPluginClientService.addPluginToActionList(ruleModeller,
+                                                        addCommand,
+                                                        SUPPORTED_SCORE_HOLDER_TYPES);
+    }
+
+    @Override
+    public IAction createIAction(final RuleModeller ruleModeller) {
+        ActionMultiConstraintBendableBigDecimalMatch constraintMatch = new ActionMultiConstraintBendableBigDecimalMatch();
+
+        actionPluginClientService.initBendableScoreLevels(ruleModeller,
+                                                          constraintMatch);
+        return constraintMatch;
+    }
+
+    @Override
+    public String getId() {
+        return "MULTI_CONSTRAINT_BENDABLE_BIG_DECIMAL_MATCH";
+    }
+
+    @Override
+    public String getActionAddDescription() {
+        return translationService.getTranslation(GuidedRuleEditorConstants.RuleModellerActionPluginModifyMultipleScoreLevels);
+    }
+
+    @Override
+    public RuleModellerWidget createWidget(final RuleModeller ruleModeller,
+                                           final EventBus eventBus,
+                                           final IAction iAction,
+                                           final Boolean readOnly) {
+
+        MultiConstraintBendableMatchRuleModellerWidget widget = new MultiConstraintBendableMatchRuleModellerWidget(ruleModeller,
+                                                                                                                   eventBus,
+                                                                                                                   (ActionMultiConstraintBendableBigDecimalMatch) iAction,
+                                                                                                                   translationService,
+                                                                                                                   readOnly);
+        actionPluginClientService.initScoreHolderAwarePlugin(ruleModeller,
+                                                             widget,
+                                                             SUPPORTED_SCORE_HOLDER_TYPES);
+
+        actionPluginClientService.invokeScoreInformationCachedOperation(ruleModeller,
+                                                                        scoreInformation -> {
+                                                                            Collection<BendableScoreLevelsWrapper> scoreLevels = scoreInformation.getBendableScoreLevelsWrappers();
+                                                                            if (scoreLevels.size() == 1) {
+                                                                                widget.setScoreLevels(scoreLevels.iterator().next());
+                                                                            }
+                                                                        });
+
+        return widget;
+    }
+}

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/plugin/MultiConstraintBendableLongMatchRuleModellerActionPlugin.java
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/plugin/MultiConstraintBendableLongMatchRuleModellerActionPlugin.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.screens.guidedrule.client.plugin;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import com.google.gwt.event.shared.EventBus;
+import org.drools.workbench.models.datamodel.rule.IAction;
+import org.drools.workbench.screens.guided.rule.client.editor.RuleModeller;
+import org.drools.workbench.screens.guided.rule.client.editor.plugin.RuleModellerActionPlugin;
+import org.drools.workbench.screens.guided.rule.client.widget.RuleModellerWidget;
+import org.jboss.errai.common.client.api.Caller;
+import org.jboss.errai.ui.client.local.spi.TranslationService;
+import org.optaplanner.workbench.screens.guidedrule.client.resources.i18n.GuidedRuleEditorConstants;
+import org.optaplanner.workbench.screens.guidedrule.client.widget.MultiConstraintBendableMatchRuleModellerWidget;
+import org.optaplanner.workbench.screens.guidedrule.model.ActionMultiConstraintBendableLongMatch;
+import org.optaplanner.workbench.screens.guidedrule.model.BendableScoreLevelsWrapper;
+import org.optaplanner.workbench.screens.guidedrule.service.ScoreHolderService;
+import org.uberfire.mvp.Command;
+
+@ApplicationScoped
+public class MultiConstraintBendableLongMatchRuleModellerActionPlugin implements RuleModellerActionPlugin {
+
+    private static final Set<String> SUPPORTED_SCORE_HOLDER_TYPES;
+
+    static {
+        SUPPORTED_SCORE_HOLDER_TYPES = new HashSet<>(1);
+        SUPPORTED_SCORE_HOLDER_TYPES.add("org.optaplanner.core.api.score.buildin.bendablelong.BendableLongScoreHolder");
+    }
+
+    @Inject
+    private Caller<ScoreHolderService> scoreHolderService;
+
+    @Inject
+    private ActionPluginClientService actionPluginClientService;
+
+    @Inject
+    private TranslationService translationService;
+
+    public MultiConstraintBendableLongMatchRuleModellerActionPlugin() {
+    }
+
+    @Override
+    public boolean accept(final IAction iAction) {
+        return iAction instanceof ActionMultiConstraintBendableLongMatch;
+    }
+
+    @Override
+    public void addPluginToActionList(final RuleModeller ruleModeller,
+                                      final Command addCommand) {
+        actionPluginClientService.addPluginToActionList(ruleModeller,
+                                                        addCommand,
+                                                        SUPPORTED_SCORE_HOLDER_TYPES);
+    }
+
+    @Override
+    public IAction createIAction(final RuleModeller ruleModeller) {
+        ActionMultiConstraintBendableLongMatch constraintMatch = new ActionMultiConstraintBendableLongMatch();
+
+        actionPluginClientService.initBendableScoreLevels(ruleModeller,
+                                                          constraintMatch);
+        return constraintMatch;
+    }
+
+    @Override
+    public String getId() {
+        return "MULTI_CONSTRAINT_BENDABLE_LONG_MATCH";
+    }
+
+    @Override
+    public String getActionAddDescription() {
+        return translationService.getTranslation(GuidedRuleEditorConstants.RuleModellerActionPluginModifyMultipleScoreLevels);
+    }
+
+    @Override
+    public RuleModellerWidget createWidget(final RuleModeller ruleModeller,
+                                           final EventBus eventBus,
+                                           final IAction iAction,
+                                           final Boolean readOnly) {
+
+        MultiConstraintBendableMatchRuleModellerWidget widget = new MultiConstraintBendableMatchRuleModellerWidget(ruleModeller,
+                                                                                                                   eventBus,
+                                                                                                                   (ActionMultiConstraintBendableLongMatch) iAction,
+                                                                                                                   translationService,
+                                                                                                                   readOnly);
+        actionPluginClientService.initScoreHolderAwarePlugin(ruleModeller,
+                                                             widget,
+                                                             SUPPORTED_SCORE_HOLDER_TYPES);
+
+        actionPluginClientService.invokeScoreInformationCachedOperation(ruleModeller,
+                                                                        scoreInformation -> {
+                                                                            Collection<BendableScoreLevelsWrapper> scoreLevels = scoreInformation.getBendableScoreLevelsWrappers();
+                                                                            if (scoreLevels.size() == 1) {
+                                                                                widget.setScoreLevels(scoreLevels.iterator().next());
+                                                                            }
+                                                                        });
+
+        return widget;
+    }
+}

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/plugin/MultiConstraintBendableMatchRuleModellerActionPlugin.java
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/plugin/MultiConstraintBendableMatchRuleModellerActionPlugin.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.screens.guidedrule.client.plugin;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import com.google.gwt.event.shared.EventBus;
+import org.drools.workbench.models.datamodel.rule.IAction;
+import org.drools.workbench.screens.guided.rule.client.editor.RuleModeller;
+import org.drools.workbench.screens.guided.rule.client.editor.plugin.RuleModellerActionPlugin;
+import org.drools.workbench.screens.guided.rule.client.widget.RuleModellerWidget;
+import org.jboss.errai.common.client.api.Caller;
+import org.jboss.errai.ui.client.local.spi.TranslationService;
+import org.optaplanner.workbench.screens.guidedrule.client.resources.i18n.GuidedRuleEditorConstants;
+import org.optaplanner.workbench.screens.guidedrule.client.widget.MultiConstraintBendableMatchRuleModellerWidget;
+import org.optaplanner.workbench.screens.guidedrule.model.ActionMultiConstraintBendableMatch;
+import org.optaplanner.workbench.screens.guidedrule.model.BendableScoreLevelsWrapper;
+import org.optaplanner.workbench.screens.guidedrule.service.ScoreHolderService;
+import org.uberfire.mvp.Command;
+
+@ApplicationScoped
+public class MultiConstraintBendableMatchRuleModellerActionPlugin implements RuleModellerActionPlugin {
+
+    private static final Set<String> SUPPORTED_SCORE_HOLDER_TYPES;
+
+    static {
+        SUPPORTED_SCORE_HOLDER_TYPES = new HashSet<>(1);
+        SUPPORTED_SCORE_HOLDER_TYPES.add("org.optaplanner.core.api.score.buildin.bendable.BendableScoreHolder");
+    }
+
+    @Inject
+    private Caller<ScoreHolderService> scoreHolderService;
+
+    @Inject
+    private ActionPluginClientService actionPluginClientService;
+
+    @Inject
+    private TranslationService translationService;
+
+    public MultiConstraintBendableMatchRuleModellerActionPlugin() {
+    }
+
+    @Override
+    public boolean accept(final IAction iAction) {
+        return iAction instanceof ActionMultiConstraintBendableMatch;
+    }
+
+    @Override
+    public void addPluginToActionList(final RuleModeller ruleModeller,
+                                      final Command addCommand) {
+        actionPluginClientService.addPluginToActionList(ruleModeller,
+                                                        addCommand,
+                                                        SUPPORTED_SCORE_HOLDER_TYPES);
+    }
+
+    @Override
+    public IAction createIAction(final RuleModeller ruleModeller) {
+        ActionMultiConstraintBendableMatch constraintMatch = new ActionMultiConstraintBendableMatch();
+
+        actionPluginClientService.initBendableScoreLevels(ruleModeller,
+                                                          constraintMatch);
+
+        return constraintMatch;
+    }
+
+    @Override
+    public String getId() {
+        return "MULTI_CONSTRAINT_BENDABLE_MATCH";
+    }
+
+    @Override
+    public String getActionAddDescription() {
+        return translationService.getTranslation(GuidedRuleEditorConstants.RuleModellerActionPluginModifyMultipleScoreLevels);
+    }
+
+    @Override
+    public RuleModellerWidget createWidget(final RuleModeller ruleModeller,
+                                           final EventBus eventBus,
+                                           final IAction iAction,
+                                           final Boolean readOnly) {
+
+        MultiConstraintBendableMatchRuleModellerWidget widget = new MultiConstraintBendableMatchRuleModellerWidget(ruleModeller,
+                                                                                                                   eventBus,
+                                                                                                                   (ActionMultiConstraintBendableMatch) iAction,
+                                                                                                                   translationService,
+                                                                                                                   readOnly);
+        actionPluginClientService.initScoreHolderAwarePlugin(ruleModeller,
+                                                             widget,
+                                                             SUPPORTED_SCORE_HOLDER_TYPES);
+
+        actionPluginClientService.invokeScoreInformationCachedOperation(ruleModeller,
+                                                                        scoreInformation -> {
+                                                                            Collection<BendableScoreLevelsWrapper> scoreLevels = scoreInformation.getBendableScoreLevelsWrappers();
+                                                                            if (scoreLevels.size() == 1) {
+                                                                                widget.setScoreLevels(scoreLevels.iterator().next());
+                                                                            }
+                                                                        });
+
+        return widget;
+    }
+}

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/plugin/MultiConstraintHardMediumSoftMatchRuleModellerActionPlugin.java
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/plugin/MultiConstraintHardMediumSoftMatchRuleModellerActionPlugin.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.screens.guidedrule.client.plugin;
+
+import java.util.HashSet;
+import java.util.Set;
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import com.google.gwt.event.shared.EventBus;
+import org.drools.workbench.models.datamodel.rule.IAction;
+import org.drools.workbench.screens.guided.rule.client.editor.RuleModeller;
+import org.drools.workbench.screens.guided.rule.client.editor.plugin.RuleModellerActionPlugin;
+import org.drools.workbench.screens.guided.rule.client.widget.RuleModellerWidget;
+import org.jboss.errai.common.client.api.Caller;
+import org.jboss.errai.ui.client.local.spi.TranslationService;
+import org.optaplanner.workbench.screens.guidedrule.client.resources.i18n.GuidedRuleEditorConstants;
+import org.optaplanner.workbench.screens.guidedrule.client.widget.MultiConstraintHardMediumSoftMatchRuleModellerWidget;
+import org.optaplanner.workbench.screens.guidedrule.model.ActionHardConstraintMatch;
+import org.optaplanner.workbench.screens.guidedrule.model.ActionMediumConstraintMatch;
+import org.optaplanner.workbench.screens.guidedrule.model.ActionMultiConstraintHardMediumSoftMatch;
+import org.optaplanner.workbench.screens.guidedrule.model.ActionSoftConstraintMatch;
+import org.optaplanner.workbench.screens.guidedrule.service.ScoreHolderService;
+import org.uberfire.mvp.Command;
+
+@ApplicationScoped
+public class MultiConstraintHardMediumSoftMatchRuleModellerActionPlugin implements RuleModellerActionPlugin {
+
+    private static final Set<String> SUPPORTED_SCORE_HOLDER_TYPES;
+
+    static {
+        SUPPORTED_SCORE_HOLDER_TYPES = new HashSet<>(1);
+        SUPPORTED_SCORE_HOLDER_TYPES.add("org.optaplanner.core.api.score.buildin.hardmediumsoft.HardMediumSoftScoreHolder");
+    }
+
+    @Inject
+    private Caller<ScoreHolderService> scoreHolderService;
+
+    @Inject
+    private ActionPluginClientService actionPluginClientService;
+
+    @Inject
+    private TranslationService translationService;
+
+    public MultiConstraintHardMediumSoftMatchRuleModellerActionPlugin() {
+    }
+
+    @Override
+    public boolean accept(final IAction iAction) {
+        return iAction instanceof ActionMultiConstraintHardMediumSoftMatch;
+    }
+
+    @Override
+    public void addPluginToActionList(final RuleModeller ruleModeller,
+                                      final Command addCommand) {
+        actionPluginClientService.addPluginToActionList(ruleModeller,
+                                                        addCommand,
+                                                        SUPPORTED_SCORE_HOLDER_TYPES);
+    }
+
+    @Override
+    public IAction createIAction(final RuleModeller ruleModeller) {
+        return new ActionMultiConstraintHardMediumSoftMatch(new ActionHardConstraintMatch(),
+                                                            new ActionMediumConstraintMatch(),
+                                                            new ActionSoftConstraintMatch());
+    }
+
+    @Override
+    public String getId() {
+        return "MULTI_CONSTRAINT_HARD_MEDIUM_SOFT_MATCH";
+    }
+
+    @Override
+    public String getActionAddDescription() {
+        return translationService.getTranslation(GuidedRuleEditorConstants.RuleModellerActionPluginModifyMultipleScoreLevels);
+    }
+
+    @Override
+    public RuleModellerWidget createWidget(final RuleModeller ruleModeller,
+                                           final EventBus eventBus,
+                                           final IAction iAction,
+                                           final Boolean readOnly) {
+
+        MultiConstraintHardMediumSoftMatchRuleModellerWidget widget = new MultiConstraintHardMediumSoftMatchRuleModellerWidget(ruleModeller,
+                                                                                                                               eventBus,
+                                                                                                                               (ActionMultiConstraintHardMediumSoftMatch) iAction,
+                                                                                                                               translationService,
+                                                                                                                               readOnly);
+        actionPluginClientService.initScoreHolderAwarePlugin(ruleModeller,
+                                                             widget,
+                                                             SUPPORTED_SCORE_HOLDER_TYPES);
+        return widget;
+    }
+}

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/plugin/MultiConstraintHardSoftMatchRuleModellerActionPlugin.java
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/plugin/MultiConstraintHardSoftMatchRuleModellerActionPlugin.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.screens.guidedrule.client.plugin;
+
+import java.util.HashSet;
+import java.util.Set;
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import com.google.gwt.event.shared.EventBus;
+import org.drools.workbench.models.datamodel.rule.IAction;
+import org.drools.workbench.screens.guided.rule.client.editor.RuleModeller;
+import org.drools.workbench.screens.guided.rule.client.editor.plugin.RuleModellerActionPlugin;
+import org.drools.workbench.screens.guided.rule.client.widget.RuleModellerWidget;
+import org.jboss.errai.common.client.api.Caller;
+import org.jboss.errai.ui.client.local.spi.TranslationService;
+import org.optaplanner.workbench.screens.guidedrule.client.resources.i18n.GuidedRuleEditorConstants;
+import org.optaplanner.workbench.screens.guidedrule.client.widget.MultiConstraintHardSoftMatchRuleModellerWidget;
+import org.optaplanner.workbench.screens.guidedrule.model.ActionHardConstraintMatch;
+import org.optaplanner.workbench.screens.guidedrule.model.ActionMultiConstraintHardSoftMatch;
+import org.optaplanner.workbench.screens.guidedrule.model.ActionSoftConstraintMatch;
+import org.optaplanner.workbench.screens.guidedrule.service.ScoreHolderService;
+import org.uberfire.mvp.Command;
+
+@ApplicationScoped
+public class MultiConstraintHardSoftMatchRuleModellerActionPlugin implements RuleModellerActionPlugin {
+
+    private static final Set<String> SUPPORTED_SCORE_HOLDER_TYPES;
+
+    static {
+        SUPPORTED_SCORE_HOLDER_TYPES = new HashSet<>(1);
+        SUPPORTED_SCORE_HOLDER_TYPES.add("org.optaplanner.core.api.score.buildin.hardsoft.HardSoftScoreHolder");
+    }
+
+    @Inject
+    private Caller<ScoreHolderService> scoreHolderService;
+
+    @Inject
+    private ActionPluginClientService actionPluginClientService;
+
+    @Inject
+    private TranslationService translationService;
+
+    public MultiConstraintHardSoftMatchRuleModellerActionPlugin() {
+    }
+
+    @Override
+    public boolean accept(final IAction iAction) {
+        return iAction instanceof ActionMultiConstraintHardSoftMatch;
+    }
+
+    @Override
+    public void addPluginToActionList(final RuleModeller ruleModeller,
+                                      final Command addCommand) {
+        actionPluginClientService.addPluginToActionList(ruleModeller,
+                                                        addCommand,
+                                                        SUPPORTED_SCORE_HOLDER_TYPES);
+    }
+
+    @Override
+    public IAction createIAction(final RuleModeller ruleModeller) {
+        return new ActionMultiConstraintHardSoftMatch(new ActionHardConstraintMatch(),
+                                                      new ActionSoftConstraintMatch());
+    }
+
+    @Override
+    public String getId() {
+        return "MULTI_CONSTRAINT_HARD_SOFT_MATCH";
+    }
+
+    @Override
+    public String getActionAddDescription() {
+        return translationService.getTranslation(GuidedRuleEditorConstants.RuleModellerActionPluginModifyMultipleScoreLevels);
+    }
+
+    @Override
+    public RuleModellerWidget createWidget(final RuleModeller ruleModeller,
+                                           final EventBus eventBus,
+                                           final IAction iAction,
+                                           final Boolean readOnly) {
+
+        MultiConstraintHardSoftMatchRuleModellerWidget widget = new MultiConstraintHardSoftMatchRuleModellerWidget(ruleModeller,
+                                                                                                                   eventBus,
+                                                                                                                   (ActionMultiConstraintHardSoftMatch) iAction,
+                                                                                                                   translationService,
+                                                                                                                   readOnly);
+        actionPluginClientService.initScoreHolderAwarePlugin(ruleModeller,
+                                                             widget,
+                                                             SUPPORTED_SCORE_HOLDER_TYPES);
+
+        return widget;
+    }
+}

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/plugin/SimpleConstraintMatchRuleModellerActionPlugin.java
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/plugin/SimpleConstraintMatchRuleModellerActionPlugin.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.screens.guidedrule.client.plugin;
+
+import java.util.HashSet;
+import java.util.Set;
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import com.google.gwt.event.shared.EventBus;
+import org.drools.workbench.models.datamodel.rule.IAction;
+import org.drools.workbench.screens.guided.rule.client.editor.RuleModeller;
+import org.drools.workbench.screens.guided.rule.client.editor.plugin.RuleModellerActionPlugin;
+import org.drools.workbench.screens.guided.rule.client.widget.RuleModellerWidget;
+import org.jboss.errai.common.client.api.Caller;
+import org.jboss.errai.ui.client.local.spi.TranslationService;
+import org.optaplanner.workbench.screens.guidedrule.client.resources.i18n.GuidedRuleEditorConstants;
+import org.optaplanner.workbench.screens.guidedrule.client.widget.ConstraintMatchRuleModellerWidget;
+import org.optaplanner.workbench.screens.guidedrule.model.ActionSimpleConstraintMatch;
+import org.optaplanner.workbench.screens.guidedrule.service.ScoreHolderService;
+import org.uberfire.mvp.Command;
+
+@ApplicationScoped
+public class SimpleConstraintMatchRuleModellerActionPlugin implements RuleModellerActionPlugin {
+
+    private static final Set<String> SUPPORTED_SCORE_HOLDER_TYPES;
+
+    static {
+        SUPPORTED_SCORE_HOLDER_TYPES = new HashSet<>(1);
+        SUPPORTED_SCORE_HOLDER_TYPES.add("org.optaplanner.core.api.score.buildin.simple.SimpleScoreHolder");
+    }
+
+    @Inject
+    private Caller<ScoreHolderService> scoreHolderService;
+
+    @Inject
+    private ActionPluginClientService actionPluginClientService;
+
+    @Inject
+    private TranslationService translationService;
+
+    public SimpleConstraintMatchRuleModellerActionPlugin() {
+    }
+
+    @Override
+    public boolean accept(final IAction iAction) {
+        return iAction instanceof ActionSimpleConstraintMatch;
+    }
+
+    @Override
+    public void addPluginToActionList(final RuleModeller ruleModeller,
+                                      final Command addCommand) {
+        actionPluginClientService.addPluginToActionList(ruleModeller,
+                                                        addCommand,
+                                                        SUPPORTED_SCORE_HOLDER_TYPES);
+    }
+
+    @Override
+    public IAction createIAction(final RuleModeller ruleModeller) {
+        return new ActionSimpleConstraintMatch();
+    }
+
+    @Override
+    public String getId() {
+        return "SIMPLE_CONSTRAINT_MATCH";
+    }
+
+    @Override
+    public String getActionAddDescription() {
+        return translationService.getTranslation(GuidedRuleEditorConstants.RuleModellerActionPluginModifySimpleScore);
+    }
+
+    @Override
+    public RuleModellerWidget createWidget(final RuleModeller ruleModeller,
+                                           final EventBus eventBus,
+                                           final IAction iAction,
+                                           final Boolean readOnly) {
+
+        ConstraintMatchRuleModellerWidget widget = new ConstraintMatchRuleModellerWidget(ruleModeller,
+                                                                                         eventBus,
+                                                                                         (ActionSimpleConstraintMatch) iAction,
+                                                                                         translationService,
+                                                                                         readOnly,
+                                                                                         GuidedRuleEditorConstants.RuleModellerActionPluginSimpleScore);
+        actionPluginClientService.initScoreHolderAwarePlugin(ruleModeller,
+                                                             widget,
+                                                             SUPPORTED_SCORE_HOLDER_TYPES);
+
+        return widget;
+    }
+}

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/plugin/SoftConstraintMatchRuleModellerActionPlugin.java
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/plugin/SoftConstraintMatchRuleModellerActionPlugin.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.screens.guidedrule.client.plugin;
+
+import java.util.HashSet;
+import java.util.Set;
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import com.google.gwt.event.shared.EventBus;
+import org.drools.workbench.models.datamodel.rule.IAction;
+import org.drools.workbench.screens.guided.rule.client.editor.RuleModeller;
+import org.drools.workbench.screens.guided.rule.client.editor.plugin.RuleModellerActionPlugin;
+import org.drools.workbench.screens.guided.rule.client.widget.RuleModellerWidget;
+import org.jboss.errai.common.client.api.Caller;
+import org.jboss.errai.ui.client.local.spi.TranslationService;
+import org.optaplanner.workbench.screens.guidedrule.client.resources.i18n.GuidedRuleEditorConstants;
+import org.optaplanner.workbench.screens.guidedrule.client.widget.ConstraintMatchRuleModellerWidget;
+import org.optaplanner.workbench.screens.guidedrule.model.ActionSoftConstraintMatch;
+import org.optaplanner.workbench.screens.guidedrule.service.ScoreHolderService;
+import org.uberfire.mvp.Command;
+
+@ApplicationScoped
+public class SoftConstraintMatchRuleModellerActionPlugin implements RuleModellerActionPlugin {
+
+    private static final Set<String> SUPPORTED_SCORE_HOLDER_TYPES;
+
+    static {
+        SUPPORTED_SCORE_HOLDER_TYPES = new HashSet<>(2);
+        SUPPORTED_SCORE_HOLDER_TYPES.add("org.optaplanner.core.api.score.buildin.hardsoft.HardSoftScoreHolder");
+        SUPPORTED_SCORE_HOLDER_TYPES.add("org.optaplanner.core.api.score.buildin.hardmediumsoft.HardMediumSoftScoreHolder");
+    }
+
+    @Inject
+    private Caller<ScoreHolderService> scoreHolderService;
+
+    @Inject
+    private ActionPluginClientService actionPluginClientService;
+
+    @Inject
+    private TranslationService translationService;
+
+    public SoftConstraintMatchRuleModellerActionPlugin() {
+    }
+
+    @Override
+    public boolean accept(final IAction iAction) {
+        return iAction instanceof ActionSoftConstraintMatch;
+    }
+
+    @Override
+    public void addPluginToActionList(final RuleModeller ruleModeller,
+                                      final Command addCommand) {
+        actionPluginClientService.addPluginToActionList(ruleModeller,
+                                                        addCommand,
+                                                        SUPPORTED_SCORE_HOLDER_TYPES);
+    }
+
+    @Override
+    public IAction createIAction(final RuleModeller ruleModeller) {
+        return new ActionSoftConstraintMatch();
+    }
+
+    @Override
+    public String getId() {
+        return "SOFT_CONSTRAINT_MATCH";
+    }
+
+    @Override
+    public String getActionAddDescription() {
+        return translationService.getTranslation(GuidedRuleEditorConstants.RuleModellerActionPluginModifySoftScore);
+    }
+
+    @Override
+    public RuleModellerWidget createWidget(final RuleModeller ruleModeller,
+                                           final EventBus eventBus,
+                                           final IAction iAction,
+                                           final Boolean readOnly) {
+
+        ConstraintMatchRuleModellerWidget widget = new ConstraintMatchRuleModellerWidget(ruleModeller,
+                                                                                         eventBus,
+                                                                                         (ActionSoftConstraintMatch) iAction,
+                                                                                         translationService,
+                                                                                         readOnly,
+                                                                                         GuidedRuleEditorConstants.RuleModellerActionPluginSoftScore);
+        actionPluginClientService.initScoreHolderAwarePlugin(ruleModeller,
+                                                             widget,
+                                                             SUPPORTED_SCORE_HOLDER_TYPES);
+
+        return widget;
+    }
+}

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/resources/GuidedRuleEditorResources.java
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/resources/GuidedRuleEditorResources.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.screens.guidedrule.client.resources;
+
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.resources.client.ClientBundle;
+import org.optaplanner.workbench.screens.guidedrule.client.resources.css.Styles;
+
+public interface GuidedRuleEditorResources extends ClientBundle {
+
+    GuidedRuleEditorResources INSTANCE = GWT.create(GuidedRuleEditorResources.class);
+
+    @Source("css/Styles.css")
+    Styles css();
+}

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/resources/css/Styles.java
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/resources/css/Styles.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.screens.guidedrule.client.resources.css;
+
+import com.google.gwt.resources.client.CssResource;
+
+public interface Styles extends CssResource {
+
+    String multiConstraintMatch();
+}

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/resources/i18n/GuidedRuleEditorConstants.java
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/resources/i18n/GuidedRuleEditorConstants.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.screens.guidedrule.client.resources.i18n;
+
+import org.jboss.errai.ui.shared.api.annotations.TranslationKey;
+
+public interface GuidedRuleEditorConstants {
+
+    @TranslationKey(defaultValue = "")
+    String RuleModellerActionPluginModifyHardScore = "RuleModellerActionPlugin.ModifyHardScore";
+
+    @TranslationKey(defaultValue = "")
+    String RuleModellerActionPluginModifyMediumScore = "RuleModellerActionPlugin.ModifyMediumScore";
+
+    @TranslationKey(defaultValue = "")
+    String RuleModellerActionPluginModifyMultipleScoreLevels = "RuleModellerActionPlugin.ModifyMultipleScoreLevels";
+
+    @TranslationKey(defaultValue = "")
+    String RuleModellerActionPluginModifySimpleScore = "RuleModellerActionPlugin.ModifySimpleScore";
+
+    @TranslationKey(defaultValue = "")
+    String RuleModellerActionPluginModifySoftScore = "RuleModellerActionPlugin.ModifySoftScore";
+
+    @TranslationKey(defaultValue = "")
+    String RuleModellerActionPluginHardScore = "RuleModellerActionPlugin.HardScore";
+
+    @TranslationKey(defaultValue = "")
+    String RuleModellerActionPluginMediumScore = "RuleModellerActionPlugin.MediumScore";
+
+    @TranslationKey(defaultValue = "")
+    String RuleModellerActionPluginSimpleScore = "RuleModellerActionPlugin.SimpleScore";
+
+    @TranslationKey(defaultValue = "")
+    String RuleModellerActionPluginSoftScore = "RuleModellerActionPlugin.SoftScore";
+
+    @TranslationKey(defaultValue = "")
+    String RuleModellerActionPluginMultiConstraintMatch = "RuleModellerActionPlugin.MultiConstraintMatch";
+
+    @TranslationKey(defaultValue = "")
+    String RuleModellerActionPluginHardScoreLevelSizeIsZero = "RuleModellerActionPlugin.HardScoreLevelSizeIsZero";
+
+    @TranslationKey(defaultValue = "")
+    String RuleModellerActionPluginSoftScoreLevelSizeIsZero = "RuleModellerActionPlugin.SoftScoreLevelSizeIsZero";
+
+    @TranslationKey(defaultValue = "")
+    String RuleModellerActionPluginScoreLevelExceeded = "RuleModellerActionPlugin.ScoreLevelExceeded";
+
+    @TranslationKey(defaultValue = "")
+    String RuleModellerActionPluginAmbigiousConstraintMatchesDetected = "RuleModellerActionPlugin.AmbigiousConstraintMatchesDetected";
+
+    @TranslationKey(defaultValue = "")
+    String ActionPluginClientServiceScoreHolderGlobalNotFound = "ActionPluginClientService.ScoreHolderGlobalNotFound";
+
+    @TranslationKey(defaultValue = "")
+    String ActionPluginClientServiceMultipleScoreHolderGlobals = "ActionPluginClientService.MultipleScoreHolderGlobals";
+
+    @TranslationKey(defaultValue = "")
+    String ActionPluginClientServiceScoreTypeNotSupported = "ActionPluginClientService.ScoreTypeNotSupported";
+}

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/widget/AbstractConstraintMatchRuleModellerWidget.java
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/widget/AbstractConstraintMatchRuleModellerWidget.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.screens.guidedrule.client.widget;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import com.google.gwt.dom.client.Style;
+import com.google.gwt.event.shared.EventBus;
+import com.google.gwt.user.client.ui.HorizontalPanel;
+import com.google.gwt.user.client.ui.Label;
+import org.drools.workbench.models.datamodel.rule.RuleModel;
+import org.drools.workbench.screens.guided.rule.client.editor.RuleModeller;
+import org.drools.workbench.screens.guided.rule.client.widget.RuleModellerWidget;
+import org.jboss.errai.ui.client.local.spi.TranslationService;
+import org.optaplanner.workbench.screens.guidedrule.client.resources.i18n.GuidedRuleEditorConstants;
+import org.optaplanner.workbench.screens.guidedrule.model.ActionConstraintMatch;
+import org.uberfire.client.views.pfly.widgets.HelpIcon;
+
+public abstract class AbstractConstraintMatchRuleModellerWidget extends RuleModellerWidget implements ScoreHolderGlobalAware {
+
+    protected TranslationService translationService;
+
+    protected HelpIcon helpIcon = new HelpIcon();
+
+    protected Set<String> messages = new HashSet<>();
+
+    public AbstractConstraintMatchRuleModellerWidget(final RuleModeller modeller,
+                                                     final EventBus eventBus,
+                                                     final TranslationService translationService) {
+        super(modeller,
+              eventBus);
+
+        this.translationService = translationService;
+    }
+
+    protected HorizontalPanel createLabelPanel(final String labelText) {
+        HorizontalPanel labelPanel = new HorizontalPanel();
+
+        labelPanel.add(new Label(labelText));
+
+        helpIcon.setVisible(false);
+        helpIcon.getElement().getStyle().setPaddingLeft(5,
+                                                        Style.Unit.PX);
+        labelPanel.add(helpIcon);
+        checkMultipleActionConstraintMatchesExist();
+
+        return labelPanel;
+    }
+
+    @Override
+    public void scoreHolderGlobalIssueDetected(final String message) {
+        messages.add(message);
+
+        displayMessages();
+    }
+
+    protected void checkMultipleActionConstraintMatchesExist() {
+        RuleModel model = getModeller().getModel();
+        long actionConstraintMatchCount = Arrays.stream(model.rhs).filter(a -> a instanceof ActionConstraintMatch).count();
+
+        if (actionConstraintMatchCount > 1) {
+            messages.add(translationService.getTranslation(GuidedRuleEditorConstants.RuleModellerActionPluginAmbigiousConstraintMatchesDetected));
+
+            displayMessages();
+        }
+    }
+
+    private void displayMessages() {
+        String joinedMessages = messages.stream().collect(Collectors.joining("<br/>"));
+
+        helpIcon.setHelpContent(joinedMessages);
+        helpIcon.setVisible(true);
+    }
+
+    @Override
+    public boolean isReadOnly() {
+        return false;
+    }
+
+    @Override
+    public boolean isFactTypeKnown() {
+        return true;
+    }
+}

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/widget/BendableConstraintMatchRuleModellerWidget.java
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/widget/BendableConstraintMatchRuleModellerWidget.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.screens.guidedrule.client.widget;
+
+import com.google.gwt.dom.client.Style;
+import com.google.gwt.event.shared.EventBus;
+import com.google.gwt.user.client.ui.HorizontalPanel;
+import com.google.gwt.user.client.ui.TextBox;
+import org.drools.workbench.screens.guided.rule.client.editor.RuleModeller;
+import org.jboss.errai.ui.client.local.spi.TranslationService;
+import org.optaplanner.workbench.screens.guidedrule.model.AbstractActionBendableConstraintMatch;
+import org.uberfire.client.views.pfly.widgets.HelpIcon;
+
+public class BendableConstraintMatchRuleModellerWidget extends AbstractConstraintMatchRuleModellerWidget {
+
+    private AbstractActionBendableConstraintMatch actionConstraintMatch;
+
+    private TextBox constraintMatchTextBox = new TextBox();
+
+    private TextBox constraintLevelTextBox = new TextBox();
+
+    private HelpIcon constraintLevelSelectHelpIcon = new HelpIcon();
+
+    public BendableConstraintMatchRuleModellerWidget(final RuleModeller mod,
+                                                     final EventBus eventBus,
+                                                     final AbstractActionBendableConstraintMatch actionConstraintMatch,
+                                                     final TranslationService translationService,
+                                                     final Boolean readOnly,
+                                                     final String labelTranslationKey) {
+        super(mod,
+              eventBus,
+              translationService);
+
+        this.actionConstraintMatch = actionConstraintMatch;
+
+        HorizontalPanel horizontalPanel = new HorizontalPanel();
+
+        HorizontalPanel labelPanel = createLabelPanel(translationService.getTranslation(labelTranslationKey));
+        horizontalPanel.add(labelPanel);
+
+        HorizontalPanel selectPanel = createSelectPanel();
+        horizontalPanel.add(selectPanel);
+
+        HorizontalPanel constraintMatchPanel = createConstraintMatchPanel();
+        horizontalPanel.add(constraintMatchPanel);
+
+        horizontalPanel.setCellWidth(labelPanel,
+                                     "150px");
+        horizontalPanel.setCellWidth(selectPanel,
+                                     "70px");
+
+        initWidget(horizontalPanel);
+    }
+
+    private HorizontalPanel createSelectPanel() {
+        HorizontalPanel selectPanel = new HorizontalPanel();
+
+        constraintLevelTextBox.getElement().setAttribute("type",
+                                                         "number");
+        constraintLevelTextBox.getElement().setAttribute("min",
+                                                         "0");
+        constraintLevelTextBox.getElement().getStyle().setWidth(40,
+                                                                Style.Unit.PX);
+        constraintLevelTextBox.setEnabled(false);
+        constraintLevelTextBox.setValue(String.valueOf(actionConstraintMatch.getPosition()));
+        constraintLevelTextBox.addValueChangeHandler(s -> actionConstraintMatch.setPosition(Integer.parseInt(s.getValue())));
+        selectPanel.add(constraintLevelTextBox);
+
+        constraintLevelSelectHelpIcon.setVisible(false);
+        constraintLevelSelectHelpIcon.getElement().getStyle().setPaddingLeft(5,
+                                                                             Style.Unit.PX);
+
+        selectPanel.add(constraintLevelSelectHelpIcon);
+
+        return selectPanel;
+    }
+
+    private HorizontalPanel createConstraintMatchPanel() {
+        HorizontalPanel constraintMatchPanel = new HorizontalPanel();
+
+        constraintMatchTextBox.setValue(actionConstraintMatch.getConstraintMatch() == null ? "" : actionConstraintMatch.getConstraintMatch());
+        constraintMatchTextBox.addValueChangeHandler(s -> actionConstraintMatch.setConstraintMatch(s.getValue()));
+        constraintMatchTextBox.setEnabled(false);
+        constraintMatchTextBox.setWidth("100%");
+
+        constraintMatchPanel.setWidth("100%");
+        constraintMatchPanel.add(constraintMatchTextBox);
+
+        return constraintMatchPanel;
+    }
+
+    @Override
+    public void scoreHolderGlobalLoadedCorrectly() {
+        constraintMatchTextBox.setEnabled(true);
+        constraintLevelTextBox.setEnabled(true);
+    }
+
+    public void setScoreLevels(final int scoreLevelSize) {
+        int currentLevelSize = actionConstraintMatch.getPosition();
+
+        if (currentLevelSize >= scoreLevelSize) {
+            constraintLevelSelectHelpIcon.setHelpContent("Score level set for this score is greater than the maximum defined by current planning solution. Modify the bendable score levels size in the planning solution or change the level for this item.");
+            constraintLevelSelectHelpIcon.setVisible(true);
+        } else {
+            constraintLevelTextBox.getElement().setAttribute("max",
+                                                             String.valueOf(scoreLevelSize - 1));
+        }
+    }
+}

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/widget/ConstraintMatchRuleModellerWidget.java
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/widget/ConstraintMatchRuleModellerWidget.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.screens.guidedrule.client.widget;
+
+import com.google.gwt.event.shared.EventBus;
+import com.google.gwt.user.client.ui.HorizontalPanel;
+import com.google.gwt.user.client.ui.TextBox;
+import org.drools.workbench.screens.guided.rule.client.editor.RuleModeller;
+import org.jboss.errai.ui.client.local.spi.TranslationService;
+import org.optaplanner.workbench.screens.guidedrule.model.AbstractActionConstraintMatch;
+
+public class ConstraintMatchRuleModellerWidget extends AbstractConstraintMatchRuleModellerWidget {
+
+    private TextBox constraintMatchTextBox = new TextBox();
+
+    public ConstraintMatchRuleModellerWidget(final RuleModeller mod,
+                                             final EventBus eventBus,
+                                             final AbstractActionConstraintMatch actionConstraintMatch,
+                                             final TranslationService translationService,
+                                             final Boolean readOnly,
+                                             final String labelTranslationKey) {
+        super(mod,
+              eventBus,
+              translationService);
+
+        HorizontalPanel horizontalPanel = new HorizontalPanel();
+
+        HorizontalPanel labelPanel = createLabelPanel(translationService.getTranslation(labelTranslationKey));
+        horizontalPanel.add(labelPanel);
+
+        HorizontalPanel constraintMatchPanel = createConstraintMatchPanel(actionConstraintMatch);
+        horizontalPanel.add(constraintMatchPanel);
+
+        horizontalPanel.setCellWidth(labelPanel,
+                                     "150px");
+
+        initWidget(horizontalPanel);
+    }
+
+    private HorizontalPanel createConstraintMatchPanel(final AbstractActionConstraintMatch actionConstraintMatch) {
+        HorizontalPanel constraintMatchPanel = new HorizontalPanel();
+
+        constraintMatchTextBox.setValue(actionConstraintMatch.getConstraintMatch() == null ? "" : actionConstraintMatch.getConstraintMatch());
+        constraintMatchTextBox.addValueChangeHandler(s -> actionConstraintMatch.setConstraintMatch(s.getValue()));
+        constraintMatchTextBox.setEnabled(false);
+        constraintMatchTextBox.setWidth("100%");
+
+        constraintMatchPanel.setWidth("100%");
+        constraintMatchPanel.add(constraintMatchTextBox);
+
+        return constraintMatchPanel;
+    }
+
+    public void scoreHolderGlobalLoadedCorrectly() {
+        constraintMatchTextBox.setEnabled(true);
+    }
+}

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/widget/MultiConstraintBendableMatchRuleModellerWidget.java
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/widget/MultiConstraintBendableMatchRuleModellerWidget.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.screens.guidedrule.client.widget;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.google.gwt.dom.client.Style;
+import com.google.gwt.event.shared.EventBus;
+import com.google.gwt.user.client.ui.HorizontalPanel;
+import com.google.gwt.user.client.ui.Label;
+import com.google.gwt.user.client.ui.TextBox;
+import com.google.gwt.user.client.ui.VerticalPanel;
+import org.drools.workbench.screens.guided.rule.client.editor.RuleModeller;
+import org.jboss.errai.ui.client.local.spi.TranslationService;
+import org.optaplanner.workbench.screens.guidedrule.client.resources.GuidedRuleEditorResources;
+import org.optaplanner.workbench.screens.guidedrule.client.resources.i18n.GuidedRuleEditorConstants;
+import org.optaplanner.workbench.screens.guidedrule.model.AbstractActionBendableConstraintMatch;
+import org.optaplanner.workbench.screens.guidedrule.model.AbstractActionMultiConstraintBendableMatch;
+import org.optaplanner.workbench.screens.guidedrule.model.BendableScoreLevelsWrapper;
+import org.uberfire.client.views.pfly.widgets.HelpIcon;
+
+public class MultiConstraintBendableMatchRuleModellerWidget extends AbstractConstraintMatchRuleModellerWidget {
+
+    private List<TextBox> hardConstraintMatchTextBoxes = new ArrayList<>();
+
+    private List<HelpIcon> hardConstraintMatchHelpIcons = new ArrayList<>();
+
+    private List<TextBox> softConstraintMatchTextBoxes = new ArrayList<>();
+
+    private List<HelpIcon> softConstraintMatchHelpIcons = new ArrayList<>();
+
+    public MultiConstraintBendableMatchRuleModellerWidget(final RuleModeller mod,
+                                                          final EventBus eventBus,
+                                                          final AbstractActionMultiConstraintBendableMatch actionConstraintMatch,
+                                                          final TranslationService translationService,
+                                                          final Boolean readOnly) {
+        super(mod,
+              eventBus,
+              translationService);
+
+        VerticalPanel verticalPanel = new VerticalPanel();
+
+        HorizontalPanel titlePanel = createLabelPanel(translationService.getTranslation(GuidedRuleEditorConstants.RuleModellerActionPluginMultiConstraintMatch));
+        verticalPanel.add(titlePanel);
+        verticalPanel.setCellHeight(titlePanel,
+                                    "25px");
+
+        VerticalPanel hardScorePanel = new VerticalPanel();
+        hardScorePanel.getElement().getStyle().setWidth(100,
+                                                        Style.Unit.PCT);
+        if (actionConstraintMatch.getActionBendableHardConstraintMatches() == null || actionConstraintMatch.getActionBendableHardConstraintMatches().isEmpty()) {
+            hardScorePanel.add(new Label(translationService.getTranslation(GuidedRuleEditorConstants.RuleModellerActionPluginHardScoreLevelSizeIsZero)));
+        } else {
+            for (int i = 0; i < actionConstraintMatch.getActionBendableHardConstraintMatches().size(); i++) {
+                HorizontalPanel horizontalPanel = createBendableConstraintMatchRow(translationService.getTranslation(GuidedRuleEditorConstants.RuleModellerActionPluginHardScore),
+                                                                                   i,
+                                                                                   hardConstraintMatchHelpIcons,
+                                                                                   hardConstraintMatchTextBoxes,
+                                                                                   actionConstraintMatch.getActionBendableHardConstraintMatches().get(i));
+                hardScorePanel.add(horizontalPanel);
+            }
+        }
+        verticalPanel.add(hardScorePanel);
+
+        VerticalPanel softScorePanel = new VerticalPanel();
+        softScorePanel.getElement().getStyle().setWidth(100,
+                                                        Style.Unit.PCT);
+        if (actionConstraintMatch.getActionBendableSoftConstraintMatches() == null || actionConstraintMatch.getActionBendableSoftConstraintMatches().isEmpty()) {
+            softScorePanel.add(new Label(translationService.getTranslation(GuidedRuleEditorConstants.RuleModellerActionPluginSoftScoreLevelSizeIsZero)));
+        } else {
+            for (int i = 0; i < actionConstraintMatch.getActionBendableSoftConstraintMatches().size(); i++) {
+                HorizontalPanel horizontalPanel = createBendableConstraintMatchRow(translationService.getTranslation(GuidedRuleEditorConstants.RuleModellerActionPluginSoftScore),
+                                                                                   i,
+                                                                                   softConstraintMatchHelpIcons,
+                                                                                   softConstraintMatchTextBoxes,
+                                                                                   actionConstraintMatch.getActionBendableSoftConstraintMatches().get(i));
+                softScorePanel.add(horizontalPanel);
+            }
+        }
+        verticalPanel.add(softScorePanel);
+
+        verticalPanel.addStyleName(GuidedRuleEditorResources.INSTANCE.css().multiConstraintMatch());
+
+        initWidget(verticalPanel);
+    }
+
+    private HorizontalPanel createBendableConstraintMatchRow(final String labelText,
+                                                             final int index,
+                                                             final List<HelpIcon> hardConstraintMatchHelpIcons,
+                                                             final List<TextBox> hardConstraintMatchTextBoxes,
+                                                             final AbstractActionBendableConstraintMatch constraintMatch) {
+        HorizontalPanel horizontalPanel = new HorizontalPanel();
+
+        HorizontalPanel labelPanel = new HorizontalPanel();
+        labelPanel.add(new Label(labelText));
+        horizontalPanel.add(labelPanel);
+
+        HorizontalPanel selectPanel = new HorizontalPanel();
+
+        TextBox constraintLevelTextBox = new TextBox();
+        constraintLevelTextBox.setEnabled(false);
+        constraintLevelTextBox.getElement().getStyle().setWidth(40,
+                                                                Style.Unit.PX);
+        constraintLevelTextBox.setValue(String.valueOf(index));
+        selectPanel.add(constraintLevelTextBox);
+
+        HelpIcon constraintLevelSelectHelpIcon = new HelpIcon();
+        hardConstraintMatchHelpIcons.add(constraintLevelSelectHelpIcon);
+        constraintLevelSelectHelpIcon.setVisible(false);
+        constraintLevelSelectHelpIcon.setHelpContent(GuidedRuleEditorConstants.RuleModellerActionPluginScoreLevelExceeded);
+        constraintLevelSelectHelpIcon.getElement().getStyle().setPaddingLeft(5,
+                                                                             Style.Unit.PX);
+        selectPanel.add(constraintLevelSelectHelpIcon);
+
+        horizontalPanel.add(selectPanel);
+
+        TextBox constraintMatchTextBox = new TextBox();
+        hardConstraintMatchTextBoxes.add(constraintMatchTextBox);
+        constraintMatchTextBox.setValue(constraintMatch.getConstraintMatch() == null ? "" : constraintMatch.getConstraintMatch());
+        constraintMatchTextBox.addValueChangeHandler(c -> constraintMatch.setConstraintMatch(c.getValue()));
+        constraintMatchTextBox.setEnabled(false);
+        constraintMatchTextBox.setWidth("100%");
+
+        horizontalPanel.add(constraintMatchTextBox);
+        horizontalPanel.setCellWidth(labelPanel,
+                                     "150px");
+        horizontalPanel.setCellWidth(selectPanel,
+                                     "70px");
+
+        horizontalPanel.setStyleName(GuidedRuleEditorResources.INSTANCE.css().multiConstraintMatch());
+        horizontalPanel.getElement().getStyle().setWidth(100,
+                                                         Style.Unit.PCT);
+
+        return horizontalPanel;
+    }
+
+    @Override
+    public void scoreHolderGlobalLoadedCorrectly() {
+        if (hardConstraintMatchTextBoxes != null) {
+            for (TextBox hardConstraintMatchTextBox : hardConstraintMatchTextBoxes) {
+                hardConstraintMatchTextBox.setEnabled(true);
+            }
+        }
+
+        if (softConstraintMatchTextBoxes != null) {
+            for (TextBox softConstraintMatchTextBox : softConstraintMatchTextBoxes) {
+                softConstraintMatchTextBox.setEnabled(true);
+            }
+        }
+    }
+
+    public void setScoreLevels(final BendableScoreLevelsWrapper scoreLevelsWrapper) {
+        if (hardConstraintMatchHelpIcons != null) {
+            for (int i = 0; i < hardConstraintMatchHelpIcons.size(); i++) {
+                if (scoreLevelsWrapper.getHardScoreLevels() <= i) {
+                    hardConstraintMatchHelpIcons.get(i).setVisible(true);
+                }
+            }
+        }
+
+        if (softConstraintMatchHelpIcons != null) {
+            for (int i = 0; i < softConstraintMatchHelpIcons.size(); i++) {
+                if (scoreLevelsWrapper.getSoftScoreLevels() <= i) {
+                    softConstraintMatchHelpIcons.get(i).setVisible(true);
+                }
+            }
+        }
+    }
+}

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/widget/MultiConstraintHardMediumSoftMatchRuleModellerWidget.java
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/widget/MultiConstraintHardMediumSoftMatchRuleModellerWidget.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.screens.guidedrule.client.widget;
+
+import com.google.gwt.event.shared.EventBus;
+import com.google.gwt.user.client.ui.HorizontalPanel;
+import com.google.gwt.user.client.ui.Label;
+import com.google.gwt.user.client.ui.TextBox;
+import com.google.gwt.user.client.ui.VerticalPanel;
+import org.drools.workbench.screens.guided.rule.client.editor.RuleModeller;
+import org.jboss.errai.ui.client.local.spi.TranslationService;
+import org.optaplanner.workbench.screens.guidedrule.client.resources.GuidedRuleEditorResources;
+import org.optaplanner.workbench.screens.guidedrule.client.resources.i18n.GuidedRuleEditorConstants;
+import org.optaplanner.workbench.screens.guidedrule.model.ActionMultiConstraintHardMediumSoftMatch;
+
+public class MultiConstraintHardMediumSoftMatchRuleModellerWidget extends AbstractConstraintMatchRuleModellerWidget {
+
+    private TextBox hardConstraintMatchTextBox = new TextBox();
+
+    private TextBox mediumConstraintMatchTextBox = new TextBox();
+
+    private TextBox softConstraintMatchTextBox = new TextBox();
+
+    public MultiConstraintHardMediumSoftMatchRuleModellerWidget(final RuleModeller mod,
+                                                                final EventBus eventBus,
+                                                                final ActionMultiConstraintHardMediumSoftMatch actionConstraintMatch,
+                                                                final TranslationService translationService,
+                                                                final Boolean readOnly) {
+        super(mod,
+              eventBus,
+              translationService);
+
+        VerticalPanel verticalPanel = new VerticalPanel();
+
+        HorizontalPanel labelPanel = createLabelPanel(translationService.getTranslation(GuidedRuleEditorConstants.RuleModellerActionPluginMultiConstraintMatch));
+
+        verticalPanel.add(labelPanel);
+
+        String hardConstraintMatch = actionConstraintMatch.getActionHardConstraintMatch().getConstraintMatch();
+        hardConstraintMatchTextBox.setValue(hardConstraintMatch == null ? "" : hardConstraintMatch);
+        hardConstraintMatchTextBox.addValueChangeHandler(s -> actionConstraintMatch.getActionHardConstraintMatch().setConstraintMatch(s.getValue()));
+        verticalPanel.add(getItemPanel(translationService.getTranslation(GuidedRuleEditorConstants.RuleModellerActionPluginHardScore),
+                                       hardConstraintMatchTextBox));
+
+        String mediumConstraintMatch = actionConstraintMatch.getActionMediumConstraintMatch().getConstraintMatch();
+        mediumConstraintMatchTextBox.setValue(mediumConstraintMatch == null ? "" : mediumConstraintMatch);
+        mediumConstraintMatchTextBox.addValueChangeHandler(s -> actionConstraintMatch.getActionMediumConstraintMatch().setConstraintMatch(s.getValue()));
+        verticalPanel.add(getItemPanel(translationService.getTranslation(GuidedRuleEditorConstants.RuleModellerActionPluginMediumScore),
+                                       mediumConstraintMatchTextBox));
+
+        String softConstraintMatch = actionConstraintMatch.getActionSoftConstraintMatch().getConstraintMatch();
+        softConstraintMatchTextBox.setValue(softConstraintMatch == null ? "" : softConstraintMatch);
+        softConstraintMatchTextBox.addValueChangeHandler(s -> actionConstraintMatch.getActionSoftConstraintMatch().setConstraintMatch(s.getValue()));
+        verticalPanel.add(getItemPanel(translationService.getTranslation(GuidedRuleEditorConstants.RuleModellerActionPluginSoftScore),
+                                       softConstraintMatchTextBox));
+
+        verticalPanel.addStyleName(GuidedRuleEditorResources.INSTANCE.css().multiConstraintMatch());
+
+        initWidget(verticalPanel);
+    }
+
+    private HorizontalPanel getItemPanel(final String labelText,
+                                         final TextBox constraintMatchTextBox) {
+        HorizontalPanel horizontalPanel = new HorizontalPanel();
+        horizontalPanel.setWidth("100%");
+
+        HorizontalPanel labelPanel = new HorizontalPanel();
+        Label label = new Label(labelText);
+        labelPanel.add(label);
+        horizontalPanel.add(labelPanel);
+
+        constraintMatchTextBox.setEnabled(false);
+        constraintMatchTextBox.setWidth("100%");
+        horizontalPanel.add(constraintMatchTextBox);
+
+        horizontalPanel.setCellWidth(labelPanel,
+                                     "150px");
+
+        return horizontalPanel;
+    }
+
+    public void scoreHolderGlobalLoadedCorrectly() {
+        hardConstraintMatchTextBox.setEnabled(true);
+        mediumConstraintMatchTextBox.setEnabled(true);
+        softConstraintMatchTextBox.setEnabled(true);
+    }
+}

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/widget/MultiConstraintHardSoftMatchRuleModellerWidget.java
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/widget/MultiConstraintHardSoftMatchRuleModellerWidget.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.screens.guidedrule.client.widget;
+
+import com.google.gwt.event.shared.EventBus;
+import com.google.gwt.user.client.ui.HorizontalPanel;
+import com.google.gwt.user.client.ui.Label;
+import com.google.gwt.user.client.ui.TextBox;
+import com.google.gwt.user.client.ui.VerticalPanel;
+import org.drools.workbench.screens.guided.rule.client.editor.RuleModeller;
+import org.jboss.errai.ui.client.local.spi.TranslationService;
+import org.optaplanner.workbench.screens.guidedrule.client.resources.GuidedRuleEditorResources;
+import org.optaplanner.workbench.screens.guidedrule.client.resources.i18n.GuidedRuleEditorConstants;
+import org.optaplanner.workbench.screens.guidedrule.model.ActionMultiConstraintHardSoftMatch;
+
+public class MultiConstraintHardSoftMatchRuleModellerWidget extends AbstractConstraintMatchRuleModellerWidget {
+
+    private TextBox hardConstraintMatchTextBox = new TextBox();
+    private TextBox softConstraintMatchTextBox = new TextBox();
+
+    public MultiConstraintHardSoftMatchRuleModellerWidget(final RuleModeller mod,
+                                                          final EventBus eventBus,
+                                                          final ActionMultiConstraintHardSoftMatch actionConstraintMatch,
+                                                          final TranslationService translationService,
+                                                          final Boolean readOnly) {
+        super(mod,
+              eventBus,
+              translationService);
+
+        VerticalPanel verticalPanel = new VerticalPanel();
+
+        HorizontalPanel labelPanel = createLabelPanel(translationService.getTranslation(GuidedRuleEditorConstants.RuleModellerActionPluginMultiConstraintMatch));
+        verticalPanel.add(labelPanel);
+        verticalPanel.setCellHeight(labelPanel,
+                                    "25px");
+
+        String hardConstraintMatch = actionConstraintMatch.getActionHardConstraintMatch().getConstraintMatch();
+        hardConstraintMatchTextBox.setValue(hardConstraintMatch == null ? "" : hardConstraintMatch);
+        hardConstraintMatchTextBox.addValueChangeHandler(s -> actionConstraintMatch.getActionHardConstraintMatch().setConstraintMatch(s.getValue()));
+        verticalPanel.add(getItemPanel(translationService.getTranslation(GuidedRuleEditorConstants.RuleModellerActionPluginHardScore),
+                                       hardConstraintMatchTextBox));
+
+        String softConstraintMatch = actionConstraintMatch.getActionSoftConstraintMatch().getConstraintMatch();
+        softConstraintMatchTextBox.setValue(softConstraintMatch == null ? "" : softConstraintMatch);
+        softConstraintMatchTextBox.addValueChangeHandler(s -> actionConstraintMatch.getActionSoftConstraintMatch().setConstraintMatch(s.getValue()));
+        verticalPanel.add(getItemPanel(translationService.getTranslation(GuidedRuleEditorConstants.RuleModellerActionPluginSoftScore),
+                                       softConstraintMatchTextBox));
+
+        verticalPanel.setStyleName(GuidedRuleEditorResources.INSTANCE.css().multiConstraintMatch());
+
+        initWidget(verticalPanel);
+    }
+
+    private HorizontalPanel getItemPanel(final String labelText,
+                                         final TextBox constraintMatchTextBox) {
+        HorizontalPanel horizontalPanel = new HorizontalPanel();
+
+        HorizontalPanel labelPanel = new HorizontalPanel();
+        Label label = new Label(labelText);
+        labelPanel.add(label);
+        horizontalPanel.add(labelPanel);
+
+        constraintMatchTextBox.setEnabled(false);
+        constraintMatchTextBox.setWidth("100%");
+        horizontalPanel.add(constraintMatchTextBox);
+
+        horizontalPanel.setWidth("100%");
+        horizontalPanel.setCellWidth(labelPanel,
+                                     "150px");
+
+        return horizontalPanel;
+    }
+
+    public void scoreHolderGlobalLoadedCorrectly() {
+        hardConstraintMatchTextBox.setEnabled(true);
+        softConstraintMatchTextBox.setEnabled(true);
+    }
+}

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/widget/ScoreHolderGlobalAware.java
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/widget/ScoreHolderGlobalAware.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.screens.guidedrule.client.widget;
+
+public interface ScoreHolderGlobalAware {
+
+    void scoreHolderGlobalIssueDetected(final String message);
+
+    void scoreHolderGlobalLoadedCorrectly();
+}

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/resources/ErraiApp.properties
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/resources/ErraiApp.properties
@@ -1,0 +1,31 @@
+#
+# Copyright 2012 Red Hat, Inc. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# ErraiApp.properties
+#
+# Do not remove, even if empty!
+#
+
+# This is a marker file. When it is detected inside a JAR or at the
+# top of any classpath, the subdirectories are scanned for deployable
+# components. As such, all Errai application modules in a project
+# should contain an ErraiApp.properties at the root of all classpaths
+# that you wish to be scanned.
+#
+# There are also some configuration options that can be set in this
+# file, although it is rarely necessary. See the documentation at
+# https://docs.jboss.org/author/display/ERRAI/ErraiApp.properties
+# for details.

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/resources/META-INF/beans.xml
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2017 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~       http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee" bean-discovery-mode="none">
+  <scan>
+    <exclude name="org.optaplanner.workbench.screens.guidedrule.client.**"/>
+  </scan>
+</beans>

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/resources/org/optaplanner/workbench/screens/guidedrule/OptaPlannerWorkbenchGuidedRuleEditorClient.gwt.xml
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/resources/org/optaplanner/workbench/screens/guidedrule/OptaPlannerWorkbenchGuidedRuleEditorClient.gwt.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+  ~ Copyright 2015 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~       http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.7.0//EN"
+    "http://www.gwtproject.org/doctype/2.7.0/gwt-module.dtd">
+<module>
+  <stylesheet src='css/Styles.css'/>
+
+  <!-- Inherit the core Web Toolkit stuff. -->
+  <inherits name="com.google.gwt.i18n.I18N"/>
+  <inherits name="com.google.gwt.http.HTTP"/>
+  <inherits name="com.google.gwt.user.User"/>
+
+  <inherits name="org.optaplanner.workbench.screens.guidedrule.OptaPlannerWorkbenchGuidedRuleEditorAPI"/>
+
+</module>

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/resources/org/optaplanner/workbench/screens/guidedrule/client/resources/css/Styles.css
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/resources/org/optaplanner/workbench/screens/guidedrule/client/resources/css/Styles.css
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.multiConstraintMatch {
+    border-collapse: separate;
+    border-spacing: 2px;
+}

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/resources/org/optaplanner/workbench/screens/guidedrule/client/resources/i18n/GuidedRuleEditorConstants.properties
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/resources/org/optaplanner/workbench/screens/guidedrule/client/resources/i18n/GuidedRuleEditorConstants.properties
@@ -1,0 +1,35 @@
+#
+# Copyright 2017 Red Hat, Inc. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+RuleModellerActionPlugin.ModifyHardScore=Modify Hard Score
+RuleModellerActionPlugin.ModifyMediumScore=Modify Medium Score
+RuleModellerActionPlugin.ModifyMultipleScoreLevels=Modify multiple score levels
+RuleModellerActionPlugin.ModifySimpleScore=Modify Simple Score
+RuleModellerActionPlugin.ModifySoftScore=Modify Soft Score
+
+RuleModellerActionPlugin.HardScore=Hard Score
+RuleModellerActionPlugin.MediumScore=Medium Score
+RuleModellerActionPlugin.SimpleScore=Simple Score
+RuleModellerActionPlugin.SoftScore=Soft Score
+RuleModellerActionPlugin.MultiConstraintMatch=Multi constraint match
+RuleModellerActionPlugin.HardScoreLevelSizeIsZero=Hard score level size is 0
+RuleModellerActionPlugin.SoftScoreLevelSizeIsZero=Soft score level size is 0
+RuleModellerActionPlugin.ScoreLevelExceeded=Score level set for this score is greater than the maximum defined by current planning solution. Modify the bendable score levels size in the planning solution or remove this item.
+RuleModellerActionPlugin.AmbigiousConstraintMatchesDetected=Ambigious Planner score constraint matches detected within a single RHS of the rule. Remove one of the items.
+
+ActionPluginClientService.ScoreHolderGlobalNotFound=scoreHolder global variable not found. The global variable is created automatically when a Planning Solution is created. Make sure to create a planning solution before proceeding to rule definition.
+ActionPluginClientService.MultipleScoreHolderGlobals=Multiple scoreHolder global variables found. The global variable is created automatically when a Planning Solution is created. Make sure there are not multiple planning solution objects within the project and that you do not define the 'scoreHolder' global variable manually.
+ActionPluginClientService.ScoreTypeNotSupported=This score type is not supported by scoreHolder global defined for this project. The global variable is created automatically when a planning solution is created. Select a correct score type in a planning solution or remove this input.

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/test/java/org/optaplanner/workbench/screens/guidedrule/client/plugin/ActionPluginClientServiceTest.java
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/test/java/org/optaplanner/workbench/screens/guidedrule/client/plugin/ActionPluginClientServiceTest.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.screens.guidedrule.client.plugin;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.drools.workbench.screens.guided.rule.client.editor.RuleModeller;
+import org.jboss.errai.ui.client.local.spi.TranslationService;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.optaplanner.core.api.score.buildin.hardsoft.HardSoftScoreHolder;
+import org.optaplanner.core.api.score.buildin.simple.SimpleScoreHolder;
+import org.optaplanner.workbench.screens.guidedrule.client.widget.ScoreHolderGlobalAware;
+import org.optaplanner.workbench.screens.guidedrule.model.AbstractActionMultiConstraintBendableMatch;
+import org.optaplanner.workbench.screens.guidedrule.model.ActionMultiConstraintBendableMatch;
+import org.optaplanner.workbench.screens.guidedrule.model.BendableScoreLevelsWrapper;
+import org.optaplanner.workbench.screens.guidedrule.model.ScoreInformation;
+import org.optaplanner.workbench.screens.guidedrule.service.ScoreHolderService;
+import org.uberfire.backend.vfs.Path;
+import org.uberfire.mocks.CallerMock;
+import org.uberfire.mvp.Command;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class ActionPluginClientServiceTest {
+
+    @Mock
+    private ScoreHolderService scoreHolderService;
+
+    @Mock
+    private TranslationService translationService;
+
+    private ActionPluginClientService service;
+
+    @Before
+    public void setUp() {
+        this.service = new ActionPluginClientService(new CallerMock(scoreHolderService),
+                                                     translationService);
+    }
+
+    @Test
+    public void invokeScoreInformationCachedOperationCacheEmpty() {
+        Map<String, Object> serviceCache = new HashMap<>();
+        RuleModeller ruleModeller = mock(RuleModeller.class);
+        when(ruleModeller.getServiceInvocationCache()).thenReturn(serviceCache);
+
+        service.invokeScoreInformationCachedOperation(ruleModeller,
+                                                      (scoreInformation) -> {
+                                                      });
+
+        verify(scoreHolderService,
+               times(1)).getProjectScoreInformation(any(Path.class));
+    }
+
+    @Test
+    public void invokeScoreInformationCachedOperationCacheNotEmpty() {
+        Map<String, Object> serviceCache = new HashMap<>();
+        serviceCache.put(ActionPluginClientService.SCORE_INFORMATION,
+                         new ScoreInformation());
+
+        RuleModeller ruleModeller = mock(RuleModeller.class);
+        when(ruleModeller.getServiceInvocationCache()).thenReturn(serviceCache);
+
+        service.invokeScoreInformationCachedOperation(ruleModeller,
+                                                      (scoreInformation) -> {
+                                                      });
+
+        verify(scoreHolderService,
+               never()).getProjectScoreInformation(any(Path.class));
+    }
+
+    @Test
+    public void initScoreHolderAwarePlugin() {
+        ScoreInformation scoreInformation = new ScoreInformation(Arrays.asList(HardSoftScoreHolder.class.getName()),
+                                                                 Arrays.asList(new BendableScoreLevelsWrapper(1,
+                                                                                                              1)));
+        Map<String, Object> serviceCache = new HashMap<>();
+        serviceCache.put(ActionPluginClientService.SCORE_INFORMATION,
+                         scoreInformation);
+
+        RuleModeller ruleModeller = mock(RuleModeller.class);
+        when(ruleModeller.getServiceInvocationCache()).thenReturn(serviceCache);
+
+        ScoreHolderGlobalAware scoreHolderGlobalAware = mock(ScoreHolderGlobalAware.class);
+
+        service.initScoreHolderAwarePlugin(ruleModeller,
+                                           scoreHolderGlobalAware,
+                                           Arrays.asList(HardSoftScoreHolder.class.getName()));
+
+        verify(scoreHolderGlobalAware,
+               times(1)).scoreHolderGlobalLoadedCorrectly();
+    }
+
+    @Test
+    public void initScoreHolderAwarePluginAmbigiousScoreHolder() {
+        // Emulate multiple scoreHolder globals within a project
+        ScoreInformation scoreInformation = new ScoreInformation(Arrays.asList(HardSoftScoreHolder.class.getName(),
+                                                                               SimpleScoreHolder.class.getName()),
+                                                                 Arrays.asList(new BendableScoreLevelsWrapper(1,
+                                                                                                              1)));
+        Map<String, Object> serviceCache = new HashMap<>();
+        serviceCache.put(ActionPluginClientService.SCORE_INFORMATION,
+                         scoreInformation);
+
+        RuleModeller ruleModeller = mock(RuleModeller.class);
+        when(ruleModeller.getServiceInvocationCache()).thenReturn(serviceCache);
+
+        ScoreHolderGlobalAware scoreHolderGlobalAware = mock(ScoreHolderGlobalAware.class);
+
+        service.initScoreHolderAwarePlugin(ruleModeller,
+                                           scoreHolderGlobalAware,
+                                           Arrays.asList(HardSoftScoreHolder.class.getName()));
+
+        verify(scoreHolderGlobalAware,
+               times(1)).scoreHolderGlobalIssueDetected(anyString());
+    }
+
+    @Test
+    public void addPluginToActionList() {
+        ScoreInformation scoreInformation = new ScoreInformation(Arrays.asList(HardSoftScoreHolder.class.getName()),
+                                                                 Arrays.asList(new BendableScoreLevelsWrapper(1,
+                                                                                                              1)));
+        Map<String, Object> serviceCache = new HashMap<>();
+        serviceCache.put(ActionPluginClientService.SCORE_INFORMATION,
+                         scoreInformation);
+
+        RuleModeller ruleModeller = mock(RuleModeller.class);
+        when(ruleModeller.getServiceInvocationCache()).thenReturn(serviceCache);
+
+        Command addCommand = mock(Command.class);
+
+        service.addPluginToActionList(ruleModeller,
+                                      addCommand,
+                                      Arrays.asList(HardSoftScoreHolder.class.getName()));
+
+        verify(addCommand,
+               times(1)).execute();
+    }
+
+    @Test
+    public void addPluginToActionListAmbigiousScoreHolder() {
+        // Emulate multiple scoreHolder globals within a project
+        ScoreInformation scoreInformation = new ScoreInformation(Arrays.asList(HardSoftScoreHolder.class.getName(),
+                                                                               SimpleScoreHolder.class.getName()),
+                                                                 Arrays.asList(new BendableScoreLevelsWrapper(1,
+                                                                                                              1)));
+        Map<String, Object> serviceCache = new HashMap<>();
+        serviceCache.put(ActionPluginClientService.SCORE_INFORMATION,
+                         scoreInformation);
+
+        RuleModeller ruleModeller = mock(RuleModeller.class);
+        when(ruleModeller.getServiceInvocationCache()).thenReturn(serviceCache);
+
+        Command addCommand = mock(Command.class);
+
+        service.addPluginToActionList(ruleModeller,
+                                      addCommand,
+                                      Arrays.asList(HardSoftScoreHolder.class.getName()));
+
+        verify(addCommand,
+               never()).execute();
+    }
+
+    @Test
+    public void initBendableScoreLevels() {
+        ScoreInformation scoreInformation = new ScoreInformation(Arrays.asList(HardSoftScoreHolder.class.getName()),
+                                                                 Arrays.asList(new BendableScoreLevelsWrapper(1,
+                                                                                                              2)));
+        Map<String, Object> serviceCache = new HashMap<>();
+        serviceCache.put(ActionPluginClientService.SCORE_INFORMATION,
+                         scoreInformation);
+
+        RuleModeller ruleModeller = mock(RuleModeller.class);
+        when(ruleModeller.getServiceInvocationCache()).thenReturn(serviceCache);
+
+        AbstractActionMultiConstraintBendableMatch constraintMatch = new ActionMultiConstraintBendableMatch();
+
+        service.initBendableScoreLevels(ruleModeller,
+                                        constraintMatch);
+
+        Assert.assertEquals(1,
+                            constraintMatch.getActionBendableHardConstraintMatches().size());
+        Assert.assertEquals(2,
+                            constraintMatch.getActionBendableSoftConstraintMatches().size());
+    }
+}

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/pom.xml
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/pom.xml
@@ -16,24 +16,24 @@
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>optaplanner-wb</artifactId>
     <groupId>org.optaplanner</groupId>
+    <artifactId>optaplanner-wb-screens</artifactId>
     <version>7.1.0-SNAPSHOT</version>
   </parent>
-  <modelVersion>4.0.0</modelVersion>
 
-  <artifactId>optaplanner-wb-screens</artifactId>
+  <artifactId>optaplanner-wb-guided-rule-editor</artifactId>
   <packaging>pom</packaging>
 
-  <name>OptaPlanner Workbench - Screens</name>
-  <description>OptaPlanner Workbench - Screens</description>
+  <name>OptaPlanner Workbench - Guided Rule Editor</name>
+  <description>OptaPlanner Workbench - Guided Rule Editor</description>
 
   <modules>
-    <module>optaplanner-wb-domain-editor</module>
-    <module>optaplanner-wb-guided-rule-editor</module>
-    <module>optaplanner-wb-solver-editor</module>
+    <module>optaplanner-wb-guided-rule-editor-api</module>
+    <module>optaplanner-wb-guided-rule-editor-client</module>
+    <module>optaplanner-wb-guided-rule-editor-backend</module>
   </modules>
 
 </project>

--- a/optaplanner-wb-webapp/pom.xml
+++ b/optaplanner-wb-webapp/pom.xml
@@ -834,6 +834,20 @@
 
     <dependency>
       <groupId>org.optaplanner</groupId>
+      <artifactId>optaplanner-wb-guided-rule-editor-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.optaplanner</groupId>
+      <artifactId>optaplanner-wb-guided-rule-editor-client</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.optaplanner</groupId>
+      <artifactId>optaplanner-wb-guided-rule-editor-backend</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.optaplanner</groupId>
       <artifactId>optaplanner-wb-domain-editor-api</artifactId>
     </dependency>
     <dependency>
@@ -1078,6 +1092,8 @@
             <compileSourcesArtifact>org.optaplanner:optaplanner-wb-upstream-model</compileSourcesArtifact>
             <compileSourcesArtifact>org.optaplanner:optaplanner-wb-solver-editor-api</compileSourcesArtifact>
             <compileSourcesArtifact>org.optaplanner:optaplanner-wb-solver-editor-client</compileSourcesArtifact>
+            <compileSourcesArtifact>org.optaplanner:optaplanner-wb-guided-rule-editor-api</compileSourcesArtifact>
+            <compileSourcesArtifact>org.optaplanner:optaplanner-wb-guided-rule-editor-client</compileSourcesArtifact>
             <compileSourcesArtifact>org.optaplanner:optaplanner-wb-domain-editor-api</compileSourcesArtifact>
             <compileSourcesArtifact>org.optaplanner:optaplanner-wb-domain-editor-client</compileSourcesArtifact>
 

--- a/optaplanner-wb-webapp/src/main/resources/org/optaplanner/workbench/OptaPlannerWorkbench.gwt.xml
+++ b/optaplanner-wb-webapp/src/main/resources/org/optaplanner/workbench/OptaPlannerWorkbench.gwt.xml
@@ -47,6 +47,8 @@
   <!-- OptaPlanner Workbench Screens -->
   <inherits name="org.optaplanner.workbench.screens.solver.OptaPlannerWorkbenchSolverEditorAPI"/>
   <inherits name="org.optaplanner.workbench.screens.solver.OptaPlannerWorkbenchSolverEditorClient"/>
+  <inherits name="org.optaplanner.workbench.screens.guidedrule.OptaPlannerWorkbenchGuidedRuleEditorAPI"/>
+  <inherits name="org.optaplanner.workbench.screens.guidedrule.OptaPlannerWorkbenchGuidedRuleEditorClient"/>
   <inherits name="org.optaplanner.workbench.screens.domaineditor.OptaPlannerWorkbenchDomainEditorAPI"/>
   <inherits name="org.optaplanner.workbench.screens.domaineditor.OptaPlannerWorkbenchDomainEditorClient"/>
 


### PR DESCRIPTION
Initial implementation of custom actions in the Guided Rule Editor. The feature is used by OptaPlanner to add constraint matches, which modify score, to the RHS of rules.

Note this hasn't been polished yet, there might be some duplication, lack of test coverage and i18n, just wanted to get ack on the proposed architecture.

Backend side:
Parsing is done on drools side. I defined RuleModelIActionPersistenceExtension interface (https://github.com/kiegroup/drools/pull/1178/files#diff-d6143d36b2f566579c59149d7feef3dcR5). The implementations are able to transform between String <-> IAction. There's no injection on drools side, therefore I extended RuleModelPersistence interface (https://github.com/kiegroup/drools/pull/1178/files#diff-94970a10523a7f4a5ed135f78a15ef92R26) and added marshal/unmarshal methods which support using custom (un)marshalers. If none are plugged in, unknown lines are interpreted as FreeFormLines. This way the extensions can be used in Guided Rule Editor and be ignored in Decision Tables.
OptaPlanner defines custom IAction implementations (e.g. ActionHardConstraintMatch) and persistence extension, which is able to handle given IAction (e.g. HardConstraintMatchPersistenceExtension).

Client side:
Created RuleModellerActionPlugin (https://github.com/kiegroup/drools-wb/pull/433/files#diff-5d1cd81ff0c6ee1457a48d636716ad77R26) interface in drools-wb. CDI-driven implementations (e.g. https://github.com/kiegroup/optaplanner-wb/pull/143/files#diff-7ce18f6758a7b2eff08c09046e9b0bb8R37) are able to handle custom IActions. They're responsible for creating widget and adding item(s) to RHS action list. I implemented list addition in an asynchronous way, as implementations may wish to call backend services before deciding on adding the item to the list (e.g. OptaPlanner checks whether scoreHolder global is defined within a project). Widgets are GWT driven due to fact one needs to extend RuleModellerWidget abstract parent. I might try to extract at least widget bodies to errai templates if needed.

@manstis ( cc @ge0ffrey )Can you please add some thoughts regarding the design? Thanks!

Part of:
https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/425
https://github.com/kiegroup/drools/pull/1178
https://github.com/kiegroup/drools-wb/pull/433
https://github.com/kiegroup/optaplanner-wb/pull/143
https://github.com/kiegroup/kie-wb-distributions/pull/486