### PR TITLE
PLANNER-827: Show warning if ConstraintMatch input is empty

### DIFF
--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/pom.xml
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/pom.xml
@@ -74,6 +74,11 @@
       <artifactId>uberfire-workbench-client-views-patternfly</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.gwtbootstrap3</groupId>
+      <artifactId>gwtbootstrap3</artifactId>
+    </dependency>
+
     <!-- GWT and GWT Extensions -->
     <dependency>
       <groupId>com.google.gwt</groupId>

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/resources/i18n/GuidedRuleEditorConstants.java
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/resources/i18n/GuidedRuleEditorConstants.java
@@ -63,6 +63,9 @@ public interface GuidedRuleEditorConstants {
     String RuleModellerActionPluginAmbigiousConstraintMatchesDetected = "RuleModellerActionPlugin.AmbigiousConstraintMatchesDetected";
 
     @TranslationKey(defaultValue = "")
+    String RuleModellerActionPluginEmptyValuesAreNotAllowedForModifyScore = "RuleModellerActionPlugin.EmptyValuesAreNotAllowedForModifyScore";
+
+    @TranslationKey(defaultValue = "")
     String ActionPluginClientServiceScoreHolderGlobalNotFound = "ActionPluginClientService.ScoreHolderGlobalNotFound";
 
     @TranslationKey(defaultValue = "")

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/widget/BendableConstraintMatchRuleModellerWidget.java
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/widget/BendableConstraintMatchRuleModellerWidget.java
@@ -19,9 +19,10 @@ package org.optaplanner.workbench.screens.guidedrule.client.widget;
 import com.google.gwt.dom.client.Style;
 import com.google.gwt.event.shared.EventBus;
 import com.google.gwt.user.client.ui.HorizontalPanel;
-import com.google.gwt.user.client.ui.TextBox;
 import org.drools.workbench.screens.guided.rule.client.editor.RuleModeller;
+import org.gwtbootstrap3.client.ui.TextBox;
 import org.jboss.errai.ui.client.local.spi.TranslationService;
+import org.optaplanner.workbench.screens.guidedrule.client.resources.i18n.GuidedRuleEditorConstants;
 import org.optaplanner.workbench.screens.guidedrule.model.AbstractActionBendableConstraintMatch;
 import org.uberfire.client.views.pfly.widgets.HelpIcon;
 
@@ -29,7 +30,7 @@ public class BendableConstraintMatchRuleModellerWidget extends AbstractConstrain
 
     private AbstractActionBendableConstraintMatch actionConstraintMatch;
 
-    private TextBox constraintMatchTextBox = new TextBox();
+    private ConstraintMatchInputWidget constraintMatchInputWidget;
 
     private TextBox constraintLevelTextBox = new TextBox();
 
@@ -46,6 +47,12 @@ public class BendableConstraintMatchRuleModellerWidget extends AbstractConstrain
               translationService);
 
         this.actionConstraintMatch = actionConstraintMatch;
+        constraintMatchInputWidget = new ConstraintMatchInputWidget(actionConstraintMatch,
+                                                                    translationService);
+        constraintMatchInputWidget
+                .addConstraintMatchBlurHandler(new ConstraintMatchInputWidgetBlurHandler(constraintMatchInputWidget));
+        constraintMatchInputWidget
+                .addConstraintMatchValueChangeHandler(new ConstraintMatchValueChangeHandler(actionConstraintMatch));
 
         HorizontalPanel horizontalPanel = new HorizontalPanel();
 
@@ -90,22 +97,17 @@ public class BendableConstraintMatchRuleModellerWidget extends AbstractConstrain
     }
 
     private HorizontalPanel createConstraintMatchPanel() {
-        HorizontalPanel constraintMatchPanel = new HorizontalPanel();
-
-        constraintMatchTextBox.setValue(actionConstraintMatch.getConstraintMatch() == null ? "" : actionConstraintMatch.getConstraintMatch());
-        constraintMatchTextBox.addValueChangeHandler(s -> actionConstraintMatch.setConstraintMatch(s.getValue()));
-        constraintMatchTextBox.setEnabled(false);
-        constraintMatchTextBox.setWidth("100%");
+        final HorizontalPanel constraintMatchPanel = new HorizontalPanel();
 
         constraintMatchPanel.setWidth("100%");
-        constraintMatchPanel.add(constraintMatchTextBox);
+        constraintMatchPanel.add(constraintMatchInputWidget);
 
         return constraintMatchPanel;
     }
 
     @Override
     public void scoreHolderGlobalLoadedCorrectly() {
-        constraintMatchTextBox.setEnabled(true);
+        constraintMatchInputWidget.setEnabled(true);
         constraintLevelTextBox.setEnabled(true);
     }
 
@@ -113,7 +115,7 @@ public class BendableConstraintMatchRuleModellerWidget extends AbstractConstrain
         int currentLevelSize = actionConstraintMatch.getPosition();
 
         if (currentLevelSize >= scoreLevelSize) {
-            constraintLevelSelectHelpIcon.setHelpContent("Score level set for this score is greater than the maximum defined by current planning solution. Modify the bendable score levels size in the planning solution or change the level for this item.");
+            constraintLevelSelectHelpIcon.setHelpContent(translationService.getTranslation(GuidedRuleEditorConstants.RuleModellerActionPluginScoreLevelExceeded));
             constraintLevelSelectHelpIcon.setVisible(true);
         } else {
             constraintLevelTextBox.getElement().setAttribute("max",

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/widget/ConstraintMatchInputWidget.java
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/widget/ConstraintMatchInputWidget.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.screens.guidedrule.client.widget;
+
+import com.google.gwt.dom.client.Document;
+import com.google.gwt.event.dom.client.BlurHandler;
+import com.google.gwt.event.dom.client.DomEvent;
+import com.google.gwt.event.logical.shared.ValueChangeHandler;
+import com.google.gwt.event.shared.HandlerRegistration;
+import org.gwtbootstrap3.client.ui.FormGroup;
+import org.gwtbootstrap3.client.ui.HelpBlock;
+import org.gwtbootstrap3.client.ui.TextBox;
+import org.jboss.errai.ui.client.local.spi.TranslationService;
+import org.optaplanner.workbench.screens.guidedrule.client.resources.i18n.GuidedRuleEditorConstants;
+import org.optaplanner.workbench.screens.guidedrule.model.AbstractActionConstraintMatch;
+import org.uberfire.client.views.pfly.widgets.ValidationState;
+
+public class ConstraintMatchInputWidget extends FormGroup {
+
+    private TextBox constraintMatchTextBox;
+
+    private HelpBlock helpBlock;
+
+    private TranslationService translationService;
+
+    public ConstraintMatchInputWidget(AbstractActionConstraintMatch actionConstraintMatch,
+                                      TranslationService translationService) {
+
+        this.translationService = translationService;
+
+        constraintMatchTextBox = new TextBox();
+        helpBlock = new HelpBlock();
+        add(constraintMatchTextBox);
+        add(helpBlock);
+
+        constraintMatchTextBox.setValue(actionConstraintMatch.getConstraintMatch() == null ? "" : actionConstraintMatch.getConstraintMatch());
+
+        constraintMatchTextBox.setEnabled(false);
+    }
+
+    public void showEmptyValuesNotAllowedError() {
+        showError(translationService.getTranslation(GuidedRuleEditorConstants.RuleModellerActionPluginEmptyValuesAreNotAllowedForModifyScore));
+    }
+
+    private void showError(String errorMessage) {
+        addStyleName(ValidationState.ERROR.getCssName());
+        helpBlock.setError(errorMessage);
+    }
+
+    public void clearError() {
+        removeStyleName(ValidationState.ERROR.getCssName());
+        helpBlock.clearError();
+    }
+
+    public String getConstraintMatchValue() {
+        return constraintMatchTextBox.getValue();
+    }
+
+    public HandlerRegistration addConstraintMatchValueChangeHandler(ValueChangeHandler<String> valueChangeHandler) {
+        return constraintMatchTextBox.addValueChangeHandler(valueChangeHandler);
+    }
+
+    public HandlerRegistration addConstraintMatchBlurHandler(BlurHandler blurHandler) {
+        HandlerRegistration registration = constraintMatchTextBox.addBlurHandler(blurHandler);
+        DomEvent.fireNativeEvent(Document.get().createBlurEvent(), constraintMatchTextBox);
+
+        return registration;
+    }
+
+    public void setEnabled(boolean enabled) {
+        constraintMatchTextBox.setEnabled(enabled);
+    }
+}

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/widget/ConstraintMatchInputWidgetBlurHandler.java
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/widget/ConstraintMatchInputWidgetBlurHandler.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.screens.guidedrule.client.widget;
+
+import com.google.gwt.event.dom.client.BlurEvent;
+import com.google.gwt.event.dom.client.BlurHandler;
+
+public class ConstraintMatchInputWidgetBlurHandler implements BlurHandler {
+
+    private ConstraintMatchInputWidget widget;
+
+    public ConstraintMatchInputWidgetBlurHandler(ConstraintMatchInputWidget widget) {
+        this.widget = widget;
+    }
+
+    @Override
+    public void onBlur(BlurEvent event) {
+        if (widget.getConstraintMatchValue() == null || widget.getConstraintMatchValue().trim().isEmpty()) {
+            widget.showEmptyValuesNotAllowedError();
+        } else {
+            widget.clearError();
+        }
+    }
+}

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/widget/ConstraintMatchRuleModellerWidget.java
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/widget/ConstraintMatchRuleModellerWidget.java
@@ -18,14 +18,13 @@ package org.optaplanner.workbench.screens.guidedrule.client.widget;
 
 import com.google.gwt.event.shared.EventBus;
 import com.google.gwt.user.client.ui.HorizontalPanel;
-import com.google.gwt.user.client.ui.TextBox;
 import org.drools.workbench.screens.guided.rule.client.editor.RuleModeller;
 import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.optaplanner.workbench.screens.guidedrule.model.AbstractActionConstraintMatch;
 
 public class ConstraintMatchRuleModellerWidget extends AbstractConstraintMatchRuleModellerWidget {
 
-    private TextBox constraintMatchTextBox = new TextBox();
+    private ConstraintMatchInputWidget constraintMatchInputWidget;
 
     public ConstraintMatchRuleModellerWidget(final RuleModeller mod,
                                              final EventBus eventBus,
@@ -36,6 +35,13 @@ public class ConstraintMatchRuleModellerWidget extends AbstractConstraintMatchRu
         super(mod,
               eventBus,
               translationService);
+
+        constraintMatchInputWidget = new ConstraintMatchInputWidget(actionConstraintMatch,
+                                                                    translationService);
+        constraintMatchInputWidget
+                .addConstraintMatchBlurHandler(new ConstraintMatchInputWidgetBlurHandler(constraintMatchInputWidget));
+        constraintMatchInputWidget
+                .addConstraintMatchValueChangeHandler(new ConstraintMatchValueChangeHandler(actionConstraintMatch));
 
         HorizontalPanel horizontalPanel = new HorizontalPanel();
 
@@ -54,18 +60,13 @@ public class ConstraintMatchRuleModellerWidget extends AbstractConstraintMatchRu
     private HorizontalPanel createConstraintMatchPanel(final AbstractActionConstraintMatch actionConstraintMatch) {
         HorizontalPanel constraintMatchPanel = new HorizontalPanel();
 
-        constraintMatchTextBox.setValue(actionConstraintMatch.getConstraintMatch() == null ? "" : actionConstraintMatch.getConstraintMatch());
-        constraintMatchTextBox.addValueChangeHandler(s -> actionConstraintMatch.setConstraintMatch(s.getValue()));
-        constraintMatchTextBox.setEnabled(false);
-        constraintMatchTextBox.setWidth("100%");
-
         constraintMatchPanel.setWidth("100%");
-        constraintMatchPanel.add(constraintMatchTextBox);
+        constraintMatchPanel.add(constraintMatchInputWidget);
 
         return constraintMatchPanel;
     }
 
     public void scoreHolderGlobalLoadedCorrectly() {
-        constraintMatchTextBox.setEnabled(true);
+        constraintMatchInputWidget.setEnabled(true);
     }
 }

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/widget/ConstraintMatchValueChangeHandler.java
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/widget/ConstraintMatchValueChangeHandler.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.screens.guidedrule.client.widget;
+
+import com.google.gwt.event.logical.shared.ValueChangeEvent;
+import com.google.gwt.event.logical.shared.ValueChangeHandler;
+import org.optaplanner.workbench.screens.guidedrule.model.AbstractActionConstraintMatch;
+
+public class ConstraintMatchValueChangeHandler implements ValueChangeHandler<String> {
+
+    private AbstractActionConstraintMatch actionConstraintMatch;
+
+    public ConstraintMatchValueChangeHandler(AbstractActionConstraintMatch actionConstraintMatch) {
+        this.actionConstraintMatch = actionConstraintMatch;
+    }
+
+    @Override
+    public void onValueChange(ValueChangeEvent<String> event) {
+        actionConstraintMatch.setConstraintMatch(event.getValue());
+    }
+}

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/widget/MultiConstraintBendableMatchRuleModellerWidget.java
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/widget/MultiConstraintBendableMatchRuleModellerWidget.java
@@ -23,9 +23,9 @@ import com.google.gwt.dom.client.Style;
 import com.google.gwt.event.shared.EventBus;
 import com.google.gwt.user.client.ui.HorizontalPanel;
 import com.google.gwt.user.client.ui.Label;
-import com.google.gwt.user.client.ui.TextBox;
 import com.google.gwt.user.client.ui.VerticalPanel;
 import org.drools.workbench.screens.guided.rule.client.editor.RuleModeller;
+import org.gwtbootstrap3.client.ui.TextBox;
 import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.optaplanner.workbench.screens.guidedrule.client.resources.GuidedRuleEditorResources;
 import org.optaplanner.workbench.screens.guidedrule.client.resources.i18n.GuidedRuleEditorConstants;
@@ -36,11 +36,11 @@ import org.uberfire.client.views.pfly.widgets.HelpIcon;
 
 public class MultiConstraintBendableMatchRuleModellerWidget extends AbstractConstraintMatchRuleModellerWidget {
 
-    private List<TextBox> hardConstraintMatchTextBoxes = new ArrayList<>();
+    private List<ConstraintMatchInputWidget> hardConstraintMatchInputWidgets = new ArrayList<>();
 
     private List<HelpIcon> hardConstraintMatchHelpIcons = new ArrayList<>();
 
-    private List<TextBox> softConstraintMatchTextBoxes = new ArrayList<>();
+    private List<ConstraintMatchInputWidget> softConstraintMatchInputWidgets = new ArrayList<>();
 
     private List<HelpIcon> softConstraintMatchHelpIcons = new ArrayList<>();
 
@@ -70,7 +70,7 @@ public class MultiConstraintBendableMatchRuleModellerWidget extends AbstractCons
                 HorizontalPanel horizontalPanel = createBendableConstraintMatchRow(translationService.getTranslation(GuidedRuleEditorConstants.RuleModellerActionPluginHardScore),
                                                                                    i,
                                                                                    hardConstraintMatchHelpIcons,
-                                                                                   hardConstraintMatchTextBoxes,
+                                                                                   hardConstraintMatchInputWidgets,
                                                                                    actionConstraintMatch.getActionBendableHardConstraintMatches().get(i));
                 hardScorePanel.add(horizontalPanel);
             }
@@ -87,7 +87,7 @@ public class MultiConstraintBendableMatchRuleModellerWidget extends AbstractCons
                 HorizontalPanel horizontalPanel = createBendableConstraintMatchRow(translationService.getTranslation(GuidedRuleEditorConstants.RuleModellerActionPluginSoftScore),
                                                                                    i,
                                                                                    softConstraintMatchHelpIcons,
-                                                                                   softConstraintMatchTextBoxes,
+                                                                                   softConstraintMatchInputWidgets,
                                                                                    actionConstraintMatch.getActionBendableSoftConstraintMatches().get(i));
                 softScorePanel.add(horizontalPanel);
             }
@@ -102,7 +102,7 @@ public class MultiConstraintBendableMatchRuleModellerWidget extends AbstractCons
     private HorizontalPanel createBendableConstraintMatchRow(final String labelText,
                                                              final int index,
                                                              final List<HelpIcon> hardConstraintMatchHelpIcons,
-                                                             final List<TextBox> hardConstraintMatchTextBoxes,
+                                                             final List<ConstraintMatchInputWidget> constraintMatchInputWidgets,
                                                              final AbstractActionBendableConstraintMatch constraintMatch) {
         HorizontalPanel horizontalPanel = new HorizontalPanel();
 
@@ -129,14 +129,15 @@ public class MultiConstraintBendableMatchRuleModellerWidget extends AbstractCons
 
         horizontalPanel.add(selectPanel);
 
-        TextBox constraintMatchTextBox = new TextBox();
-        hardConstraintMatchTextBoxes.add(constraintMatchTextBox);
-        constraintMatchTextBox.setValue(constraintMatch.getConstraintMatch() == null ? "" : constraintMatch.getConstraintMatch());
-        constraintMatchTextBox.addValueChangeHandler(c -> constraintMatch.setConstraintMatch(c.getValue()));
-        constraintMatchTextBox.setEnabled(false);
-        constraintMatchTextBox.setWidth("100%");
+        ConstraintMatchInputWidget constraintMatchInputWidget = new ConstraintMatchInputWidget(constraintMatch,
+                                                                                               translationService);
+        constraintMatchInputWidget
+                .addConstraintMatchBlurHandler(new ConstraintMatchInputWidgetBlurHandler(constraintMatchInputWidget));
+        constraintMatchInputWidget
+                .addConstraintMatchValueChangeHandler(new ConstraintMatchValueChangeHandler(constraintMatch));
+        constraintMatchInputWidgets.add(constraintMatchInputWidget);
 
-        horizontalPanel.add(constraintMatchTextBox);
+        horizontalPanel.add(constraintMatchInputWidget);
         horizontalPanel.setCellWidth(labelPanel,
                                      "150px");
         horizontalPanel.setCellWidth(selectPanel,
@@ -151,15 +152,15 @@ public class MultiConstraintBendableMatchRuleModellerWidget extends AbstractCons
 
     @Override
     public void scoreHolderGlobalLoadedCorrectly() {
-        if (hardConstraintMatchTextBoxes != null) {
-            for (TextBox hardConstraintMatchTextBox : hardConstraintMatchTextBoxes) {
-                hardConstraintMatchTextBox.setEnabled(true);
+        if (hardConstraintMatchInputWidgets != null) {
+            for (ConstraintMatchInputWidget hardConstraintMatchInputWidget : hardConstraintMatchInputWidgets) {
+                hardConstraintMatchInputWidget.setEnabled(true);
             }
         }
 
-        if (softConstraintMatchTextBoxes != null) {
-            for (TextBox softConstraintMatchTextBox : softConstraintMatchTextBoxes) {
-                softConstraintMatchTextBox.setEnabled(true);
+        if (softConstraintMatchInputWidgets != null) {
+            for (ConstraintMatchInputWidget softConstraintMatchInputWidget : softConstraintMatchInputWidgets) {
+                softConstraintMatchInputWidget.setEnabled(true);
             }
         }
     }

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/widget/MultiConstraintHardMediumSoftMatchRuleModellerWidget.java
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/widget/MultiConstraintHardMediumSoftMatchRuleModellerWidget.java
@@ -18,8 +18,8 @@ package org.optaplanner.workbench.screens.guidedrule.client.widget;
 
 import com.google.gwt.event.shared.EventBus;
 import com.google.gwt.user.client.ui.HorizontalPanel;
+import com.google.gwt.user.client.ui.IsWidget;
 import com.google.gwt.user.client.ui.Label;
-import com.google.gwt.user.client.ui.TextBox;
 import com.google.gwt.user.client.ui.VerticalPanel;
 import org.drools.workbench.screens.guided.rule.client.editor.RuleModeller;
 import org.jboss.errai.ui.client.local.spi.TranslationService;
@@ -29,11 +29,9 @@ import org.optaplanner.workbench.screens.guidedrule.model.ActionMultiConstraintH
 
 public class MultiConstraintHardMediumSoftMatchRuleModellerWidget extends AbstractConstraintMatchRuleModellerWidget {
 
-    private TextBox hardConstraintMatchTextBox = new TextBox();
-
-    private TextBox mediumConstraintMatchTextBox = new TextBox();
-
-    private TextBox softConstraintMatchTextBox = new TextBox();
+    private ConstraintMatchInputWidget hardConstraintMatchInputWidget;
+    private ConstraintMatchInputWidget mediumConstraintMatchInputWidget;
+    private ConstraintMatchInputWidget softConstraintMatchInputWidget;
 
     public MultiConstraintHardMediumSoftMatchRuleModellerWidget(final RuleModeller mod,
                                                                 final EventBus eventBus,
@@ -44,29 +42,39 @@ public class MultiConstraintHardMediumSoftMatchRuleModellerWidget extends Abstra
               eventBus,
               translationService);
 
+        hardConstraintMatchInputWidget = new ConstraintMatchInputWidget(actionConstraintMatch.getActionHardConstraintMatch(),
+                                                                        translationService);
+        hardConstraintMatchInputWidget
+                .addConstraintMatchBlurHandler(new ConstraintMatchInputWidgetBlurHandler(hardConstraintMatchInputWidget));
+        hardConstraintMatchInputWidget
+                .addConstraintMatchValueChangeHandler(new ConstraintMatchValueChangeHandler(actionConstraintMatch.getActionHardConstraintMatch()));
+        mediumConstraintMatchInputWidget = new ConstraintMatchInputWidget(actionConstraintMatch.getActionMediumConstraintMatch(),
+                                                                          translationService);
+        mediumConstraintMatchInputWidget
+                .addConstraintMatchBlurHandler(new ConstraintMatchInputWidgetBlurHandler(mediumConstraintMatchInputWidget));
+        mediumConstraintMatchInputWidget
+                .addConstraintMatchValueChangeHandler(new ConstraintMatchValueChangeHandler(actionConstraintMatch.getActionMediumConstraintMatch()));
+        softConstraintMatchInputWidget = new ConstraintMatchInputWidget(actionConstraintMatch.getActionSoftConstraintMatch(),
+                                                                        translationService);
+        softConstraintMatchInputWidget
+                .addConstraintMatchBlurHandler(new ConstraintMatchInputWidgetBlurHandler(softConstraintMatchInputWidget));
+        softConstraintMatchInputWidget
+                .addConstraintMatchValueChangeHandler(new ConstraintMatchValueChangeHandler(actionConstraintMatch.getActionSoftConstraintMatch()));
+
         VerticalPanel verticalPanel = new VerticalPanel();
 
         HorizontalPanel labelPanel = createLabelPanel(translationService.getTranslation(GuidedRuleEditorConstants.RuleModellerActionPluginMultiConstraintMatch));
 
         verticalPanel.add(labelPanel);
 
-        String hardConstraintMatch = actionConstraintMatch.getActionHardConstraintMatch().getConstraintMatch();
-        hardConstraintMatchTextBox.setValue(hardConstraintMatch == null ? "" : hardConstraintMatch);
-        hardConstraintMatchTextBox.addValueChangeHandler(s -> actionConstraintMatch.getActionHardConstraintMatch().setConstraintMatch(s.getValue()));
         verticalPanel.add(getItemPanel(translationService.getTranslation(GuidedRuleEditorConstants.RuleModellerActionPluginHardScore),
-                                       hardConstraintMatchTextBox));
+                                       hardConstraintMatchInputWidget));
 
-        String mediumConstraintMatch = actionConstraintMatch.getActionMediumConstraintMatch().getConstraintMatch();
-        mediumConstraintMatchTextBox.setValue(mediumConstraintMatch == null ? "" : mediumConstraintMatch);
-        mediumConstraintMatchTextBox.addValueChangeHandler(s -> actionConstraintMatch.getActionMediumConstraintMatch().setConstraintMatch(s.getValue()));
         verticalPanel.add(getItemPanel(translationService.getTranslation(GuidedRuleEditorConstants.RuleModellerActionPluginMediumScore),
-                                       mediumConstraintMatchTextBox));
+                                       mediumConstraintMatchInputWidget));
 
-        String softConstraintMatch = actionConstraintMatch.getActionSoftConstraintMatch().getConstraintMatch();
-        softConstraintMatchTextBox.setValue(softConstraintMatch == null ? "" : softConstraintMatch);
-        softConstraintMatchTextBox.addValueChangeHandler(s -> actionConstraintMatch.getActionSoftConstraintMatch().setConstraintMatch(s.getValue()));
         verticalPanel.add(getItemPanel(translationService.getTranslation(GuidedRuleEditorConstants.RuleModellerActionPluginSoftScore),
-                                       softConstraintMatchTextBox));
+                                       softConstraintMatchInputWidget));
 
         verticalPanel.addStyleName(GuidedRuleEditorResources.INSTANCE.css().multiConstraintMatch());
 
@@ -74,7 +82,7 @@ public class MultiConstraintHardMediumSoftMatchRuleModellerWidget extends Abstra
     }
 
     private HorizontalPanel getItemPanel(final String labelText,
-                                         final TextBox constraintMatchTextBox) {
+                                         final IsWidget constraintMatchWidget) {
         HorizontalPanel horizontalPanel = new HorizontalPanel();
         horizontalPanel.setWidth("100%");
 
@@ -83,9 +91,7 @@ public class MultiConstraintHardMediumSoftMatchRuleModellerWidget extends Abstra
         labelPanel.add(label);
         horizontalPanel.add(labelPanel);
 
-        constraintMatchTextBox.setEnabled(false);
-        constraintMatchTextBox.setWidth("100%");
-        horizontalPanel.add(constraintMatchTextBox);
+        horizontalPanel.add(constraintMatchWidget);
 
         horizontalPanel.setCellWidth(labelPanel,
                                      "150px");
@@ -94,8 +100,8 @@ public class MultiConstraintHardMediumSoftMatchRuleModellerWidget extends Abstra
     }
 
     public void scoreHolderGlobalLoadedCorrectly() {
-        hardConstraintMatchTextBox.setEnabled(true);
-        mediumConstraintMatchTextBox.setEnabled(true);
-        softConstraintMatchTextBox.setEnabled(true);
+        hardConstraintMatchInputWidget.setEnabled(true);
+        mediumConstraintMatchInputWidget.setEnabled(true);
+        softConstraintMatchInputWidget.setEnabled(true);
     }
 }

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/widget/MultiConstraintHardSoftMatchRuleModellerWidget.java
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/widget/MultiConstraintHardSoftMatchRuleModellerWidget.java
@@ -18,8 +18,8 @@ package org.optaplanner.workbench.screens.guidedrule.client.widget;
 
 import com.google.gwt.event.shared.EventBus;
 import com.google.gwt.user.client.ui.HorizontalPanel;
+import com.google.gwt.user.client.ui.IsWidget;
 import com.google.gwt.user.client.ui.Label;
-import com.google.gwt.user.client.ui.TextBox;
 import com.google.gwt.user.client.ui.VerticalPanel;
 import org.drools.workbench.screens.guided.rule.client.editor.RuleModeller;
 import org.jboss.errai.ui.client.local.spi.TranslationService;
@@ -29,8 +29,8 @@ import org.optaplanner.workbench.screens.guidedrule.model.ActionMultiConstraintH
 
 public class MultiConstraintHardSoftMatchRuleModellerWidget extends AbstractConstraintMatchRuleModellerWidget {
 
-    private TextBox hardConstraintMatchTextBox = new TextBox();
-    private TextBox softConstraintMatchTextBox = new TextBox();
+    private ConstraintMatchInputWidget hardConstraintMatchInputWidget;
+    private ConstraintMatchInputWidget softConstraintMatchInputWidget;
 
     public MultiConstraintHardSoftMatchRuleModellerWidget(final RuleModeller mod,
                                                           final EventBus eventBus,
@@ -40,6 +40,18 @@ public class MultiConstraintHardSoftMatchRuleModellerWidget extends AbstractCons
         super(mod,
               eventBus,
               translationService);
+        hardConstraintMatchInputWidget = new ConstraintMatchInputWidget(actionConstraintMatch.getActionHardConstraintMatch(),
+                                                                        translationService);
+        hardConstraintMatchInputWidget
+                .addConstraintMatchBlurHandler(new ConstraintMatchInputWidgetBlurHandler(hardConstraintMatchInputWidget));
+        hardConstraintMatchInputWidget
+                .addConstraintMatchValueChangeHandler(new ConstraintMatchValueChangeHandler(actionConstraintMatch.getActionHardConstraintMatch()));
+        softConstraintMatchInputWidget = new ConstraintMatchInputWidget(actionConstraintMatch.getActionSoftConstraintMatch(),
+                                                                        translationService);
+        softConstraintMatchInputWidget
+                .addConstraintMatchBlurHandler(new ConstraintMatchInputWidgetBlurHandler(softConstraintMatchInputWidget));
+        softConstraintMatchInputWidget
+                .addConstraintMatchValueChangeHandler(new ConstraintMatchValueChangeHandler(actionConstraintMatch.getActionSoftConstraintMatch()));
 
         VerticalPanel verticalPanel = new VerticalPanel();
 
@@ -48,17 +60,11 @@ public class MultiConstraintHardSoftMatchRuleModellerWidget extends AbstractCons
         verticalPanel.setCellHeight(labelPanel,
                                     "25px");
 
-        String hardConstraintMatch = actionConstraintMatch.getActionHardConstraintMatch().getConstraintMatch();
-        hardConstraintMatchTextBox.setValue(hardConstraintMatch == null ? "" : hardConstraintMatch);
-        hardConstraintMatchTextBox.addValueChangeHandler(s -> actionConstraintMatch.getActionHardConstraintMatch().setConstraintMatch(s.getValue()));
         verticalPanel.add(getItemPanel(translationService.getTranslation(GuidedRuleEditorConstants.RuleModellerActionPluginHardScore),
-                                       hardConstraintMatchTextBox));
+                                       hardConstraintMatchInputWidget));
 
-        String softConstraintMatch = actionConstraintMatch.getActionSoftConstraintMatch().getConstraintMatch();
-        softConstraintMatchTextBox.setValue(softConstraintMatch == null ? "" : softConstraintMatch);
-        softConstraintMatchTextBox.addValueChangeHandler(s -> actionConstraintMatch.getActionSoftConstraintMatch().setConstraintMatch(s.getValue()));
         verticalPanel.add(getItemPanel(translationService.getTranslation(GuidedRuleEditorConstants.RuleModellerActionPluginSoftScore),
-                                       softConstraintMatchTextBox));
+                                       softConstraintMatchInputWidget));
 
         verticalPanel.setStyleName(GuidedRuleEditorResources.INSTANCE.css().multiConstraintMatch());
 
@@ -66,7 +72,7 @@ public class MultiConstraintHardSoftMatchRuleModellerWidget extends AbstractCons
     }
 
     private HorizontalPanel getItemPanel(final String labelText,
-                                         final TextBox constraintMatchTextBox) {
+                                         final IsWidget constraintWidget) {
         HorizontalPanel horizontalPanel = new HorizontalPanel();
 
         HorizontalPanel labelPanel = new HorizontalPanel();
@@ -74,9 +80,7 @@ public class MultiConstraintHardSoftMatchRuleModellerWidget extends AbstractCons
         labelPanel.add(label);
         horizontalPanel.add(labelPanel);
 
-        constraintMatchTextBox.setEnabled(false);
-        constraintMatchTextBox.setWidth("100%");
-        horizontalPanel.add(constraintMatchTextBox);
+        horizontalPanel.add(constraintWidget);
 
         horizontalPanel.setWidth("100%");
         horizontalPanel.setCellWidth(labelPanel,
@@ -86,7 +90,7 @@ public class MultiConstraintHardSoftMatchRuleModellerWidget extends AbstractCons
     }
 
     public void scoreHolderGlobalLoadedCorrectly() {
-        hardConstraintMatchTextBox.setEnabled(true);
-        softConstraintMatchTextBox.setEnabled(true);
+        hardConstraintMatchInputWidget.setEnabled(true);
+        softConstraintMatchInputWidget.setEnabled(true);
     }
 }

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/resources/org/optaplanner/workbench/screens/guidedrule/client/resources/i18n/GuidedRuleEditorConstants.properties
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/resources/org/optaplanner/workbench/screens/guidedrule/client/resources/i18n/GuidedRuleEditorConstants.properties
@@ -29,6 +29,7 @@ RuleModellerActionPlugin.HardScoreLevelSizeIsZero=Hard score level size is 0
 RuleModellerActionPlugin.SoftScoreLevelSizeIsZero=Soft score level size is 0
 RuleModellerActionPlugin.ScoreLevelExceeded=Score level set for this score is greater than the maximum defined by current planning solution. Modify the bendable score levels size in the planning solution or remove this item.
 RuleModellerActionPlugin.AmbigiousConstraintMatchesDetected=Ambigious Planner score constraint matches detected within a single RHS of the rule. Remove one of the items.
+RuleModellerActionPlugin.EmptyValuesAreNotAllowedForModifyScore=Empty values are not allowed for the Modify Score actions. Please put either number or expression like $person.age
 
 ActionPluginClientService.ScoreHolderGlobalNotFound=scoreHolder global variable not found. The global variable is created automatically when a Planning Solution is created. Make sure to create a planning solution before proceeding to rule definition.
 ActionPluginClientService.MultipleScoreHolderGlobals=Multiple scoreHolder global variables found. The global variable is created automatically when a Planning Solution is created. Make sure there are not multiple planning solution objects within the project and that you do not define the 'scoreHolder' global variable manually.

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/test/java/org/optaplanner/workbench/screens/guidedrule/client/widget/ConstraintMatchInputWidgetBlurHandlerTest.java
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/test/java/org/optaplanner/workbench/screens/guidedrule/client/widget/ConstraintMatchInputWidgetBlurHandlerTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.screens.guidedrule.client.widget;
+
+import com.google.gwt.event.dom.client.BlurEvent;
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class ConstraintMatchInputWidgetBlurHandlerTest {
+
+    ConstraintMatchInputWidgetBlurHandler handler;
+
+    @Mock
+    ConstraintMatchInputWidget widget;
+
+    @Before
+    public void setUp() throws Exception {
+        handler = new ConstraintMatchInputWidgetBlurHandler(widget);
+
+    }
+
+    @Test
+    public void testNullConstraintMatch() throws Exception {
+        when(widget.getConstraintMatchValue()).thenReturn(null);
+
+        handler.onBlur(mock(BlurEvent.class));
+
+        verify(widget).showEmptyValuesNotAllowedError();
+        verify(widget, never()).clearError();
+    }
+
+    @Test
+    public void testEmptyConstraintMatch() throws Exception {
+        when(widget.getConstraintMatchValue()).thenReturn("");
+
+        handler.onBlur(mock(BlurEvent.class));
+
+        verify(widget).showEmptyValuesNotAllowedError();
+        verify(widget, never()).clearError();
+    }
+
+    @Test
+    public void testJustWhiteSpaceConstraintMatch() throws Exception {
+        when(widget.getConstraintMatchValue()).thenReturn(" ");
+
+        handler.onBlur(mock(BlurEvent.class));
+
+        verify(widget).showEmptyValuesNotAllowedError();
+        verify(widget, never()).clearError();
+    }
+
+    @Test
+    public void testNumberConstraintMatch() throws Exception {
+        when(widget.getConstraintMatchValue()).thenReturn("123");
+
+        handler.onBlur(mock(BlurEvent.class));
+
+        verify(widget, never()).showEmptyValuesNotAllowedError();
+        verify(widget).clearError();
+    }
+
+    @Test
+    public void testExpressionConstraintMatch() throws Exception {
+        when(widget.getConstraintMatchValue()).thenReturn("$person.getAge()");
+
+        handler.onBlur(mock(BlurEvent.class));
+
+        verify(widget, never()).showEmptyValuesNotAllowedError();
+        verify(widget).clearError();
+    }
+
+
+}

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/test/java/org/optaplanner/workbench/screens/guidedrule/client/widget/ConstraintMatchValueChangeHandlerTest.java
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/test/java/org/optaplanner/workbench/screens/guidedrule/client/widget/ConstraintMatchValueChangeHandlerTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.screens.guidedrule.client.widget;
+
+import com.google.gwt.event.logical.shared.ValueChangeEvent;
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.optaplanner.workbench.screens.guidedrule.model.AbstractActionConstraintMatch;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class ConstraintMatchValueChangeHandlerTest {
+
+    ConstraintMatchValueChangeHandler handler;
+
+    @Mock
+    AbstractActionConstraintMatch actionConstraintMatch;
+
+    @Before
+    public void setUp() throws Exception {
+        handler = new ConstraintMatchValueChangeHandler(actionConstraintMatch);
+    }
+
+    @Test
+    public void testNewConstraintMatchValue() throws Exception {
+        assertSetNewConstraintMatch("$person.getAge()");
+    }
+
+    @Test
+    public void testNewNullConstraintMatchValue() throws Exception {
+        assertSetNewConstraintMatch(null);
+    }
+
+    @Test
+    public void testNewEmptyConstraintMatchValue() throws Exception {
+        assertSetNewConstraintMatch("");
+    }
+
+    private void assertSetNewConstraintMatch(String newValue) {
+        ValueChangeEvent<String> event = mock(ValueChangeEvent.class);
+        when(event.getValue()).thenReturn(newValue);
+        handler.onValueChange(event);
+
+        verify(actionConstraintMatch).setConstraintMatch(newValue);
+    }
+}


### PR DESCRIPTION
This PR prevents the code generation if user didn't put value of score into the given input field. 

Previously if user didn't put value of score, there was generated code like:
```java
scoreHolder.addHardConstraintMatch(kcontext, null);
```
This is problem because most holders use just simple types like `int`.

Problem of my PR is that if user saves Guided Rule, where no all scores are put, then Modify Score actions are not preserved in the Guided Rule during reopening. 

I had in mind second solution, that would display some warning message next to score input fields where score is missing.

@mcimbora please could you have a look and give some proposals, suggestions or anything?