### PR TITLE
AF-540: adapted to use appformer generic java model

### DIFF
--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-api/pom.xml
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-api/pom.xml
@@ -32,6 +32,11 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-project-datamodel-api</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.drools</groupId>
       <artifactId>drools-workbench-models-datamodel-api</artifactId>
     </dependency>

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-api/src/main/java/org/optaplanner/workbench/screens/guidedrule/util/TemplateUtils.java
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-api/src/main/java/org/optaplanner/workbench/screens/guidedrule/util/TemplateUtils.java
@@ -22,7 +22,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.function.Function;
 
-import org.drools.workbench.models.datamodel.oracle.DataType;
+import org.appformer.project.datamodel.oracle.DataType;
 import org.drools.workbench.models.datamodel.rule.InterpolationVariable;
 
 public final class TemplateUtils {

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-api/src/main/resources/org/optaplanner/workbench/screens/guidedrule/OptaPlannerWorkbenchGuidedRuleEditorAPI.gwt.xml
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-api/src/main/resources/org/optaplanner/workbench/screens/guidedrule/OptaPlannerWorkbenchGuidedRuleEditorAPI.gwt.xml
@@ -19,6 +19,9 @@
     "http://www.gwtproject.org/doctype/2.7.0/gwt-module.dtd">
 <module>
 
+  <!-- DataModel dependencies -->
+  <inherits name="org.appformer.project.datamodel.AFProjectDataModelAPI"/>
+
   <source path="model"/>
   <source path="util"/>
   <source path="service"/>

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-api/src/test/java/org/optaplanner/workbench/screens/guidedrule/model/ActionConstraintMatchTest.java
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-api/src/test/java/org/optaplanner/workbench/screens/guidedrule/model/ActionConstraintMatchTest.java
@@ -20,7 +20,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.function.Function;
 
-import org.drools.workbench.models.datamodel.oracle.DataType;
+import org.appformer.project.datamodel.oracle.DataType;
 import org.drools.workbench.models.datamodel.rule.IAction;
 import org.drools.workbench.models.datamodel.rule.InterpolationVariable;
 import org.junit.Test;

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-api/src/test/java/org/optaplanner/workbench/screens/guidedrule/util/TemplateUtilsTest.java
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-api/src/test/java/org/optaplanner/workbench/screens/guidedrule/util/TemplateUtilsTest.java
@@ -19,7 +19,7 @@ package org.optaplanner.workbench.screens.guidedrule.util;
 import java.util.Collection;
 import java.util.function.Function;
 
-import org.drools.workbench.models.datamodel.oracle.DataType;
+import org.appformer.project.datamodel.oracle.DataType;
 import org.drools.workbench.models.datamodel.rule.InterpolationVariable;
 import org.junit.Test;
 

--- a/optaplanner-wb-webapp/pom.xml
+++ b/optaplanner-wb-webapp/pom.xml
@@ -250,6 +250,12 @@
       <artifactId>log4j-over-slf4j</artifactId>
     </dependency>
 
+    <!-- Models held within AppFormer -->
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-project-datamodel-api</artifactId>
+    </dependency>
+
     <!-- Models held within Drools -->
     <dependency>
       <groupId>org.drools</groupId>
@@ -1209,6 +1215,9 @@
             <compileSourcesArtifact>org.uberfire:uberfire-wires-core-client</compileSourcesArtifact>
             <compileSourcesArtifact>org.uberfire:uberfire-wires-core-grids</compileSourcesArtifact>
             <compileSourcesArtifact>org.uberfire:uberfire-wires-core-trees</compileSourcesArtifact>
+
+            <!-- AppFormer DataModel -->
+            <compileSourcesArtifact>org.uberfire:uberfire-project-datamodel-api</compileSourcesArtifact>
 
             <!-- UberFire -->
             <compileSourcesArtifact>org.uberfire:uberfire-maven-support</compileSourcesArtifact>

--- a/optaplanner-wb-webapp/src/main/resources/org/optaplanner/workbench/OptaPlannerWorkbench.gwt.xml
+++ b/optaplanner-wb-webapp/src/main/resources/org/optaplanner/workbench/OptaPlannerWorkbench.gwt.xml
@@ -16,6 +16,9 @@
   <inherits name="org.uberfire.ext.widgets.common.UberfireWidgetsCommons"/>
   <inherits name="org.uberfire.ext.preferences.UberfirePreferences"/>
 
+  <!-- DataModel dependencies -->
+  <inherits name="org.appformer.project.datamodel.AFProjectDataModelAPI"/>
+
   <!-- Guvnor dependencies -->
   <inherits name='org.guvnor.asset.management.GuvnorAssetMgmtClient'/>
   <inherits name='org.guvnor.structure.GuvnorStructureClient'/>


### PR DESCRIPTION
This is a mandatory step before merging the repos to form AppFormer single repository.

Related PRs:
https://github.com/AppFormer/uberfire/pull/784
https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/487
https://github.com/kiegroup/drools/pull/1397
https://github.com/kiegroup/droolsjbpm-integration/pull/1135
https://github.com/kiegroup/guvnor/pull/484
https://github.com/kiegroup/kie-wb-common/pull/1005
https://github.com/kiegroup/drools-wb/pull/560
https://github.com/kiegroup/optaplanner-wb/pull/205