### PR TITLE
PLANNER-784: Workbench: AbstractSolution.score can't be marshaled when using JAXB

### DIFF
--- a/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-api/src/main/java/org/optaplanner/workbench/screens/domaineditor/model/PlannerDomainAnnotations.java
+++ b/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-api/src/main/java/org/optaplanner/workbench/screens/domaineditor/model/PlannerDomainAnnotations.java
@@ -30,4 +30,9 @@ public class PlannerDomainAnnotations {
 
     public static final String PLANNING_ENTITY_COLLECTION_PROPERTY_ANNOTATION = "org.optaplanner.core.api.domain.solution.PlanningEntityCollectionProperty";
 
+    public static final String JAXB_XML_JAVA_TYPE_ADAPTER_ANNOTATION = "javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter";
+
+    public static final String JAXB_XML_ROOT_ELEMENT = "javax.xml.bind.annotation.XmlRootElement";
+
+    public static final String JAXB_XML_ACCESSOR_TYPE = "javax.xml.bind.annotation.XmlAccessorType";
 }

--- a/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-backend/pom.xml
+++ b/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-backend/pom.xml
@@ -35,11 +35,6 @@
 
     <!-- dependencies added because of new illegal transitive dependency check -->
     <dependency>
-      <groupId>org.drools</groupId>
-      <artifactId>drools-core</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>org.guvnor</groupId>
       <artifactId>guvnor-project-api</artifactId>
     </dependency>

--- a/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-backend/src/main/java/org/optaplanner/workbench/screens/domaineditor/backend/server/PlannerDomainHandler.java
+++ b/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-backend/src/main/java/org/optaplanner/workbench/screens/domaineditor/backend/server/PlannerDomainHandler.java
@@ -21,6 +21,9 @@ import java.util.List;
 import java.util.Map;
 import javax.annotation.Generated;
 import javax.enterprise.context.ApplicationScoped;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
 import org.kie.workbench.common.screens.datamodeller.backend.server.handler.DomainHandler;
 import org.kie.workbench.common.services.datamodeller.core.AnnotationDefinition;
@@ -43,20 +46,24 @@ public class PlannerDomainHandler implements DomainHandler {
 
     static {
         //Planner managed annotations
-        domainAnnotations.add( DriverUtils.buildAnnotationDefinition( PlanningEntity.class ) );
-        domainAnnotations.add( DriverUtils.buildAnnotationDefinition( PlanningScore.class ) );
-        domainAnnotations.add( DriverUtils.buildAnnotationDefinition( PlanningSolution.class ) );
-        domainAnnotations.add( DriverUtils.buildAnnotationDefinition( PlanningVariable.class ) );
-        domainAnnotations.add( DriverUtils.buildAnnotationDefinition( ValueRangeProvider.class ) );
-        domainAnnotations.add( DriverUtils.buildAnnotationDefinition( PlanningEntityCollectionProperty.class ) );
-        domainAnnotations.add( DriverUtils.buildAnnotationDefinition( ComparatorDefinition.class ) );
-        domainAnnotations.add( DriverUtils.buildAnnotationDefinition( ComparatorObjectPropertyPath.class ) );
-        domainAnnotations.add( DriverUtils.buildAnnotationDefinition( ComparatorObjectProperty.class ) );
-        domainAnnotations.add( DriverUtils.buildAnnotationDefinition( Generated.class ) );
+        domainAnnotations.add(DriverUtils.buildAnnotationDefinition(PlanningEntity.class));
+        domainAnnotations.add(DriverUtils.buildAnnotationDefinition(PlanningScore.class));
+        domainAnnotations.add(DriverUtils.buildAnnotationDefinition(PlanningSolution.class));
+        domainAnnotations.add(DriverUtils.buildAnnotationDefinition(PlanningVariable.class));
+        domainAnnotations.add(DriverUtils.buildAnnotationDefinition(ValueRangeProvider.class));
+        domainAnnotations.add(DriverUtils.buildAnnotationDefinition(PlanningEntityCollectionProperty.class));
+        domainAnnotations.add(DriverUtils.buildAnnotationDefinition(ComparatorDefinition.class));
+        domainAnnotations.add(DriverUtils.buildAnnotationDefinition(ComparatorObjectPropertyPath.class));
+        domainAnnotations.add(DriverUtils.buildAnnotationDefinition(ComparatorObjectProperty.class));
+        domainAnnotations.add(DriverUtils.buildAnnotationDefinition(Generated.class));
+        domainAnnotations.add(DriverUtils.buildAnnotationDefinition(XmlJavaTypeAdapter.class));
+        domainAnnotations.add(DriverUtils.buildAnnotationDefinition(XmlRootElement.class));
+        domainAnnotations.add(DriverUtils.buildAnnotationDefinition(XmlAccessorType.class));
     }
 
     @Override
-    public void setDefaultValues( DataObject dataObject, Map<String, Object> options ) {
+    public void setDefaultValues(DataObject dataObject,
+                                 Map<String, Object> options) {
         //This domain doesn't do any by default processing at data object creation time
     }
 
@@ -64,5 +71,4 @@ public class PlannerDomainHandler implements DomainHandler {
     public List<AnnotationDefinition> getManagedAnnotations() {
         return domainAnnotations;
     }
-
 }

--- a/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-backend/src/main/java/org/optaplanner/workbench/screens/domaineditor/backend/server/PlannerMethodFilter.java
+++ b/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-backend/src/main/java/org/optaplanner/workbench/screens/domaineditor/backend/server/PlannerMethodFilter.java
@@ -16,54 +16,36 @@
 
 package org.optaplanner.workbench.screens.domaineditor.backend.server;
 
-import java.util.HashSet;
-import java.util.Set;
 import javax.annotation.Generated;
 import javax.enterprise.context.ApplicationScoped;
 
 import org.jboss.forge.roaster.model.Method;
 import org.kie.workbench.common.services.datamodeller.driver.MethodFilter;
-import org.optaplanner.core.api.score.buildin.bendable.BendableScore;
-import org.optaplanner.core.api.score.buildin.bendablebigdecimal.BendableBigDecimalScore;
-import org.optaplanner.core.api.score.buildin.bendablelong.BendableLongScore;
 
 @ApplicationScoped
 public class PlannerMethodFilter implements MethodFilter {
 
-    private static Set<String> BENDABLE_SCORE_TYPES;
-
-    static {
-        BENDABLE_SCORE_TYPES = new HashSet<>();
-        BENDABLE_SCORE_TYPES.add( BendableScore.class.getName() );
-        BENDABLE_SCORE_TYPES.add( BendableScore.class.getSimpleName() );
-        BENDABLE_SCORE_TYPES.add( BendableLongScore.class.getName() );
-        BENDABLE_SCORE_TYPES.add( BendableLongScore.class.getSimpleName() );
-        BENDABLE_SCORE_TYPES.add( BendableBigDecimalScore.class.getName() );
-        BENDABLE_SCORE_TYPES.add( BendableBigDecimalScore.class.getSimpleName() );
-    }
-
     @Override
-    public boolean accept( Method<?, ?> method ) {
-        return !method.isConstructor() && method.getAnnotation( Generated.class ) != null
-                && ( isGetScoreMethod( method ) || isSetScoreMethod( method ) || isCompareMethod( method ) );
+    public boolean accept(Method<?, ?> method) {
+        return !method.isConstructor() && method.getAnnotation(Generated.class) != null
+                && (isGetScoreMethod(method) || isSetScoreMethod(method) || isCompareMethod(method));
     }
 
-    private boolean isGetScoreMethod( Method<?, ?> method ) {
-        return "getScore".equals( method.getName() )
-                && ( method.getParameters() == null || method.getParameters().isEmpty() )
-                && ( method.getReturnType() != null && BENDABLE_SCORE_TYPES.contains( method.getReturnType().getName() ) );
+    private boolean isGetScoreMethod(Method<?, ?> method) {
+        return "getScore".equals(method.getName())
+                && (method.getParameters() == null || method.getParameters().isEmpty())
+                && (method.getReturnType() != null);
     }
 
-    private boolean isSetScoreMethod( Method<?, ?> method ) {
-        return "setScore".equals( method.getName() )
-                && ( method.getParameters() != null && method.getParameters().size() == 1 && BENDABLE_SCORE_TYPES.contains( method.getParameters().get( 0 ).getType().getName() ) )
-                && ( method.getReturnType() == null || method.getReturnType().getName().equals( "void" ) );
+    private boolean isSetScoreMethod(Method<?, ?> method) {
+        return "setScore".equals(method.getName())
+                && (method.getParameters() != null && method.getParameters().size() == 1)
+                && (method.getReturnType() == null || method.getReturnType().getName().equals("void"));
     }
 
-    private boolean isCompareMethod( Method<?, ?> method ) {
-        return "compare".equals( method.getName() )
-                && ( method.getParameters() != null && method.getParameters().size() == 2 )
-                && ( method.getReturnType() != null && method.getReturnType().getName().equals( "int" ) );
+    private boolean isCompareMethod(Method<?, ?> method) {
+        return "compare".equals(method.getName())
+                && (method.getParameters() != null && method.getParameters().size() == 2)
+                && (method.getReturnType() != null && method.getReturnType().getName().equals("int"));
     }
-
 }

--- a/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-backend/src/main/java/org/optaplanner/workbench/screens/domaineditor/backend/server/helper/PlanningSolutionSaveHelper.java
+++ b/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-backend/src/main/java/org/optaplanner/workbench/screens/domaineditor/backend/server/helper/PlanningSolutionSaveHelper.java
@@ -43,7 +43,7 @@ import static org.optaplanner.workbench.screens.domaineditor.model.PlannerDomain
 @ApplicationScoped
 public class PlanningSolutionSaveHelper implements DataModelerSaveHelper {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger( PlanningSolutionSaveHelper.class );
+    private static final Logger LOGGER = LoggerFactory.getLogger(PlanningSolutionSaveHelper.class);
 
     private static final String SCORE_HOLDER = "scoreHolder";
 
@@ -65,12 +65,12 @@ public class PlanningSolutionSaveHelper implements DataModelerSaveHelper {
     }
 
     @Inject
-    public PlanningSolutionSaveHelper( @Named("ioStrategy") final IOService ioService,
-                                       final DataModelerService dataModelerService,
-                                       final GlobalsEditorService globalsEditorService,
-                                       final KieProjectService kieProjectService,
-                                       final ScoreHolderUtils scoreHolderUtils,
-                                       final MetadataService metadataService ) {
+    public PlanningSolutionSaveHelper(@Named("ioStrategy") final IOService ioService,
+                                      final DataModelerService dataModelerService,
+                                      final GlobalsEditorService globalsEditorService,
+                                      final KieProjectService kieProjectService,
+                                      final ScoreHolderUtils scoreHolderUtils,
+                                      final MetadataService metadataService) {
         this.ioService = ioService;
         this.dataModelerService = dataModelerService;
         this.globalsEditorService = globalsEditorService;
@@ -80,78 +80,77 @@ public class PlanningSolutionSaveHelper implements DataModelerSaveHelper {
     }
 
     @Override
-    public void postProcess( final Path sourcePath,
-                             final Path destinationPath ) {
+    public void postProcess(final Path sourcePath,
+                            final Path destinationPath) {
 
-        String dataObjectSource = ioService.readAllString( Paths.convert( destinationPath ) );
-        GenerationResult generationResult = dataModelerService.loadDataObject( destinationPath,
-                                                                               dataObjectSource,
-                                                                               destinationPath );
-        org.uberfire.java.nio.file.Path source = Paths.convert( kieProjectService.resolvePackage( sourcePath ).getPackageMainResourcesPath() );
-        org.uberfire.java.nio.file.Path sourcePackage = Files.isDirectory( source ) ? source : source.getParent();
+        String dataObjectSource = ioService.readAllString(Paths.convert(destinationPath));
+        GenerationResult generationResult = dataModelerService.loadDataObject(destinationPath,
+                                                                              dataObjectSource,
+                                                                              destinationPath);
+        org.uberfire.java.nio.file.Path source = Paths.convert(kieProjectService.resolvePackage(sourcePath).getPackageMainResourcesPath());
+        org.uberfire.java.nio.file.Path sourcePackage = Files.isDirectory(source) ? source : source.getParent();
 
-        String sourceSolutionFileName = sourcePath.getFileName().substring( 0,
-                                                                            sourcePath.getFileName().indexOf( "." ) );
-        org.uberfire.java.nio.file.Path sourceScoreHolderGlobalPath = sourcePackage.resolve( sourceSolutionFileName + SCORE_HOLDER_GLOBAL_FILE_SUFFIX );
+        String sourceSolutionFileName = sourcePath.getFileName().substring(0,
+                                                                           sourcePath.getFileName().indexOf("."));
+        org.uberfire.java.nio.file.Path sourceScoreHolderGlobalPath = sourcePackage.resolve(sourceSolutionFileName + SCORE_HOLDER_GLOBAL_FILE_SUFFIX);
 
-        if ( generationResult.hasErrors() ) {
-            LOGGER.warn( "Path " + destinationPath + " parsing as a data object has failed. Score holder global generation will be skipped." );
+        if (generationResult.hasErrors()) {
+            LOGGER.warn("Path " + destinationPath + " parsing as a data object has failed. Score holder global generation will be skipped.");
         } else {
             DataObject dataObject = generationResult.getDataObject();
-            if ( dataObject.getAnnotation( PLANNING_SOLUTION_ANNOTATION ) != null ) {
-                String sourceScoreTypeFqn = scoreHolderUtils.extractScoreTypeFqn( dataObject,
-                                                                                  destinationPath );
-                String scoreHolderTypeFqn = scoreHolderUtils.getScoreHolderTypeFqn( sourceScoreTypeFqn );
+            if (dataObject.getAnnotation(PLANNING_SOLUTION_ANNOTATION) != null) {
+                String sourceScoreTypeFqn = scoreHolderUtils.extractScoreTypeFqn(dataObject);
+                String scoreHolderTypeFqn = scoreHolderUtils.getScoreHolderTypeFqn(sourceScoreTypeFqn);
 
-                if ( scoreHolderTypeFqn == null ) {
-                    LOGGER.warn( "'scoreHolder' global variable will not be generated, as the selected score type is not supported" );
+                if (scoreHolderTypeFqn == null) {
+                    LOGGER.warn("'scoreHolder' global variable will not be generated, as the selected score type is not supported");
                     return;
                 }
 
-                if ( sourcePath.equals( destinationPath ) ) {
-                    boolean scoreHolderGlobalFileExists = ioService.exists( sourceScoreHolderGlobalPath );
+                if (sourcePath.equals(destinationPath)) {
+                    boolean scoreHolderGlobalFileExists = ioService.exists(sourceScoreHolderGlobalPath);
 
-                    if ( scoreHolderGlobalFileExists ) {
-                        GlobalsModel globalsModel = globalsEditorService.load( Paths.convert( sourceScoreHolderGlobalPath ) );
-                        globalsModel.setGlobals( Arrays.asList( new Global( SCORE_HOLDER,
-                                                                            scoreHolderTypeFqn ) ) );
-                        globalsEditorService.save( Paths.convert( sourceScoreHolderGlobalPath ),
-                                                   globalsModel,
-                                                   metadataService.getMetadata( Paths.convert( sourceScoreHolderGlobalPath ) ),
-                                                   "Auto generate scoreHolder global" );
+                    if (scoreHolderGlobalFileExists) {
+                        GlobalsModel globalsModel = globalsEditorService.load(Paths.convert(sourceScoreHolderGlobalPath));
+                        globalsModel.setGlobals(Arrays.asList(new Global(SCORE_HOLDER,
+                                                                         scoreHolderTypeFqn)));
+                        globalsEditorService.save(Paths.convert(sourceScoreHolderGlobalPath),
+                                                  globalsModel,
+                                                  metadataService.getMetadata(Paths.convert(sourceScoreHolderGlobalPath)),
+                                                  "Auto generate scoreHolder global");
                     } else {
-                        createScoreHolderGlobalFile( Paths.convert( sourcePackage ),
-                                                     scoreHolderTypeFqn,
-                                                     sourceSolutionFileName );
+                        createScoreHolderGlobalFile(Paths.convert(sourcePackage),
+                                                    scoreHolderTypeFqn,
+                                                    sourceSolutionFileName);
                     }
                 } else {
-                    org.uberfire.java.nio.file.Path destination = Paths.convert( kieProjectService.resolvePackage( destinationPath ).getPackageMainResourcesPath() );
-                    org.uberfire.java.nio.file.Path destinationPackage = Files.isDirectory( destination ) ? destination : destination.getParent();
+                    org.uberfire.java.nio.file.Path destination = Paths.convert(kieProjectService.resolvePackage(destinationPath).getPackageMainResourcesPath());
+                    org.uberfire.java.nio.file.Path destinationPackage = Files.isDirectory(destination) ? destination : destination.getParent();
 
-                    ioService.deleteIfExists( sourceScoreHolderGlobalPath );
+                    ioService.deleteIfExists(sourceScoreHolderGlobalPath);
 
-                    String destinationScoreHolderFileSimpleName = destinationPath.getFileName().substring( 0,
-                                                                                                           destinationPath.getFileName().indexOf( "." ) );
-                    createScoreHolderGlobalFile( Paths.convert( destinationPackage ),
-                                                 scoreHolderTypeFqn,
-                                                 destinationScoreHolderFileSimpleName );
+                    String destinationScoreHolderFileSimpleName = destinationPath.getFileName().substring(0,
+                                                                                                          destinationPath.getFileName().indexOf("."));
+                    createScoreHolderGlobalFile(Paths.convert(destinationPackage),
+                                                scoreHolderTypeFqn,
+                                                destinationScoreHolderFileSimpleName);
                 }
             } else {
-                ioService.deleteIfExists( sourceScoreHolderGlobalPath );
+                ioService.deleteIfExists(sourceScoreHolderGlobalPath);
             }
         }
     }
 
-    private void createScoreHolderGlobalFile( final Path folderPath,
-                                              final String scoreHolderTypeFqn,
-                                              final String solutionFileName ) {
+    private void createScoreHolderGlobalFile(final Path folderPath,
+                                             final String scoreHolderTypeFqn,
+                                             final String solutionFileName) {
         GlobalsModel globalsModel = new GlobalsModel();
-        globalsModel.setGlobals( Arrays.asList( new Global( SCORE_HOLDER,
-                                                            scoreHolderTypeFqn ) ) );
+        globalsModel.setGlobals(Arrays.asList(new Global(SCORE_HOLDER,
+                                                         scoreHolderTypeFqn)));
 
-        globalsEditorService.generate( folderPath,
-                                       solutionFileName + SCORE_HOLDER_GLOBAL_FILE_SUFFIX,
-                                       globalsModel,
-                                       "Auto generate Score holder global variable based on a @PlanningSolution " + solutionFileName );
+        globalsEditorService.generate(folderPath,
+                                      solutionFileName + SCORE_HOLDER_GLOBAL_FILE_SUFFIX,
+                                      globalsModel,
+                                      "Auto generate Score holder global variable based on a @PlanningSolution " + solutionFileName);
     }
 }

--- a/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-backend/src/main/java/org/optaplanner/workbench/screens/domaineditor/backend/server/validation/PlanningSolutionScoreHolderDeleteValidator.java
+++ b/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-backend/src/main/java/org/optaplanner/workbench/screens/domaineditor/backend/server/validation/PlanningSolutionScoreHolderDeleteValidator.java
@@ -28,9 +28,7 @@ import org.guvnor.common.services.shared.message.Level;
 import org.guvnor.common.services.shared.validation.model.ValidationMessage;
 import org.kie.workbench.common.screens.datamodeller.model.GenerationResult;
 import org.kie.workbench.common.screens.datamodeller.service.DataModelerService;
-import org.kie.workbench.common.services.backend.project.ProjectClassLoaderHelper;
 import org.kie.workbench.common.services.datamodeller.core.DataObject;
-import org.kie.workbench.common.services.shared.project.KieProjectService;
 import org.kie.workbench.common.services.shared.validation.DeleteValidator;
 import org.optaplanner.workbench.screens.domaineditor.validation.ScoreHolderGlobalToBeRemovedMessage;
 import org.optaplanner.workbench.screens.domaineditor.validation.ScoreHolderGlobalTypeNotRecognizedMessage;
@@ -55,52 +53,51 @@ public class PlanningSolutionScoreHolderDeleteValidator implements DeleteValidat
     private ScoreHolderUtils scoreHolderUtils;
 
     @Inject
-    public PlanningSolutionScoreHolderDeleteValidator( final DataModelerService dataModelerService,
-                                                       @Named("ioStrategy") final IOService ioService,
-                                                       final ScoreHolderUtils scoreHolderUtils ) {
+    public PlanningSolutionScoreHolderDeleteValidator(final DataModelerService dataModelerService,
+                                                      @Named("ioStrategy") final IOService ioService,
+                                                      final ScoreHolderUtils scoreHolderUtils) {
         this.dataModelerService = dataModelerService;
         this.ioService = ioService;
         this.scoreHolderUtils = scoreHolderUtils;
     }
 
     @Override
-    public Collection<ValidationMessage> validate( final Path dataObjectPath,
-                                                   final DataObject dataObject ) {
-        return validatePath( dataObjectPath );
+    public Collection<ValidationMessage> validate(final Path dataObjectPath,
+                                                  final DataObject dataObject) {
+        return validatePath(dataObjectPath);
     }
 
     @Override
-    public Collection<ValidationMessage> validate( final Path dataObjectPath ) {
-        return validatePath( dataObjectPath );
+    public Collection<ValidationMessage> validate(final Path dataObjectPath) {
+        return validatePath(dataObjectPath);
     }
 
-    private Collection<ValidationMessage> validatePath( final Path dataObjectPath ) {
-        if ( dataObjectPath != null ) {
-            String dataObjectSource = ioService.readAllString( Paths.convert( dataObjectPath ) );
-            GenerationResult generationResult = dataModelerService.loadDataObject( dataObjectPath,
-                                                                                   dataObjectSource,
-                                                                                   dataObjectPath );
-            if ( generationResult.hasErrors() ) {
+    private Collection<ValidationMessage> validatePath(final Path dataObjectPath) {
+        if (dataObjectPath != null) {
+            String dataObjectSource = ioService.readAllString(Paths.convert(dataObjectPath));
+            GenerationResult generationResult = dataModelerService.loadDataObject(dataObjectPath,
+                                                                                  dataObjectSource,
+                                                                                  dataObjectPath);
+            if (generationResult.hasErrors()) {
                 return Collections.emptyList();
             } else {
                 DataObject originalDataObject = generationResult.getDataObject();
 
-                if ( originalDataObject.getAnnotation( PLANNING_SOLUTION_ANNOTATION ) != null ) {
-                    String originalDataObjectScoreTypeFqn = scoreHolderUtils.extractScoreTypeFqn( originalDataObject,
-                                                                                                  dataObjectPath );
+                if (originalDataObject.getAnnotation(PLANNING_SOLUTION_ANNOTATION) != null) {
+                    String originalDataObjectScoreTypeFqn = scoreHolderUtils.extractScoreTypeFqn(originalDataObject);
 
-                    String originalDataObjectScoreHolderTypeFqn = scoreHolderUtils.getScoreHolderTypeFqn( originalDataObjectScoreTypeFqn );
+                    String originalDataObjectScoreHolderTypeFqn = scoreHolderUtils.getScoreHolderTypeFqn(originalDataObjectScoreTypeFqn);
 
-                    if ( originalDataObjectScoreHolderTypeFqn == null ) {
-                        return Arrays.asList( new ScoreHolderGlobalTypeNotRecognizedMessage( Level.WARNING ) );
+                    if (originalDataObjectScoreHolderTypeFqn == null) {
+                        return Arrays.asList(new ScoreHolderGlobalTypeNotRecognizedMessage(Level.WARNING));
                     }
 
-                    List<Path> scoreHolderGlobalUsages = dataModelerService.findClassUsages( dataObjectPath,
-                                                                                             originalDataObjectScoreHolderTypeFqn );
-                    if ( scoreHolderGlobalUsages.isEmpty() ) {
+                    List<Path> scoreHolderGlobalUsages = dataModelerService.findClassUsages(dataObjectPath,
+                                                                                            originalDataObjectScoreHolderTypeFqn);
+                    if (scoreHolderGlobalUsages.isEmpty()) {
                         return Collections.emptyList();
                     } else {
-                        return Arrays.asList( new ScoreHolderGlobalToBeRemovedMessage( Level.WARNING ) );
+                        return Arrays.asList(new ScoreHolderGlobalToBeRemovedMessage(Level.WARNING));
                     }
                 }
             }
@@ -109,7 +106,7 @@ public class PlanningSolutionScoreHolderDeleteValidator implements DeleteValidat
     }
 
     @Override
-    public boolean accept( final Path path ) {
-        return path.getFileName().endsWith( ".java" );
+    public boolean accept(final Path path) {
+        return path.getFileName().endsWith(".java");
     }
 }

--- a/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-backend/src/main/java/org/optaplanner/workbench/screens/domaineditor/backend/server/validation/PlanningSolutionScoreHolderSaveValidator.java
+++ b/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-backend/src/main/java/org/optaplanner/workbench/screens/domaineditor/backend/server/validation/PlanningSolutionScoreHolderSaveValidator.java
@@ -45,7 +45,7 @@ import static org.optaplanner.workbench.screens.domaineditor.model.PlannerDomain
  * <li>Is a Planning Solution and score type has changed.</li>
  * <li>Changes from a Planning Solution to a different data object type</li>
  * </ol>
- *
+ * <p>
  * Display warning message as the type of 'scoreHolder' global variable associated with a score type defined in the Planning Solution
  * will be changed (or the score holder global will be deleted) as a consequence. This potentially breaks all the rules where
  * the 'scoreHolder' global variable is referenced.
@@ -60,59 +60,57 @@ public class PlanningSolutionScoreHolderSaveValidator implements SaveValidator<D
     private ScoreHolderUtils scoreHolderUtils;
 
     @Inject
-    public PlanningSolutionScoreHolderSaveValidator( final DataModelerService dataModelerService,
-                                                     @Named("ioStrategy") final IOService ioService,
-                                                     final ScoreHolderUtils scoreHolderUtils ) {
+    public PlanningSolutionScoreHolderSaveValidator(final DataModelerService dataModelerService,
+                                                    @Named("ioStrategy") final IOService ioService,
+                                                    final ScoreHolderUtils scoreHolderUtils) {
         this.dataModelerService = dataModelerService;
         this.ioService = ioService;
         this.scoreHolderUtils = scoreHolderUtils;
     }
 
     @Override
-    public Collection<ValidationMessage> validate( final Path dataObjectPath,
-                                                   final DataObject dataObject ) {
-        if ( dataObjectPath != null ) {
-            String dataObjectSource = ioService.readAllString( Paths.convert( dataObjectPath ) );
-            GenerationResult generationResult = dataModelerService.loadDataObject( dataObjectPath,
-                                                                                   dataObjectSource,
-                                                                                   dataObjectPath );
-            if ( generationResult.hasErrors() ) {
+    public Collection<ValidationMessage> validate(final Path dataObjectPath,
+                                                  final DataObject dataObject) {
+        if (dataObjectPath != null) {
+            String dataObjectSource = ioService.readAllString(Paths.convert(dataObjectPath));
+            GenerationResult generationResult = dataModelerService.loadDataObject(dataObjectPath,
+                                                                                  dataObjectSource,
+                                                                                  dataObjectPath);
+            if (generationResult.hasErrors()) {
                 return Collections.emptyList();
             } else {
                 DataObject originalDataObject = generationResult.getDataObject();
 
-                if ( originalDataObject.getAnnotation( PLANNING_SOLUTION_ANNOTATION ) != null ) {
-                    String originalDataObjectScoreTypeFqn = scoreHolderUtils.extractScoreTypeFqn( originalDataObject,
-                                                                                                  dataObjectPath );
+                if (originalDataObject.getAnnotation(PLANNING_SOLUTION_ANNOTATION) != null) {
+                    String originalDataObjectScoreTypeFqn = scoreHolderUtils.extractScoreTypeFqn(originalDataObject);
 
-                    String originalDataObjectScoreHolderTypeFqn = scoreHolderUtils.getScoreHolderTypeFqn( originalDataObjectScoreTypeFqn );
+                    String originalDataObjectScoreHolderTypeFqn = scoreHolderUtils.getScoreHolderTypeFqn(originalDataObjectScoreTypeFqn);
 
-                    if ( originalDataObjectScoreHolderTypeFqn == null ) {
-                        return Arrays.asList( new ScoreHolderGlobalTypeNotRecognizedMessage( Level.WARNING ) );
+                    if (originalDataObjectScoreHolderTypeFqn == null) {
+                        return Arrays.asList(new ScoreHolderGlobalTypeNotRecognizedMessage(Level.WARNING));
                     }
 
-                    List<Path> scoreHolderGlobalUsages = dataModelerService.findClassUsages( dataObjectPath,
-                                                                                             originalDataObjectScoreHolderTypeFqn );
-                    if ( scoreHolderGlobalUsages.isEmpty() ) {
+                    List<Path> scoreHolderGlobalUsages = dataModelerService.findClassUsages(dataObjectPath,
+                                                                                            originalDataObjectScoreHolderTypeFqn);
+                    if (scoreHolderGlobalUsages.isEmpty()) {
                         return Collections.emptyList();
                     } else {
                         // Planning Solution -> No Planning Solution
-                        if ( dataObject.getAnnotation( PLANNING_SOLUTION_ANNOTATION ) == null ) {
-                            return Arrays.asList( new ScoreHolderGlobalToBeRemovedMessage( Level.WARNING ) );
+                        if (dataObject.getAnnotation(PLANNING_SOLUTION_ANNOTATION) == null) {
+                            return Arrays.asList(new ScoreHolderGlobalToBeRemovedMessage(Level.WARNING));
                         } else {
                             // Planning Solution Type T1 -> Planning Solution Type T2
-                            String dataObjectScoreTypeFqn = scoreHolderUtils.extractScoreTypeFqn( dataObject,
-                                                                                                  dataObjectPath );
+                            String dataObjectScoreTypeFqn = scoreHolderUtils.extractScoreTypeFqn(dataObject);
 
-                            String dataObjectScoreHolderTypeFqn = scoreHolderUtils.getScoreHolderTypeFqn( dataObjectScoreTypeFqn );
+                            String dataObjectScoreHolderTypeFqn = scoreHolderUtils.getScoreHolderTypeFqn(dataObjectScoreTypeFqn);
 
-                            if ( dataObjectScoreHolderTypeFqn == null ) {
-                                return Arrays.asList( new ScoreHolderGlobalTypeNotRecognizedMessage( Level.WARNING ) );
+                            if (dataObjectScoreHolderTypeFqn == null) {
+                                return Arrays.asList(new ScoreHolderGlobalTypeNotRecognizedMessage(Level.WARNING));
                             }
 
                             // Planning solution has changed
-                            if ( !originalDataObjectScoreHolderTypeFqn.equals( dataObjectScoreHolderTypeFqn ) ) {
-                                return Arrays.asList( new ScoreHolderGlobalTypeToBeChangedMessage( Level.WARNING ) );
+                            if (!originalDataObjectScoreHolderTypeFqn.equals(dataObjectScoreHolderTypeFqn)) {
+                                return Arrays.asList(new ScoreHolderGlobalTypeToBeChangedMessage(Level.WARNING));
                             }
                         }
                     }
@@ -123,7 +121,7 @@ public class PlanningSolutionScoreHolderSaveValidator implements SaveValidator<D
     }
 
     @Override
-    public boolean accept( final Path path ) {
-        return path.getFileName().endsWith( ".java" );
+    public boolean accept(final Path path) {
+        return path.getFileName().endsWith(".java");
     }
 }

--- a/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-backend/src/main/java/org/optaplanner/workbench/screens/domaineditor/backend/server/validation/ScoreHolderUtils.java
+++ b/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-backend/src/main/java/org/optaplanner/workbench/screens/domaineditor/backend/server/validation/ScoreHolderUtils.java
@@ -16,18 +16,14 @@
 
 package org.optaplanner.workbench.screens.domaineditor.backend.server.validation;
 
-import java.util.Set;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
-import org.drools.core.base.ClassTypeResolver;
 import org.kie.workbench.common.services.backend.project.ProjectClassLoaderHelper;
 import org.kie.workbench.common.services.datamodeller.core.DataObject;
-import org.kie.workbench.common.services.shared.project.KieProject;
+import org.kie.workbench.common.services.datamodeller.core.ObjectProperty;
 import org.kie.workbench.common.services.shared.project.KieProjectService;
+import org.optaplanner.core.api.domain.solution.PlanningSolution;
 import org.optaplanner.core.api.score.buildin.bendable.BendableScore;
 import org.optaplanner.core.api.score.buildin.bendable.BendableScoreHolder;
 import org.optaplanner.core.api.score.buildin.bendablebigdecimal.BendableBigDecimalScore;
@@ -56,12 +52,9 @@ import org.optaplanner.core.api.score.buildin.simpledouble.SimpleDoubleScore;
 import org.optaplanner.core.api.score.buildin.simpledouble.SimpleDoubleScoreHolder;
 import org.optaplanner.core.api.score.buildin.simplelong.SimpleLongScore;
 import org.optaplanner.core.api.score.buildin.simplelong.SimpleLongScoreHolder;
-import org.uberfire.backend.vfs.Path;
 
 @ApplicationScoped
 public class ScoreHolderUtils {
-
-    private static final Pattern ABSTRACT_SOLUTION_PATTERN = Pattern.compile( "[\\w+\\.]*AbstractSolution<([\\w+\\.]*\\w+)>" );
 
     private KieProjectService kieProjectService;
 
@@ -71,67 +64,50 @@ public class ScoreHolderUtils {
     }
 
     @Inject
-    public ScoreHolderUtils( final KieProjectService kieProjectService,
-                             final ProjectClassLoaderHelper classLoaderHelper ) {
+    public ScoreHolderUtils(final KieProjectService kieProjectService,
+                            final ProjectClassLoaderHelper classLoaderHelper) {
         this.kieProjectService = kieProjectService;
         this.classLoaderHelper = classLoaderHelper;
     }
 
-    public String extractScoreTypeFqn( final DataObject dataObject,
-                                       final Path dataObjectPath ) {
-        Matcher matcher = ABSTRACT_SOLUTION_PATTERN.matcher( dataObject.getSuperClassName() );
-
-        if ( matcher.matches() ) {
-            String scoreType = matcher.group( 1 );
-
-            final String scoreTypeFqn;
-            if ( scoreType.contains( "." ) ) {
-                scoreTypeFqn = scoreType;
-            } else {
-                KieProject kieProject = kieProjectService.resolveProject( dataObjectPath );
-                Set<String> imports = dataObject.getImports().stream().map( i -> i.getName() ).collect( Collectors.toSet() );
-                ClassLoader projectClassLoader = classLoaderHelper.getProjectClassLoader( kieProject );
-                ClassTypeResolver classTypeResolver = new ClassTypeResolver( imports,
-                                                                             projectClassLoader );
-                try {
-                    scoreTypeFqn = classTypeResolver.getFullTypeName( scoreType );
-                } catch ( ClassNotFoundException e ) {
-                    return null;
-                }
+    public String extractScoreTypeFqn(final DataObject dataObject) {
+        if (dataObject.getAnnotation(PlanningSolution.class.getName()) != null) {
+            final ObjectProperty scoreObjectProperty = dataObject.getProperty("score");
+            if (scoreObjectProperty != null) {
+                return scoreObjectProperty.getClassName();
             }
-            return scoreTypeFqn;
         }
         return null;
     }
 
-    public String getScoreHolderTypeFqn( final String scoreTypeFqn ) {
-        if ( BendableScore.class.getName().equals( scoreTypeFqn ) ) {
+    public String getScoreHolderTypeFqn(final String scoreTypeFqn) {
+        if (BendableScore.class.getName().equals(scoreTypeFqn)) {
             return BendableScoreHolder.class.getName();
-        } else if ( BendableBigDecimalScore.class.getName().equals( scoreTypeFqn ) ) {
+        } else if (BendableBigDecimalScore.class.getName().equals(scoreTypeFqn)) {
             return BendableBigDecimalScoreHolder.class.getName();
-        } else if ( BendableLongScore.class.getName().equals( scoreTypeFqn ) ) {
+        } else if (BendableLongScore.class.getName().equals(scoreTypeFqn)) {
             return BendableLongScoreHolder.class.getName();
-        } else if ( HardMediumSoftScore.class.getName().equals( scoreTypeFqn ) ) {
+        } else if (HardMediumSoftScore.class.getName().equals(scoreTypeFqn)) {
             return HardMediumSoftScoreHolder.class.getName();
-        } else if ( HardMediumSoftBigDecimalScore.class.getName().equals( scoreTypeFqn ) ) {
+        } else if (HardMediumSoftBigDecimalScore.class.getName().equals(scoreTypeFqn)) {
             return HardMediumSoftBigDecimalScoreHolder.class.getName();
-        } else if ( HardMediumSoftLongScore.class.getName().equals( scoreTypeFqn ) ) {
+        } else if (HardMediumSoftLongScore.class.getName().equals(scoreTypeFqn)) {
             return HardMediumSoftLongScoreHolder.class.getName();
-        } else if ( HardSoftScore.class.getName().equals( scoreTypeFqn ) ) {
+        } else if (HardSoftScore.class.getName().equals(scoreTypeFqn)) {
             return HardSoftScoreHolder.class.getName();
-        } else if ( HardSoftBigDecimalScore.class.getName().equals( scoreTypeFqn ) ) {
+        } else if (HardSoftBigDecimalScore.class.getName().equals(scoreTypeFqn)) {
             return HardSoftBigDecimalScoreHolder.class.getName();
-        } else if ( HardSoftDoubleScore.class.getName().equals( scoreTypeFqn ) ) {
+        } else if (HardSoftDoubleScore.class.getName().equals(scoreTypeFqn)) {
             return HardSoftDoubleScoreHolder.class.getName();
-        } else if ( HardSoftLongScore.class.getName().equals( scoreTypeFqn ) ) {
+        } else if (HardSoftLongScore.class.getName().equals(scoreTypeFqn)) {
             return HardSoftLongScoreHolder.class.getName();
-        } else if ( SimpleScore.class.getName().equals( scoreTypeFqn ) ) {
+        } else if (SimpleScore.class.getName().equals(scoreTypeFqn)) {
             return SimpleScoreHolder.class.getName();
-        } else if ( SimpleBigDecimalScore.class.getName().equals( scoreTypeFqn ) ) {
+        } else if (SimpleBigDecimalScore.class.getName().equals(scoreTypeFqn)) {
             return SimpleBigDecimalScoreHolder.class.getName();
-        } else if ( SimpleDoubleScore.class.getName().equals( scoreTypeFqn ) ) {
+        } else if (SimpleDoubleScore.class.getName().equals(scoreTypeFqn)) {
             return SimpleDoubleScoreHolder.class.getName();
-        } else if ( SimpleLongScore.class.getName().equals( scoreTypeFqn ) ) {
+        } else if (SimpleLongScore.class.getName().equals(scoreTypeFqn)) {
             return SimpleLongScoreHolder.class.getName();
         }
         return null;

--- a/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-backend/src/test/java/org/optaplanner/workbench/screens/domaineditor/backend/PlanningSolutionScoreHolderDeleteValidatorTest.java
+++ b/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-backend/src/test/java/org/optaplanner/workbench/screens/domaineditor/backend/PlanningSolutionScoreHolderDeleteValidatorTest.java
@@ -64,99 +64,97 @@ public class PlanningSolutionScoreHolderDeleteValidatorTest {
 
     @Before
     public void setUp() {
-        validator = new PlanningSolutionScoreHolderDeleteValidator( dataModelerService,
-                                                                    ioService,
-                                                                    scoreHolderUtils );
+        validator = new PlanningSolutionScoreHolderDeleteValidator(dataModelerService,
+                                                                   ioService,
+                                                                   scoreHolderUtils);
     }
 
     @Test
     public void planningSolution() {
-        Path dataObjectPath = PathFactory.newPath( "Test.java",
-                                                   "file:///dataObjects" );
-        when( ioService.readAllString( Paths.convert( dataObjectPath ) ) ).thenReturn( "testResult" );
+        Path dataObjectPath = PathFactory.newPath("Test.java",
+                                                  "file:///dataObjects");
+        when(ioService.readAllString(Paths.convert(dataObjectPath))).thenReturn("testResult");
 
-        DataObject originalDataObject = new DataObjectImpl( "test",
-                                                            "Test" );
-        originalDataObject.addAnnotation( new AnnotationImpl( DriverUtils.buildAnnotationDefinition( PlanningSolution.class ) ) );
+        DataObject originalDataObject = new DataObjectImpl("test",
+                                                           "Test");
+        originalDataObject.addAnnotation(new AnnotationImpl(DriverUtils.buildAnnotationDefinition(PlanningSolution.class)));
 
         GenerationResult generationResult = new GenerationResult();
-        generationResult.setDataObject( originalDataObject );
-        when( dataModelerService.loadDataObject( any(),
-                                                 anyString(),
-                                                 any() ) ).thenReturn( generationResult );
+        generationResult.setDataObject(originalDataObject);
+        when(dataModelerService.loadDataObject(any(),
+                                               anyString(),
+                                               any())).thenReturn(generationResult);
 
-        when( scoreHolderUtils.extractScoreTypeFqn( originalDataObject,
-                                                    dataObjectPath ) ).thenReturn( HardSoftScore.class.getName() );
-        when( scoreHolderUtils.getScoreHolderTypeFqn( HardSoftScore.class.getName() ) ).thenReturn( HardSoftScoreHolder.class.getName() );
+        when(scoreHolderUtils.extractScoreTypeFqn(originalDataObject)).thenReturn(HardSoftScore.class.getName());
+        when(scoreHolderUtils.getScoreHolderTypeFqn(HardSoftScore.class.getName())).thenReturn(HardSoftScoreHolder.class.getName());
 
-        when( dataModelerService.findClassUsages( dataObjectPath,
-                                                  HardSoftScoreHolder.class.getName() ) ).thenReturn( Arrays.asList( mock( Path.class ) ) );
+        when(dataModelerService.findClassUsages(dataObjectPath,
+                                                HardSoftScoreHolder.class.getName())).thenReturn(Arrays.asList(mock(Path.class)));
 
-        DataObject updatedDataObject = new DataObjectImpl( "test",
-                                                           "Test" );
-        updatedDataObject.addAnnotation( new AnnotationImpl( DriverUtils.buildAnnotationDefinition( PlanningSolution.class ) ) );
+        DataObject updatedDataObject = new DataObjectImpl("test",
+                                                          "Test");
+        updatedDataObject.addAnnotation(new AnnotationImpl(DriverUtils.buildAnnotationDefinition(PlanningSolution.class)));
 
-        Collection<ValidationMessage> result = validator.validate( dataObjectPath,
-                                                                   updatedDataObject );
-        assertEquals( 1,
-                      result.size() );
+        Collection<ValidationMessage> result = validator.validate(dataObjectPath,
+                                                                  updatedDataObject);
+        assertEquals(1,
+                     result.size());
 
         ValidationMessage message = result.iterator().next();
-        assertTrue( message instanceof ScoreHolderGlobalToBeRemovedMessage );
+        assertTrue(message instanceof ScoreHolderGlobalToBeRemovedMessage);
     }
 
     @Test
     public void notAPlanningSolution() {
-        Path dataObjectPath = PathFactory.newPath( "Test.java",
-                                                   "file:///dataObjects" );
-        when( ioService.readAllString( Paths.convert( dataObjectPath ) ) ).thenReturn( "testResult" );
+        Path dataObjectPath = PathFactory.newPath("Test.java",
+                                                  "file:///dataObjects");
+        when(ioService.readAllString(Paths.convert(dataObjectPath))).thenReturn("testResult");
 
-        DataObject originalDataObject = new DataObjectImpl( "test",
-                                                            "Test" );
+        DataObject originalDataObject = new DataObjectImpl("test",
+                                                           "Test");
 
         GenerationResult generationResult = new GenerationResult();
-        generationResult.setDataObject( originalDataObject );
-        when( dataModelerService.loadDataObject( any(),
-                                                 anyString(),
-                                                 any() ) ).thenReturn( generationResult );
+        generationResult.setDataObject(originalDataObject);
+        when(dataModelerService.loadDataObject(any(),
+                                               anyString(),
+                                               any())).thenReturn(generationResult);
 
-        DataObject updatedDataObject = new DataObjectImpl( "test",
-                                                           "Test" );
+        DataObject updatedDataObject = new DataObjectImpl("test",
+                                                          "Test");
 
-        Collection<ValidationMessage> result = validator.validate( dataObjectPath,
-                                                                   updatedDataObject );
-        assertTrue( result.isEmpty() );
+        Collection<ValidationMessage> result = validator.validate(dataObjectPath,
+                                                                  updatedDataObject);
+        assertTrue(result.isEmpty());
     }
 
     @Test
     public void scoreHolderTypeNotRecognized() {
-        Path dataObjectPath = PathFactory.newPath( "Test.java",
-                                                   "file:///dataObjects" );
-        when( ioService.readAllString( Paths.convert( dataObjectPath ) ) ).thenReturn( "testResult" );
+        Path dataObjectPath = PathFactory.newPath("Test.java",
+                                                  "file:///dataObjects");
+        when(ioService.readAllString(Paths.convert(dataObjectPath))).thenReturn("testResult");
 
-        DataObject originalDataObject = new DataObjectImpl( "test",
-                                                            "Test" );
-        originalDataObject.addAnnotation( new AnnotationImpl( DriverUtils.buildAnnotationDefinition( PlanningSolution.class ) ) );
+        DataObject originalDataObject = new DataObjectImpl("test",
+                                                           "Test");
+        originalDataObject.addAnnotation(new AnnotationImpl(DriverUtils.buildAnnotationDefinition(PlanningSolution.class)));
 
         GenerationResult generationResult = new GenerationResult();
-        generationResult.setDataObject( originalDataObject );
-        when( dataModelerService.loadDataObject( any(),
-                                                 anyString(),
-                                                 any() ) ).thenReturn( generationResult );
+        generationResult.setDataObject(originalDataObject);
+        when(dataModelerService.loadDataObject(any(),
+                                               anyString(),
+                                               any())).thenReturn(generationResult);
 
-        when( scoreHolderUtils.extractScoreTypeFqn( originalDataObject,
-                                                    dataObjectPath ) ).thenReturn( "UnknownScoreClassName" );
-        when( scoreHolderUtils.getScoreHolderTypeFqn( "UnknownScoreClassName" ) ).thenReturn( null );
+        when(scoreHolderUtils.extractScoreTypeFqn(originalDataObject)).thenReturn("UnknownScoreClassName");
+        when(scoreHolderUtils.getScoreHolderTypeFqn("UnknownScoreClassName")).thenReturn(null);
 
-        DataObject updatedDataObject = new DataObjectImpl( "test",
-                                                           "Test" );
+        DataObject updatedDataObject = new DataObjectImpl("test",
+                                                          "Test");
 
-        Collection<ValidationMessage> result = validator.validate( dataObjectPath,
-                                                                   updatedDataObject );
-        assertEquals( 1,
-                      result.size() );
+        Collection<ValidationMessage> result = validator.validate(dataObjectPath,
+                                                                  updatedDataObject);
+        assertEquals(1,
+                     result.size());
 
         ValidationMessage message = result.iterator().next();
-        assertTrue( message instanceof ScoreHolderGlobalTypeNotRecognizedMessage );
+        assertTrue(message instanceof ScoreHolderGlobalTypeNotRecognizedMessage);
     }
 }

--- a/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-backend/src/test/java/org/optaplanner/workbench/screens/domaineditor/backend/PlanningSolutionScoreHolderSaveValidatorTest.java
+++ b/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-backend/src/test/java/org/optaplanner/workbench/screens/domaineditor/backend/PlanningSolutionScoreHolderSaveValidatorTest.java
@@ -37,7 +37,6 @@ import org.optaplanner.core.api.score.buildin.hardsoft.HardSoftScore;
 import org.optaplanner.core.api.score.buildin.hardsoft.HardSoftScoreHolder;
 import org.optaplanner.core.api.score.buildin.simple.SimpleScore;
 import org.optaplanner.core.api.score.buildin.simple.SimpleScoreHolder;
-import org.optaplanner.core.impl.domain.solution.AbstractSolution;
 import org.optaplanner.workbench.screens.domaineditor.backend.server.validation.PlanningSolutionScoreHolderSaveValidator;
 import org.optaplanner.workbench.screens.domaineditor.backend.server.validation.ScoreHolderUtils;
 import org.optaplanner.workbench.screens.domaineditor.validation.ScoreHolderGlobalTypeToBeChangedMessage;
@@ -67,117 +66,112 @@ public class PlanningSolutionScoreHolderSaveValidatorTest {
 
     @Before
     public void setUp() {
-        validator = new PlanningSolutionScoreHolderSaveValidator( dataModelerService,
-                                                                  ioService,
-                                                                  scoreHolderUtils );
+        validator = new PlanningSolutionScoreHolderSaveValidator(dataModelerService,
+                                                                 ioService,
+                                                                 scoreHolderUtils);
     }
 
     @Test
     public void scoreTypeChanged() {
-        Path dataObjectPath = PathFactory.newPath( "Test.java",
-                                                   "file:///dataObjects" );
-        when( ioService.readAllString( Paths.convert( dataObjectPath ) ) ).thenReturn( "testResult" );
+        Path dataObjectPath = PathFactory.newPath("Test.java",
+                                                  "file:///dataObjects");
+        when(ioService.readAllString(Paths.convert(dataObjectPath))).thenReturn("testResult");
 
-        DataObject originalDataObject = createDataObject( HardSoftScore.class );
+        DataObject originalDataObject = createDataObject(HardSoftScore.class);
         GenerationResult generationResult = new GenerationResult();
-        generationResult.setDataObject( originalDataObject );
-        when( dataModelerService.loadDataObject( any(),
-                                                 anyString(),
-                                                 any() ) ).thenReturn( generationResult );
-        when( scoreHolderUtils.extractScoreTypeFqn( originalDataObject,
-                                                    dataObjectPath ) ).thenReturn( HardSoftScore.class.getName() );
-        when( scoreHolderUtils.getScoreHolderTypeFqn( HardSoftScore.class.getName() ) ).thenReturn( HardSoftScoreHolder.class.getName() );
+        generationResult.setDataObject(originalDataObject);
+        when(dataModelerService.loadDataObject(any(),
+                                               anyString(),
+                                               any())).thenReturn(generationResult);
+        when(scoreHolderUtils.extractScoreTypeFqn(originalDataObject)).thenReturn(HardSoftScore.class.getName());
+        when(scoreHolderUtils.getScoreHolderTypeFqn(HardSoftScore.class.getName())).thenReturn(HardSoftScoreHolder.class.getName());
 
-        when( dataModelerService.findClassUsages( dataObjectPath,
-                                                  HardSoftScoreHolder.class.getName() ) ).thenReturn( Arrays.asList( mock( Path.class ) ) );
+        when(dataModelerService.findClassUsages(dataObjectPath,
+                                                HardSoftScoreHolder.class.getName())).thenReturn(Arrays.asList(mock(Path.class)));
 
-        DataObject updatedDataObject = createDataObject( SimpleScore.class );
-        when( scoreHolderUtils.extractScoreTypeFqn( updatedDataObject,
-                                                    dataObjectPath ) ).thenReturn( SimpleScore.class.getName() );
-        when( scoreHolderUtils.getScoreHolderTypeFqn( SimpleScore.class.getName() ) ).thenReturn( SimpleScoreHolder.class.getName() );
+        DataObject updatedDataObject = createDataObject(SimpleScore.class);
+        when(scoreHolderUtils.extractScoreTypeFqn(updatedDataObject)).thenReturn(SimpleScore.class.getName());
+        when(scoreHolderUtils.getScoreHolderTypeFqn(SimpleScore.class.getName())).thenReturn(SimpleScoreHolder.class.getName());
 
-        Collection<ValidationMessage> result = validator.validate( dataObjectPath,
-                                                                   updatedDataObject );
-        assertEquals( 1,
-                      result.size() );
+        Collection<ValidationMessage> result = validator.validate(dataObjectPath,
+                                                                  updatedDataObject);
+        assertEquals(1,
+                     result.size());
 
         ValidationMessage message = result.iterator().next();
-        assertTrue( message instanceof ScoreHolderGlobalTypeToBeChangedMessage );
+        assertTrue(message instanceof ScoreHolderGlobalTypeToBeChangedMessage);
     }
 
     @Test
     public void dataObjectToAPlanningSolution() {
-        Path dataObjectPath = PathFactory.newPath( "Test.java",
-                                                   "file:///dataObjects" );
-        when( ioService.readAllString( Paths.convert( dataObjectPath ) ) ).thenReturn( "testResult" );
+        Path dataObjectPath = PathFactory.newPath("Test.java",
+                                                  "file:///dataObjects");
+        when(ioService.readAllString(Paths.convert(dataObjectPath))).thenReturn("testResult");
 
-        DataObject originalDataObject = createDataObject( null );
+        DataObject originalDataObject = createDataObject(null);
         GenerationResult generationResult = new GenerationResult();
-        generationResult.setDataObject( originalDataObject );
-        when( dataModelerService.loadDataObject( any(),
-                                                 anyString(),
-                                                 any() ) ).thenReturn( generationResult );
+        generationResult.setDataObject(originalDataObject);
+        when(dataModelerService.loadDataObject(any(),
+                                               anyString(),
+                                               any())).thenReturn(generationResult);
 
-        DataObject updatedDataObject = createDataObject( SimpleScore.class );
+        DataObject updatedDataObject = createDataObject(SimpleScore.class);
 
-        Collection<ValidationMessage> result = validator.validate( dataObjectPath,
-                                                                   updatedDataObject );
-        assertTrue( result.isEmpty() );
+        Collection<ValidationMessage> result = validator.validate(dataObjectPath,
+                                                                  updatedDataObject);
+        assertTrue(result.isEmpty());
     }
 
     @Test
     public void dataObjectToADataObject() {
-        Path dataObjectPath = PathFactory.newPath( "Test.java",
-                                                   "file:///dataObjects" );
-        when( ioService.readAllString( Paths.convert( dataObjectPath ) ) ).thenReturn( "testResult" );
+        Path dataObjectPath = PathFactory.newPath("Test.java",
+                                                  "file:///dataObjects");
+        when(ioService.readAllString(Paths.convert(dataObjectPath))).thenReturn("testResult");
 
-        DataObject originalDataObject = createDataObject( null );
+        DataObject originalDataObject = createDataObject(null);
         GenerationResult generationResult = new GenerationResult();
-        generationResult.setDataObject( originalDataObject );
-        when( dataModelerService.loadDataObject( any(),
-                                                 anyString(),
-                                                 any() ) ).thenReturn( generationResult );
+        generationResult.setDataObject(originalDataObject);
+        when(dataModelerService.loadDataObject(any(),
+                                               anyString(),
+                                               any())).thenReturn(generationResult);
 
-        DataObject updatedDataObject = createDataObject( null );
+        DataObject updatedDataObject = createDataObject(null);
 
-        Collection<ValidationMessage> result = validator.validate( dataObjectPath,
-                                                                   updatedDataObject );
-        assertTrue( result.isEmpty() );
+        Collection<ValidationMessage> result = validator.validate(dataObjectPath,
+                                                                  updatedDataObject);
+        assertTrue(result.isEmpty());
     }
 
     @Test
     public void scoreHolderTypeNotRecognized() {
-        Path dataObjectPath = PathFactory.newPath( "Test.java",
-                                                   "file:///dataObjects" );
-        when( ioService.readAllString( Paths.convert( dataObjectPath ) ) ).thenReturn( "testResult" );
+        Path dataObjectPath = PathFactory.newPath("Test.java",
+                                                  "file:///dataObjects");
+        when(ioService.readAllString(Paths.convert(dataObjectPath))).thenReturn("testResult");
 
-        DataObject originalDataObject = createDataObject( HardSoftScore.class );
+        DataObject originalDataObject = createDataObject(HardSoftScore.class);
         GenerationResult generationResult = new GenerationResult();
-        generationResult.setDataObject( originalDataObject );
-        when( dataModelerService.loadDataObject( any(),
-                                                 anyString(),
-                                                 any() ) ).thenReturn( generationResult );
-        when( scoreHolderUtils.extractScoreTypeFqn( originalDataObject,
-                                                    dataObjectPath ) ).thenReturn( HardSoftScore.class.getName() );
-        when( scoreHolderUtils.getScoreHolderTypeFqn( HardSoftScore.class.getName() ) ).thenReturn( HardSoftScoreHolder.class.getName() );
+        generationResult.setDataObject(originalDataObject);
+        when(dataModelerService.loadDataObject(any(),
+                                               anyString(),
+                                               any())).thenReturn(generationResult);
+        when(scoreHolderUtils.extractScoreTypeFqn(originalDataObject)).thenReturn(HardSoftScore.class.getName());
+        when(scoreHolderUtils.getScoreHolderTypeFqn(HardSoftScore.class.getName())).thenReturn(HardSoftScoreHolder.class.getName());
 
-        when( dataModelerService.findClassUsages( dataObjectPath,
-                                                  HardSoftScoreHolder.class.getName() ) ).thenReturn( Arrays.asList( mock( Path.class ) ) );
+        when(dataModelerService.findClassUsages(dataObjectPath,
+                                                HardSoftScoreHolder.class.getName())).thenReturn(Arrays.asList(mock(Path.class)));
 
-        DataObject updatedDataObject = createDataObject( SimpleScore.class );
-        when( scoreHolderUtils.extractScoreTypeFqn( updatedDataObject,
-                                                    dataObjectPath ) ).thenReturn( "UnknownScoreClassName" );
-        when( scoreHolderUtils.getScoreHolderTypeFqn( "UnknownScoreClassName" ) ).thenReturn( null );
+        DataObject updatedDataObject = createDataObject(SimpleScore.class);
+        when(scoreHolderUtils.extractScoreTypeFqn(updatedDataObject)).thenReturn("UnknownScoreClassName");
+        when(scoreHolderUtils.getScoreHolderTypeFqn("UnknownScoreClassName")).thenReturn(null);
     }
 
-    private DataObject createDataObject( Class<? extends Score> scoreClass ) {
-        DataObject dataObject = new DataObjectImpl( "test",
-                                                    "Test" );
-        if ( scoreClass != null ) {
-            dataObject.addAnnotation( new AnnotationImpl( DriverUtils.buildAnnotationDefinition( PlanningSolution.class ) ) );
-            dataObject.setSuperClassName( String.format( "%s<%s>",
-                                                         AbstractSolution.class.getName(),
-                                                         scoreClass.getName() ) );
+    private DataObject createDataObject(Class<? extends Score> scoreClass) {
+        DataObject dataObject = new DataObjectImpl("test",
+                                                   "Test");
+        if (scoreClass != null) {
+            dataObject.addAnnotation(new AnnotationImpl(DriverUtils.buildAnnotationDefinition(PlanningSolution.class)));
+            dataObject.addProperty("score",
+                                   scoreClass.getName());
         }
         return dataObject;
     }

--- a/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-backend/src/test/java/org/optaplanner/workbench/screens/domaineditor/backend/ScoreHolderUtilsTest.java
+++ b/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-backend/src/test/java/org/optaplanner/workbench/screens/domaineditor/backend/ScoreHolderUtilsTest.java
@@ -51,44 +51,20 @@ public class ScoreHolderUtilsTest {
 
     @Before
     public void setUp() {
-        scoreHolderUtils = new ScoreHolderUtils( kieProjectService,
-                                                 classLoaderHelper );
+        scoreHolderUtils = new ScoreHolderUtils(kieProjectService,
+                                                classLoaderHelper);
     }
 
     @Test
-    public void extractScoreTypeFqnFullScoreType() {
-        DataObject dataObject = new DataObjectImpl( "test",
-                                                    "Test" );
-        dataObject.addAnnotation( new AnnotationImpl( DriverUtils.buildAnnotationDefinition( PlanningSolution.class ) ) );
-        dataObject.setSuperClassName( String.format( "%s<%s>",
-                                                     AbstractSolution.class.getName(),
-                                                     HardSoftScore.class.getName() ) );
+    public void extractScoreTypeFqn() {
+        DataObject dataObject = new DataObjectImpl("test",
+                                                   "Test");
+        dataObject.addAnnotation(new AnnotationImpl(DriverUtils.buildAnnotationDefinition(PlanningSolution.class)));
+        dataObject.addProperty("score", HardSoftScore.class.getName());
 
-        String result = scoreHolderUtils.extractScoreTypeFqn( dataObject,
-                                                              mock( Path.class ) );
+        String result = scoreHolderUtils.extractScoreTypeFqn(dataObject);
 
-        assertEquals( HardSoftScore.class.getName(),
-                      result );
-    }
-
-    @Test
-    public void extractScoreTypeFqnSimpleScoreType() {
-        DataObject dataObject = new DataObjectImpl( "test",
-                                                    "Test" );
-        dataObject.addAnnotation( new AnnotationImpl( DriverUtils.buildAnnotationDefinition( PlanningSolution.class ) ) );
-        dataObject.setSuperClassName( String.format( "%s<%s>",
-                                                     AbstractSolution.class.getName(),
-                                                     HardSoftScore.class.getSimpleName() ) );
-        dataObject.addImport( new ImportImpl( HardSoftScore.class.getName() ) );
-
-        KieProject kieProject = mock( KieProject.class );
-        when( kieProjectService.resolveProject( any( Path.class ) ) ).thenReturn( kieProject );
-        when( classLoaderHelper.getProjectClassLoader( kieProject ) ).thenReturn( getClass().getClassLoader() );
-
-        String result = scoreHolderUtils.extractScoreTypeFqn( dataObject,
-                                                              mock( Path.class ) );
-
-        assertEquals( HardSoftScore.class.getName(),
-                      result );
+        assertEquals(HardSoftScore.class.getName(),
+                     result);
     }
 }

--- a/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-backend/src/test/java/org/optaplanner/workbench/screens/domaineditor/backend/helper/PlanningSolutionSaveHelperTest.java
+++ b/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-backend/src/test/java/org/optaplanner/workbench/screens/domaineditor/backend/helper/PlanningSolutionSaveHelperTest.java
@@ -72,119 +72,118 @@ public class PlanningSolutionSaveHelperTest {
 
     @Before
     public void setUp() {
-        saveHelper = new PlanningSolutionSaveHelper( ioService,
-                                                     dataModelerService,
-                                                     globalsEditorService,
-                                                     kieProjectService,
-                                                     scoreHolderUtils,
-                                                     metadataService );
+        saveHelper = new PlanningSolutionSaveHelper(ioService,
+                                                    dataModelerService,
+                                                    globalsEditorService,
+                                                    kieProjectService,
+                                                    scoreHolderUtils,
+                                                    metadataService);
     }
 
     @Test
     public void scoreTypeChangedScoreHolderGlobalFileExisting() {
-        Path sourcePath = PathFactory.newPath( "TestSource.java",
-                                               "file:///dataObjects" );
-        Path destinationPath = PathFactory.newPath( "TestSource.java",
-                                                    "file:///dataObjects" );
-        testPlanningSolutionSaved( true,
-                                   sourcePath,
-                                   destinationPath );
+        Path sourcePath = PathFactory.newPath("TestSource.java",
+                                              "file:///dataObjects");
+        Path destinationPath = PathFactory.newPath("TestSource.java",
+                                                   "file:///dataObjects");
+        testPlanningSolutionSaved(true,
+                                  sourcePath,
+                                  destinationPath);
     }
 
     @Test
     public void scoreTypeChangedScoreHolderGlobalFileNonExisting() {
-        Path sourcePath = PathFactory.newPath( "TestSource.java",
-                                               "file:///dataObjects" );
-        Path destinationPath = PathFactory.newPath( "TestSource.java",
-                                                    "file:///dataObjects" );
-        testPlanningSolutionSaved( false,
-                                   sourcePath,
-                                   destinationPath );
+        Path sourcePath = PathFactory.newPath("TestSource.java",
+                                              "file:///dataObjects");
+        Path destinationPath = PathFactory.newPath("TestSource.java",
+                                                   "file:///dataObjects");
+        testPlanningSolutionSaved(false,
+                                  sourcePath,
+                                  destinationPath);
     }
 
     @Test
     public void planningSolutionDataObjectRenamed() {
-        Path sourcePath = PathFactory.newPath( "TestSource.java",
-                                               "file:///dataObjects1" );
-        Path destinationPath = PathFactory.newPath( "TestDestination.java",
-                                                    "file:///dataObjects2" );
-        testPlanningSolutionSaved( false,
-                                   sourcePath,
-                                   destinationPath );
+        Path sourcePath = PathFactory.newPath("TestSource.java",
+                                              "file:///dataObjects1");
+        Path destinationPath = PathFactory.newPath("TestDestination.java",
+                                                   "file:///dataObjects2");
+        testPlanningSolutionSaved(false,
+                                  sourcePath,
+                                  destinationPath);
     }
 
-    private void testPlanningSolutionSaved( boolean scoreHolderGlobalFileExists,
-                                            Path sourcePath,
-                                            Path destinationPath ) {
-        when( ioService.readAllString( Paths.convert( sourcePath ) ) ).thenReturn( "test source" );
+    private void testPlanningSolutionSaved(boolean scoreHolderGlobalFileExists,
+                                           Path sourcePath,
+                                           Path destinationPath) {
+        when(ioService.readAllString(Paths.convert(sourcePath))).thenReturn("test source");
 
-        DataObject dataObject = new DataObjectImpl( "test",
-                                                    "TestSource" );
-        dataObject.addAnnotation( new AnnotationImpl( DriverUtils.buildAnnotationDefinition( PlanningSolution.class ) ) );
+        DataObject dataObject = new DataObjectImpl("test",
+                                                   "TestSource");
+        dataObject.addAnnotation(new AnnotationImpl(DriverUtils.buildAnnotationDefinition(PlanningSolution.class)));
         GenerationResult generationResult = new GenerationResult();
-        generationResult.setDataObject( dataObject );
-        when( dataModelerService.loadDataObject( any(),
-                                                 anyString(),
-                                                 any() ) ).thenReturn( generationResult );
-
-        Package _package = mock( Package.class );
-        when( _package.getPackageMainResourcesPath() ).thenReturn( PathFactory.newPath( "dataObjects",
-                                                                                        "file:///dataObjects" ) );
-        when( kieProjectService.resolvePackage( any( Path.class ) ) ).thenReturn( _package );
-
-        when( scoreHolderUtils.extractScoreTypeFqn( dataObject,
-                                                    destinationPath ) ).thenReturn( HardSoftScore.class.getName() );
-        when( scoreHolderUtils.getScoreHolderTypeFqn( HardSoftScore.class.getName() ) ).thenReturn( HardSoftScoreHolder.class.getName() );
-        when( ioService.exists( any() ) ).thenReturn( scoreHolderGlobalFileExists );
-        when( globalsEditorService.load( any( Path.class ) ) ).thenReturn( mock( GlobalsModel.class ) );
-
-        saveHelper.postProcess( sourcePath,
-                                destinationPath );
-
-        if ( sourcePath.equals( destinationPath ) ) {
-            if ( scoreHolderGlobalFileExists ) {
-                verify( globalsEditorService,
-                        times( 1 ) ).save( any( Path.class ),
-                                           any( GlobalsModel.class ),
-                                           any( Metadata.class ),
-                                           anyString() );
-            } else {
-                verify( globalsEditorService,
-                        times( 1 ) ).generate( any( Path.class ),
+        generationResult.setDataObject(dataObject);
+        when(dataModelerService.loadDataObject(any(),
                                                anyString(),
-                                               any( GlobalsModel.class ),
-                                               anyString() );
+                                               any())).thenReturn(generationResult);
+
+        Package _package = mock(Package.class);
+        when(_package.getPackageMainResourcesPath()).thenReturn(PathFactory.newPath("dataObjects",
+                                                                                    "file:///dataObjects"));
+        when(kieProjectService.resolvePackage(any(Path.class))).thenReturn(_package);
+
+        when(scoreHolderUtils.extractScoreTypeFqn(dataObject)).thenReturn(HardSoftScore.class.getName());
+        when(scoreHolderUtils.getScoreHolderTypeFqn(HardSoftScore.class.getName())).thenReturn(HardSoftScoreHolder.class.getName());
+        when(ioService.exists(any())).thenReturn(scoreHolderGlobalFileExists);
+        when(globalsEditorService.load(any(Path.class))).thenReturn(mock(GlobalsModel.class));
+
+        saveHelper.postProcess(sourcePath,
+                               destinationPath);
+
+        if (sourcePath.equals(destinationPath)) {
+            if (scoreHolderGlobalFileExists) {
+                verify(globalsEditorService,
+                       times(1)).save(any(Path.class),
+                                      any(GlobalsModel.class),
+                                      any(Metadata.class),
+                                      anyString());
+            } else {
+                verify(globalsEditorService,
+                       times(1)).generate(any(Path.class),
+                                          anyString(),
+                                          any(GlobalsModel.class),
+                                          anyString());
             }
         } else {
-            verify( ioService ).deleteIfExists( any( org.uberfire.java.nio.file.Path.class ) );
+            verify(ioService).deleteIfExists(any(org.uberfire.java.nio.file.Path.class));
         }
     }
 
     @Test
     public void saveDataObjectNotAPlanningSolution() {
-        Path sourcePath = PathFactory.newPath( "TestSource.java",
-                                               "file:///dataObjects" );
-        Path destinationPath = PathFactory.newPath( "TestSource.java",
-                                                    "file:///dataObjects" );
+        Path sourcePath = PathFactory.newPath("TestSource.java",
+                                              "file:///dataObjects");
+        Path destinationPath = PathFactory.newPath("TestSource.java",
+                                                   "file:///dataObjects");
 
-        when( ioService.readAllString( Paths.convert( sourcePath ) ) ).thenReturn( "test source" );
+        when(ioService.readAllString(Paths.convert(sourcePath))).thenReturn("test source");
 
-        DataObject dataObject = new DataObjectImpl( "test",
-                                                    "TestSource" );
+        DataObject dataObject = new DataObjectImpl("test",
+                                                   "TestSource");
         GenerationResult generationResult = new GenerationResult();
-        generationResult.setDataObject( dataObject );
-        when( dataModelerService.loadDataObject( any(),
-                                                 anyString(),
-                                                 any() ) ).thenReturn( generationResult );
+        generationResult.setDataObject(dataObject);
+        when(dataModelerService.loadDataObject(any(),
+                                               anyString(),
+                                               any())).thenReturn(generationResult);
 
-        Package _package = mock( Package.class );
-        when( _package.getPackageMainResourcesPath() ).thenReturn( PathFactory.newPath( "dataObjects",
-                                                                                        "file:///dataObjects" ) );
-        when( kieProjectService.resolvePackage( any( Path.class ) ) ).thenReturn( _package );
+        Package _package = mock(Package.class);
+        when(_package.getPackageMainResourcesPath()).thenReturn(PathFactory.newPath("dataObjects",
+                                                                                    "file:///dataObjects"));
+        when(kieProjectService.resolvePackage(any(Path.class))).thenReturn(_package);
 
-        saveHelper.postProcess( sourcePath,
-                                destinationPath );
+        saveHelper.postProcess(sourcePath,
+                               destinationPath);
 
-        verify( ioService ).deleteIfExists( any( org.uberfire.java.nio.file.Path.class ) );
+        verify(ioService).deleteIfExists(any(org.uberfire.java.nio.file.Path.class));
     }
 }

--- a/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-client/src/main/java/org/optaplanner/workbench/screens/domaineditor/client/util/PlannerDomainTypes.java
+++ b/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-client/src/main/java/org/optaplanner/workbench/screens/domaineditor/client/util/PlannerDomainTypes.java
@@ -16,8 +16,8 @@
 
 package org.optaplanner.workbench.screens.domaineditor.client.util;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashMap;
+import java.util.Map;
 
 import org.optaplanner.core.api.score.Score;
 import org.optaplanner.core.api.score.buildin.bendable.BendableScore;
@@ -37,26 +37,53 @@ import org.optaplanner.core.api.score.buildin.simplelong.SimpleLongScore;
 
 public class PlannerDomainTypes {
 
-    public static final String ABSTRACT_SOLUTION_CLASS_NAME = "org.optaplanner.core.impl.domain.solution.AbstractSolution";
-
-    public static final String ABSTRACT_SOLUTION_SIMPLE_CLASS_NAME = "AbstractSolution";
-
-    public static final List<Class<? extends Score>> SCORE_TYPES = new ArrayList<>(  );
+    public static final Map<Class<? extends Score>, ScoreConfigurationHolder> SCORE_CONFIGURATION_MAP = new HashMap<>();
 
     static {
-        SCORE_TYPES.add( BendableScore.class );
-        SCORE_TYPES.add( BendableBigDecimalScore.class );
-        SCORE_TYPES.add( BendableLongScore.class );
-        SCORE_TYPES.add( HardMediumSoftScore.class );
-        SCORE_TYPES.add( HardMediumSoftBigDecimalScore.class );
-        SCORE_TYPES.add( HardMediumSoftLongScore.class );
-        SCORE_TYPES.add( HardSoftScore.class );
-        SCORE_TYPES.add( HardSoftBigDecimalScore.class );
-        SCORE_TYPES.add( HardSoftDoubleScore.class );
-        SCORE_TYPES.add( HardSoftLongScore.class );
-        SCORE_TYPES.add( SimpleScore.class );
-        SCORE_TYPES.add( SimpleBigDecimalScore.class );
-        SCORE_TYPES.add( SimpleDoubleScore.class );
-        SCORE_TYPES.add( SimpleLongScore.class );
+        SCORE_CONFIGURATION_MAP.put(BendableScore.class,
+                                    ScoreConfigurationHolder.create("org.optaplanner.persistence.jaxb.api.score.buildin.bendable.BendableScoreJaxbXmlAdapter"));
+        SCORE_CONFIGURATION_MAP.put(BendableBigDecimalScore.class,
+                                    ScoreConfigurationHolder.create("org.optaplanner.persistence.jaxb.api.score.buildin.bendablebigdecimal.BendableBigDecimalScoreJaxbXmlAdapter"));
+        SCORE_CONFIGURATION_MAP.put(BendableLongScore.class,
+                                    ScoreConfigurationHolder.create("org.optaplanner.persistence.jaxb.api.score.buildin.bendablelong.BendableLongScoreJaxbXmlAdapter"));
+        SCORE_CONFIGURATION_MAP.put(HardMediumSoftScore.class,
+                                    ScoreConfigurationHolder.create("org.optaplanner.persistence.jaxb.api.score.buildin.hardmediumsoft.HardMediumSoftScoreJaxbXmlAdapter"));
+        SCORE_CONFIGURATION_MAP.put(HardMediumSoftBigDecimalScore.class,
+                                    ScoreConfigurationHolder.create("org.optaplanner.persistence.jaxb.api.score.buildin.hardmediumsoftbigdecimal.HardMediumSoftBigDecimalScoreJaxbXmlAdapter"));
+        SCORE_CONFIGURATION_MAP.put(HardMediumSoftLongScore.class,
+                                    ScoreConfigurationHolder.create("org.optaplanner.persistence.jaxb.api.score.buildin.hardmediumsoftlong.HardMediumSoftLongScoreJaxbXmlAdapter"));
+        SCORE_CONFIGURATION_MAP.put(HardSoftScore.class,
+                                    ScoreConfigurationHolder.create("org.optaplanner.persistence.jaxb.api.score.buildin.hardsoft.HardSoftScoreJaxbXmlAdapter"));
+        SCORE_CONFIGURATION_MAP.put(HardSoftBigDecimalScore.class,
+                                    ScoreConfigurationHolder.create("org.optaplanner.persistence.jaxb.api.score.buildin.hardsoftbigdecimal.HardSoftBigDecimalScoreJaxbXmlAdapter"));
+        SCORE_CONFIGURATION_MAP.put(HardSoftDoubleScore.class,
+                                    ScoreConfigurationHolder.create("org.optaplanner.persistence.jaxb.api.score.buildin.hardsoftdouble.HardSoftDoubleScoreJaxbXmlAdapter"));
+        SCORE_CONFIGURATION_MAP.put(HardSoftLongScore.class,
+                                    ScoreConfigurationHolder.create("org.optaplanner.persistence.jaxb.api.score.buildin.hardsoftlong.HardSoftLongScoreJaxbXmlAdapter"));
+        SCORE_CONFIGURATION_MAP.put(SimpleScore.class,
+                                    ScoreConfigurationHolder.create("org.optaplanner.persistence.jaxb.api.score.buildin.simple.SimpleScoreJaxbXmlAdapter"));
+        SCORE_CONFIGURATION_MAP.put(SimpleBigDecimalScore.class,
+                                    ScoreConfigurationHolder.create("org.optaplanner.persistence.jaxb.api.score.buildin.simplebigdecimal.SimpleBigDecimalScoreJaxbXmlAdapter"));
+        SCORE_CONFIGURATION_MAP.put(SimpleDoubleScore.class,
+                                    ScoreConfigurationHolder.create("org.optaplanner.persistence.jaxb.api.score.buildin.simpledouble.SimpleDoubleScoreJaxbXmlAdapter"));
+        SCORE_CONFIGURATION_MAP.put(SimpleLongScore.class,
+                                    ScoreConfigurationHolder.create("org.optaplanner.persistence.jaxb.api.score.buildin.simplelong.SimpleLongScoreJaxbXmlAdapter"));
+    }
+
+    public static class ScoreConfigurationHolder {
+
+        private String jaxbXmlAdapterClass;
+
+        private ScoreConfigurationHolder(final String jaxbXmlAdapterClass) {
+            this.jaxbXmlAdapterClass = jaxbXmlAdapterClass;
+        }
+
+        public static ScoreConfigurationHolder create(final String jaxbXmlAdapterClass) {
+            return new ScoreConfigurationHolder(jaxbXmlAdapterClass);
+        }
+
+        public String getJaxbXmlAdapterClass() {
+            return jaxbXmlAdapterClass;
+        }
     }
 }

--- a/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-client/src/test/java/org/optaplanner/workbench/screens/domaineditor/client/widgets/planner/PlannerDataObjectFieldEditorTest.java
+++ b/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-client/src/test/java/org/optaplanner/workbench/screens/domaineditor/client/widgets/planner/PlannerDataObjectFieldEditorTest.java
@@ -112,7 +112,7 @@ public class PlannerDataObjectFieldEditorTest
         //first configure the DataObject as a PlanningSolution
         DataObject dataObject = context.getDataObject();
         dataObject.addAnnotation( new AnnotationImpl( context.getAnnotationDefinition( PlanningSolution.class.getName() ) ) );
-        dataObject.setSuperClassName( AbstractSolution.class.getName()+ "<" + HardSoftScore.class.getName() + ">" );
+        dataObject.addProperty("score", HardSoftScore.class.getName());
 
         ObjectProperty field1 = dataObject.getProperty( "field1" );
         //emulates the selection of field1

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-backend/src/main/java/org/optaplanner/workbench/screens/guidedrule/backend/server/service/ScoreHolderServiceImpl.java
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-backend/src/main/java/org/optaplanner/workbench/screens/guidedrule/backend/server/service/ScoreHolderServiceImpl.java
@@ -31,8 +31,7 @@ import org.kie.workbench.common.screens.datamodeller.service.DataModelerService;
 import org.kie.workbench.common.screens.javaeditor.type.JavaResourceTypeDefinition;
 import org.kie.workbench.common.services.datamodeller.core.Annotation;
 import org.kie.workbench.common.services.datamodeller.core.DataObject;
-import org.kie.workbench.common.services.datamodeller.core.Method;
-import org.kie.workbench.common.services.datamodeller.core.Type;
+import org.kie.workbench.common.services.datamodeller.core.ObjectProperty;
 import org.kie.workbench.common.services.shared.project.KieProjectService;
 import org.optaplanner.core.api.domain.solution.PlanningScore;
 import org.optaplanner.core.api.domain.solution.PlanningSolution;
@@ -123,12 +122,10 @@ public class ScoreHolderServiceImpl implements ScoreHolderService {
         if (!generationResult.hasErrors()) {
             DataObject dataObject = generationResult.getDataObject();
 
-            Method getScoreMethod = dataObject.getMethod("getScore",
-                                                         Collections.emptyList());
-            if (getScoreMethod != null) {
-                Type getScoreMethodReturnType = getScoreMethod.getReturnType();
-                if (getScoreMethodReturnType != null && isBendableScore(getScoreMethod.getReturnType().getName())) {
-                    Annotation annotation = getScoreMethod.getAnnotation(PlanningScore.class.getName());
+            ObjectProperty scoreObjectProperty = dataObject.getProperty("score");
+            if (scoreObjectProperty != null) {
+                if (isBendableScore(scoreObjectProperty.getClassName())) {
+                    Annotation annotation = scoreObjectProperty.getAnnotation(PlanningScore.class.getName());
                     if (annotation != null) {
                         Object hardLevelsSize = annotation.getValue("bendableHardLevelsSize");
                         Object softLevelsSize = annotation.getValue("bendableSoftLevelsSize");

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-backend/src/test/java/org/optaplanner/workbench/screens/guidedrule/backend/server/service/ScoreHolderServiceImplTest.java
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-backend/src/test/java/org/optaplanner/workbench/screens/guidedrule/backend/server/service/ScoreHolderServiceImplTest.java
@@ -18,7 +18,6 @@ package org.optaplanner.workbench.screens.guidedrule.backend.server.service;
 
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 
 import org.drools.workbench.screens.globals.model.Global;
 import org.drools.workbench.screens.globals.model.GlobalsModel;
@@ -30,12 +29,10 @@ import org.kie.workbench.common.screens.datamodeller.model.GenerationResult;
 import org.kie.workbench.common.screens.datamodeller.service.DataModelerService;
 import org.kie.workbench.common.screens.javaeditor.type.JavaResourceTypeDefinition;
 import org.kie.workbench.common.services.datamodeller.core.DataObject;
-import org.kie.workbench.common.services.datamodeller.core.Method;
-import org.kie.workbench.common.services.datamodeller.core.Visibility;
+import org.kie.workbench.common.services.datamodeller.core.ObjectProperty;
 import org.kie.workbench.common.services.datamodeller.core.impl.AnnotationImpl;
 import org.kie.workbench.common.services.datamodeller.core.impl.DataObjectImpl;
-import org.kie.workbench.common.services.datamodeller.core.impl.MethodImpl;
-import org.kie.workbench.common.services.datamodeller.core.impl.TypeImpl;
+import org.kie.workbench.common.services.datamodeller.core.impl.ObjectPropertyImpl;
 import org.kie.workbench.common.services.datamodeller.util.DriverUtils;
 import org.kie.workbench.common.services.shared.project.KieProjectService;
 import org.mockito.InjectMocks;
@@ -131,19 +128,17 @@ public class ScoreHolderServiceImplTest {
         AnnotationImpl planningSolutionAnnotation = new AnnotationImpl(DriverUtils.buildAnnotationDefinition(PlanningSolution.class));
         dataObject.addAnnotation(planningSolutionAnnotation);
 
-        Method getScoreMethod = new MethodImpl("getScore",
-                                               Collections.EMPTY_LIST,
-                                               "return score;",
-                                               new TypeImpl(BendableScore.class.getName()),
-                                               Visibility.PUBLIC);
-        dataObject.addMethod(getScoreMethod);
+        ObjectProperty scoreObjectProperty = new ObjectPropertyImpl("score",
+                                                                    BendableScore.class.getName(),
+                                                                    false);
+        dataObject.addProperty(scoreObjectProperty);
 
         AnnotationImpl planningScoreAnnotation = new AnnotationImpl(DriverUtils.buildAnnotationDefinition(PlanningScore.class));
         planningScoreAnnotation.setValue("bendableHardLevelsSize",
                                          1);
         planningScoreAnnotation.setValue("bendableSoftLevelsSize",
                                          2);
-        getScoreMethod.addAnnotation(planningScoreAnnotation);
+        scoreObjectProperty.addAnnotation(planningScoreAnnotation);
 
         return dataObject;
     }


### PR DESCRIPTION
Override getScore getter in AbstractSolution implementations so that JAXB can figure out a correct type of the score used. Additionally I polished the implementation of a score change logic.

@ge0ffrey This is a WB side of the PLANNER-784 fix.


Part of:
- https://github.com/kiegroup/optaplanner-wb/pull/158
- https://github.com/kiegroup/kie-wb-common/pull/869
- https://github.com/kiegroup/kie-wb-playground/pull/23