### PR TITLE
PLANNER-824: Long Score Holders can be filled with float values

### DIFF
--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/plugin/ActionPluginClientService.java
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/plugin/ActionPluginClientService.java
@@ -75,14 +75,14 @@ public class ActionPluginClientService {
                                               scoreInformation -> {
                                                   Collection<String> scoreHolderFqns = scoreInformation.getScoreHolderFqnTypeFqns();
                                                   if (scoreHolderFqns.isEmpty()) {
-                                                      scoreHolderGlobalAware.scoreHolderGlobalIssueDetected(translationService.getTranslation(GuidedRuleEditorConstants.ActionPluginClientServiceScoreHolderGlobalNotFound));
+                                                      scoreHolderGlobalAware.scoreHolderGlobalIssueDetected(translationService.getTranslation(GuidedRuleEditorConstants.ActionPluginClientService_ScoreHolderGlobalNotFound));
                                                   } else if (scoreHolderFqns.size() > 1) {
-                                                      scoreHolderGlobalAware.scoreHolderGlobalIssueDetected(translationService.getTranslation(translationService.getTranslation(GuidedRuleEditorConstants.ActionPluginClientServiceMultipleScoreHolderGlobals)));
+                                                      scoreHolderGlobalAware.scoreHolderGlobalIssueDetected(translationService.getTranslation(translationService.getTranslation(GuidedRuleEditorConstants.ActionPluginClientService_MultipleScoreHolderGlobals)));
                                                   } else if (scoreHolderFqns.size() == 1) {
                                                       if (!supportedScoreHolderTypes.containsAll(scoreHolderFqns)) {
-                                                          scoreHolderGlobalAware.scoreHolderGlobalIssueDetected(translationService.getTranslation(GuidedRuleEditorConstants.ActionPluginClientServiceScoreTypeNotSupported));
+                                                          scoreHolderGlobalAware.scoreHolderGlobalIssueDetected(translationService.getTranslation(GuidedRuleEditorConstants.ActionPluginClientService_ScoreTypeNotSupported));
                                                       } else {
-                                                          scoreHolderGlobalAware.scoreHolderGlobalLoadedCorrectly();
+                                                          scoreHolderGlobalAware.scoreHolderGlobalLoadedCorrectly(scoreHolderFqns.iterator().next());
                                                       }
                                                   }
                                               });

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/plugin/BendableHardConstraintMatchRuleModellerActionPlugin.java
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/plugin/BendableHardConstraintMatchRuleModellerActionPlugin.java
@@ -27,13 +27,11 @@ import org.drools.workbench.models.datamodel.rule.IAction;
 import org.drools.workbench.screens.guided.rule.client.editor.RuleModeller;
 import org.drools.workbench.screens.guided.rule.client.editor.plugin.RuleModellerActionPlugin;
 import org.drools.workbench.screens.guided.rule.client.widget.RuleModellerWidget;
-import org.jboss.errai.common.client.api.Caller;
 import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.optaplanner.workbench.screens.guidedrule.client.resources.i18n.GuidedRuleEditorConstants;
 import org.optaplanner.workbench.screens.guidedrule.client.widget.BendableConstraintMatchRuleModellerWidget;
 import org.optaplanner.workbench.screens.guidedrule.model.ActionBendableHardConstraintMatch;
 import org.optaplanner.workbench.screens.guidedrule.model.BendableScoreLevelsWrapper;
-import org.optaplanner.workbench.screens.guidedrule.service.ScoreHolderService;
 import org.uberfire.mvp.Command;
 
 @ApplicationScoped
@@ -47,9 +45,6 @@ public class BendableHardConstraintMatchRuleModellerActionPlugin implements Rule
         SUPPORTED_SCORE_HOLDER_TYPES.add("org.optaplanner.core.api.score.buildin.bendablelong.BendableLongScoreHolder");
         SUPPORTED_SCORE_HOLDER_TYPES.add("org.optaplanner.core.api.score.buildin.bendablebigdecimal.BendableBigDecimalScoreHolder");
     }
-
-    @Inject
-    private Caller<ScoreHolderService> scoreHolderService;
 
     @Inject
     private ActionPluginClientService actionPluginClientService;
@@ -85,7 +80,7 @@ public class BendableHardConstraintMatchRuleModellerActionPlugin implements Rule
 
     @Override
     public String getActionAddDescription() {
-        return translationService.getTranslation(GuidedRuleEditorConstants.RuleModellerActionPluginModifyHardScore);
+        return translationService.getTranslation(GuidedRuleEditorConstants.RuleModellerActionPlugin_ModifyHardScore);
     }
 
     @Override
@@ -98,7 +93,7 @@ public class BendableHardConstraintMatchRuleModellerActionPlugin implements Rule
                                                                                                          (ActionBendableHardConstraintMatch) iAction,
                                                                                                          translationService,
                                                                                                          readOnly,
-                                                                                                         GuidedRuleEditorConstants.RuleModellerActionPluginHardScore);
+                                                                                                         GuidedRuleEditorConstants.RuleModellerActionPlugin_HardScore);
         actionPluginClientService.initScoreHolderAwarePlugin(ruleModeller,
                                                              widget,
                                                              SUPPORTED_SCORE_HOLDER_TYPES);

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/plugin/BendableSoftConstraintMatchRuleModellerActionPlugin.java
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/plugin/BendableSoftConstraintMatchRuleModellerActionPlugin.java
@@ -27,13 +27,11 @@ import org.drools.workbench.models.datamodel.rule.IAction;
 import org.drools.workbench.screens.guided.rule.client.editor.RuleModeller;
 import org.drools.workbench.screens.guided.rule.client.editor.plugin.RuleModellerActionPlugin;
 import org.drools.workbench.screens.guided.rule.client.widget.RuleModellerWidget;
-import org.jboss.errai.common.client.api.Caller;
 import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.optaplanner.workbench.screens.guidedrule.client.resources.i18n.GuidedRuleEditorConstants;
 import org.optaplanner.workbench.screens.guidedrule.client.widget.BendableConstraintMatchRuleModellerWidget;
 import org.optaplanner.workbench.screens.guidedrule.model.ActionBendableSoftConstraintMatch;
 import org.optaplanner.workbench.screens.guidedrule.model.BendableScoreLevelsWrapper;
-import org.optaplanner.workbench.screens.guidedrule.service.ScoreHolderService;
 import org.uberfire.mvp.Command;
 
 @ApplicationScoped
@@ -47,9 +45,6 @@ public class BendableSoftConstraintMatchRuleModellerActionPlugin implements Rule
         SUPPORTED_SCORE_HOLDER_TYPES.add("org.optaplanner.core.api.score.buildin.bendablelong.BendableLongScoreHolder");
         SUPPORTED_SCORE_HOLDER_TYPES.add("org.optaplanner.core.api.score.buildin.bendablebigdecimal.BendableBigDecimalScoreHolder");
     }
-
-    @Inject
-    private Caller<ScoreHolderService> scoreHolderService;
 
     @Inject
     private ActionPluginClientService actionPluginClientService;
@@ -85,7 +80,7 @@ public class BendableSoftConstraintMatchRuleModellerActionPlugin implements Rule
 
     @Override
     public String getActionAddDescription() {
-        return translationService.getTranslation(GuidedRuleEditorConstants.RuleModellerActionPluginModifySoftScore);
+        return translationService.getTranslation(GuidedRuleEditorConstants.RuleModellerActionPlugin_ModifySoftScore);
     }
 
     @Override
@@ -98,7 +93,7 @@ public class BendableSoftConstraintMatchRuleModellerActionPlugin implements Rule
                                                                                                          (ActionBendableSoftConstraintMatch) iAction,
                                                                                                          translationService,
                                                                                                          readOnly,
-                                                                                                         GuidedRuleEditorConstants.RuleModellerActionPluginSoftScore);
+                                                                                                         GuidedRuleEditorConstants.RuleModellerActionPlugin_SoftScore);
         actionPluginClientService.initScoreHolderAwarePlugin(ruleModeller,
                                                              widget,
                                                              SUPPORTED_SCORE_HOLDER_TYPES);

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/plugin/HardConstraintMatchRuleModellerActionPlugin.java
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/plugin/HardConstraintMatchRuleModellerActionPlugin.java
@@ -25,12 +25,10 @@ import org.drools.workbench.models.datamodel.rule.IAction;
 import org.drools.workbench.screens.guided.rule.client.editor.RuleModeller;
 import org.drools.workbench.screens.guided.rule.client.editor.plugin.RuleModellerActionPlugin;
 import org.drools.workbench.screens.guided.rule.client.widget.RuleModellerWidget;
-import org.jboss.errai.common.client.api.Caller;
 import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.optaplanner.workbench.screens.guidedrule.client.resources.i18n.GuidedRuleEditorConstants;
 import org.optaplanner.workbench.screens.guidedrule.client.widget.ConstraintMatchRuleModellerWidget;
 import org.optaplanner.workbench.screens.guidedrule.model.ActionHardConstraintMatch;
-import org.optaplanner.workbench.screens.guidedrule.service.ScoreHolderService;
 import org.uberfire.mvp.Command;
 
 @ApplicationScoped
@@ -48,9 +46,6 @@ public class HardConstraintMatchRuleModellerActionPlugin implements RuleModeller
         SUPPORTED_SCORE_HOLDER_TYPES.add("org.optaplanner.core.api.score.buildin.hardsoftdouble.HardSoftDoubleScoreHolder");
         SUPPORTED_SCORE_HOLDER_TYPES.add("org.optaplanner.core.api.score.buildin.hardsoftlong.HardSoftLongScoreHolder");
     }
-
-    @Inject
-    private Caller<ScoreHolderService> scoreHolderService;
 
     @Inject
     private ActionPluginClientService actionPluginClientService;
@@ -86,7 +81,7 @@ public class HardConstraintMatchRuleModellerActionPlugin implements RuleModeller
 
     @Override
     public String getActionAddDescription() {
-        return translationService.getTranslation(GuidedRuleEditorConstants.RuleModellerActionPluginModifyHardScore);
+        return translationService.getTranslation(GuidedRuleEditorConstants.RuleModellerActionPlugin_ModifyHardScore);
     }
 
     @Override
@@ -99,7 +94,7 @@ public class HardConstraintMatchRuleModellerActionPlugin implements RuleModeller
                                                                                          (ActionHardConstraintMatch) iAction,
                                                                                          translationService,
                                                                                          readOnly,
-                                                                                         GuidedRuleEditorConstants.RuleModellerActionPluginHardScore);
+                                                                                         GuidedRuleEditorConstants.RuleModellerActionPlugin_HardScore);
         actionPluginClientService.initScoreHolderAwarePlugin(ruleModeller,
                                                              widget,
                                                              SUPPORTED_SCORE_HOLDER_TYPES);

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/plugin/MediumConstraintMatchRuleModellerActionPlugin.java
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/plugin/MediumConstraintMatchRuleModellerActionPlugin.java
@@ -26,12 +26,10 @@ import org.drools.workbench.models.datamodel.rule.IAction;
 import org.drools.workbench.screens.guided.rule.client.editor.RuleModeller;
 import org.drools.workbench.screens.guided.rule.client.editor.plugin.RuleModellerActionPlugin;
 import org.drools.workbench.screens.guided.rule.client.widget.RuleModellerWidget;
-import org.jboss.errai.common.client.api.Caller;
 import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.optaplanner.workbench.screens.guidedrule.client.resources.i18n.GuidedRuleEditorConstants;
 import org.optaplanner.workbench.screens.guidedrule.client.widget.ConstraintMatchRuleModellerWidget;
 import org.optaplanner.workbench.screens.guidedrule.model.ActionMediumConstraintMatch;
-import org.optaplanner.workbench.screens.guidedrule.service.ScoreHolderService;
 import org.uberfire.mvp.Command;
 
 @ApplicationScoped
@@ -45,9 +43,6 @@ public class MediumConstraintMatchRuleModellerActionPlugin implements RuleModell
         SUPPORTED_SCORE_HOLDER_TYPES.add("org.optaplanner.core.api.score.buildin.hardmediumsoftbigdecimal.HardMediumSoftBigDecimalScoreHolder");
         SUPPORTED_SCORE_HOLDER_TYPES.add("org.optaplanner.core.api.score.buildin.hardmediumsoftlong.HardMediumSoftLongScoreHolder");
     }
-
-    @Inject
-    private Caller<ScoreHolderService> scoreHolderService;
 
     @Inject
     private ActionPluginClientService actionPluginClientService;
@@ -83,7 +78,7 @@ public class MediumConstraintMatchRuleModellerActionPlugin implements RuleModell
 
     @Override
     public String getActionAddDescription() {
-        return translationService.getTranslation(GuidedRuleEditorConstants.RuleModellerActionPluginModifyMediumScore);
+        return translationService.getTranslation(GuidedRuleEditorConstants.RuleModellerActionPlugin_ModifyMediumScore);
     }
 
     @Override
@@ -97,7 +92,7 @@ public class MediumConstraintMatchRuleModellerActionPlugin implements RuleModell
                                                                                          (ActionMediumConstraintMatch) iAction,
                                                                                          translationService,
                                                                                          readOnly,
-                                                                                         GuidedRuleEditorConstants.RuleModellerActionPluginMediumScore);
+                                                                                         GuidedRuleEditorConstants.RuleModellerActionPlugin_MediumScore);
         actionPluginClientService.initScoreHolderAwarePlugin(ruleModeller,
                                                              widget,
                                                              SUPPORTED_SCORE_HOLDER_TYPES);

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/plugin/MultiConstraintBendableBigDecimalMatchRuleModellerActionPlugin.java
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/plugin/MultiConstraintBendableBigDecimalMatchRuleModellerActionPlugin.java
@@ -27,13 +27,11 @@ import org.drools.workbench.models.datamodel.rule.IAction;
 import org.drools.workbench.screens.guided.rule.client.editor.RuleModeller;
 import org.drools.workbench.screens.guided.rule.client.editor.plugin.RuleModellerActionPlugin;
 import org.drools.workbench.screens.guided.rule.client.widget.RuleModellerWidget;
-import org.jboss.errai.common.client.api.Caller;
 import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.optaplanner.workbench.screens.guidedrule.client.resources.i18n.GuidedRuleEditorConstants;
 import org.optaplanner.workbench.screens.guidedrule.client.widget.MultiConstraintBendableMatchRuleModellerWidget;
 import org.optaplanner.workbench.screens.guidedrule.model.ActionMultiConstraintBendableBigDecimalMatch;
 import org.optaplanner.workbench.screens.guidedrule.model.BendableScoreLevelsWrapper;
-import org.optaplanner.workbench.screens.guidedrule.service.ScoreHolderService;
 import org.uberfire.mvp.Command;
 
 @ApplicationScoped
@@ -45,9 +43,6 @@ public class MultiConstraintBendableBigDecimalMatchRuleModellerActionPlugin impl
         SUPPORTED_SCORE_HOLDER_TYPES = new HashSet<>(1);
         SUPPORTED_SCORE_HOLDER_TYPES.add("org.optaplanner.core.api.score.buildin.bendablebigdecimal.BendableBigDecimalScoreHolder");
     }
-
-    @Inject
-    private Caller<ScoreHolderService> scoreHolderService;
 
     @Inject
     private ActionPluginClientService actionPluginClientService;
@@ -87,7 +82,7 @@ public class MultiConstraintBendableBigDecimalMatchRuleModellerActionPlugin impl
 
     @Override
     public String getActionAddDescription() {
-        return translationService.getTranslation(GuidedRuleEditorConstants.RuleModellerActionPluginModifyMultipleScoreLevels);
+        return translationService.getTranslation(GuidedRuleEditorConstants.RuleModellerActionPlugin_ModifyMultipleScoreLevels);
     }
 
     @Override

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/plugin/MultiConstraintBendableLongMatchRuleModellerActionPlugin.java
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/plugin/MultiConstraintBendableLongMatchRuleModellerActionPlugin.java
@@ -27,13 +27,11 @@ import org.drools.workbench.models.datamodel.rule.IAction;
 import org.drools.workbench.screens.guided.rule.client.editor.RuleModeller;
 import org.drools.workbench.screens.guided.rule.client.editor.plugin.RuleModellerActionPlugin;
 import org.drools.workbench.screens.guided.rule.client.widget.RuleModellerWidget;
-import org.jboss.errai.common.client.api.Caller;
 import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.optaplanner.workbench.screens.guidedrule.client.resources.i18n.GuidedRuleEditorConstants;
 import org.optaplanner.workbench.screens.guidedrule.client.widget.MultiConstraintBendableMatchRuleModellerWidget;
 import org.optaplanner.workbench.screens.guidedrule.model.ActionMultiConstraintBendableLongMatch;
 import org.optaplanner.workbench.screens.guidedrule.model.BendableScoreLevelsWrapper;
-import org.optaplanner.workbench.screens.guidedrule.service.ScoreHolderService;
 import org.uberfire.mvp.Command;
 
 @ApplicationScoped
@@ -45,9 +43,6 @@ public class MultiConstraintBendableLongMatchRuleModellerActionPlugin implements
         SUPPORTED_SCORE_HOLDER_TYPES = new HashSet<>(1);
         SUPPORTED_SCORE_HOLDER_TYPES.add("org.optaplanner.core.api.score.buildin.bendablelong.BendableLongScoreHolder");
     }
-
-    @Inject
-    private Caller<ScoreHolderService> scoreHolderService;
 
     @Inject
     private ActionPluginClientService actionPluginClientService;
@@ -87,7 +82,7 @@ public class MultiConstraintBendableLongMatchRuleModellerActionPlugin implements
 
     @Override
     public String getActionAddDescription() {
-        return translationService.getTranslation(GuidedRuleEditorConstants.RuleModellerActionPluginModifyMultipleScoreLevels);
+        return translationService.getTranslation(GuidedRuleEditorConstants.RuleModellerActionPlugin_ModifyMultipleScoreLevels);
     }
 
     @Override

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/plugin/MultiConstraintBendableMatchRuleModellerActionPlugin.java
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/plugin/MultiConstraintBendableMatchRuleModellerActionPlugin.java
@@ -27,13 +27,11 @@ import org.drools.workbench.models.datamodel.rule.IAction;
 import org.drools.workbench.screens.guided.rule.client.editor.RuleModeller;
 import org.drools.workbench.screens.guided.rule.client.editor.plugin.RuleModellerActionPlugin;
 import org.drools.workbench.screens.guided.rule.client.widget.RuleModellerWidget;
-import org.jboss.errai.common.client.api.Caller;
 import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.optaplanner.workbench.screens.guidedrule.client.resources.i18n.GuidedRuleEditorConstants;
 import org.optaplanner.workbench.screens.guidedrule.client.widget.MultiConstraintBendableMatchRuleModellerWidget;
 import org.optaplanner.workbench.screens.guidedrule.model.ActionMultiConstraintBendableMatch;
 import org.optaplanner.workbench.screens.guidedrule.model.BendableScoreLevelsWrapper;
-import org.optaplanner.workbench.screens.guidedrule.service.ScoreHolderService;
 import org.uberfire.mvp.Command;
 
 @ApplicationScoped
@@ -45,9 +43,6 @@ public class MultiConstraintBendableMatchRuleModellerActionPlugin implements Rul
         SUPPORTED_SCORE_HOLDER_TYPES = new HashSet<>(1);
         SUPPORTED_SCORE_HOLDER_TYPES.add("org.optaplanner.core.api.score.buildin.bendable.BendableScoreHolder");
     }
-
-    @Inject
-    private Caller<ScoreHolderService> scoreHolderService;
 
     @Inject
     private ActionPluginClientService actionPluginClientService;
@@ -88,7 +83,7 @@ public class MultiConstraintBendableMatchRuleModellerActionPlugin implements Rul
 
     @Override
     public String getActionAddDescription() {
-        return translationService.getTranslation(GuidedRuleEditorConstants.RuleModellerActionPluginModifyMultipleScoreLevels);
+        return translationService.getTranslation(GuidedRuleEditorConstants.RuleModellerActionPlugin_ModifyMultipleScoreLevels);
     }
 
     @Override

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/plugin/MultiConstraintHardMediumSoftMatchRuleModellerActionPlugin.java
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/plugin/MultiConstraintHardMediumSoftMatchRuleModellerActionPlugin.java
@@ -26,7 +26,6 @@ import org.drools.workbench.models.datamodel.rule.IAction;
 import org.drools.workbench.screens.guided.rule.client.editor.RuleModeller;
 import org.drools.workbench.screens.guided.rule.client.editor.plugin.RuleModellerActionPlugin;
 import org.drools.workbench.screens.guided.rule.client.widget.RuleModellerWidget;
-import org.jboss.errai.common.client.api.Caller;
 import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.optaplanner.workbench.screens.guidedrule.client.resources.i18n.GuidedRuleEditorConstants;
 import org.optaplanner.workbench.screens.guidedrule.client.widget.MultiConstraintHardMediumSoftMatchRuleModellerWidget;
@@ -34,7 +33,6 @@ import org.optaplanner.workbench.screens.guidedrule.model.ActionHardConstraintMa
 import org.optaplanner.workbench.screens.guidedrule.model.ActionMediumConstraintMatch;
 import org.optaplanner.workbench.screens.guidedrule.model.ActionMultiConstraintHardMediumSoftMatch;
 import org.optaplanner.workbench.screens.guidedrule.model.ActionSoftConstraintMatch;
-import org.optaplanner.workbench.screens.guidedrule.service.ScoreHolderService;
 import org.uberfire.mvp.Command;
 
 @ApplicationScoped
@@ -48,9 +46,6 @@ public class MultiConstraintHardMediumSoftMatchRuleModellerActionPlugin implemen
         SUPPORTED_SCORE_HOLDER_TYPES.add("org.optaplanner.core.api.score.buildin.hardmediumsoftbigdecimal.HardMediumSoftBigDecimalScoreHolder");
         SUPPORTED_SCORE_HOLDER_TYPES.add("org.optaplanner.core.api.score.buildin.hardmediumsoftlong.HardMediumSoftLongScoreHolder");
     }
-
-    @Inject
-    private Caller<ScoreHolderService> scoreHolderService;
 
     @Inject
     private ActionPluginClientService actionPluginClientService;
@@ -88,7 +83,7 @@ public class MultiConstraintHardMediumSoftMatchRuleModellerActionPlugin implemen
 
     @Override
     public String getActionAddDescription() {
-        return translationService.getTranslation(GuidedRuleEditorConstants.RuleModellerActionPluginModifyMultipleScoreLevels);
+        return translationService.getTranslation(GuidedRuleEditorConstants.RuleModellerActionPlugin_ModifyMultipleScoreLevels);
     }
 
     @Override

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/plugin/MultiConstraintHardSoftMatchRuleModellerActionPlugin.java
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/plugin/MultiConstraintHardSoftMatchRuleModellerActionPlugin.java
@@ -26,14 +26,12 @@ import org.drools.workbench.models.datamodel.rule.IAction;
 import org.drools.workbench.screens.guided.rule.client.editor.RuleModeller;
 import org.drools.workbench.screens.guided.rule.client.editor.plugin.RuleModellerActionPlugin;
 import org.drools.workbench.screens.guided.rule.client.widget.RuleModellerWidget;
-import org.jboss.errai.common.client.api.Caller;
 import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.optaplanner.workbench.screens.guidedrule.client.resources.i18n.GuidedRuleEditorConstants;
 import org.optaplanner.workbench.screens.guidedrule.client.widget.MultiConstraintHardSoftMatchRuleModellerWidget;
 import org.optaplanner.workbench.screens.guidedrule.model.ActionHardConstraintMatch;
 import org.optaplanner.workbench.screens.guidedrule.model.ActionMultiConstraintHardSoftMatch;
 import org.optaplanner.workbench.screens.guidedrule.model.ActionSoftConstraintMatch;
-import org.optaplanner.workbench.screens.guidedrule.service.ScoreHolderService;
 import org.uberfire.mvp.Command;
 
 @ApplicationScoped
@@ -48,9 +46,6 @@ public class MultiConstraintHardSoftMatchRuleModellerActionPlugin implements Rul
         SUPPORTED_SCORE_HOLDER_TYPES.add("org.optaplanner.core.api.score.buildin.hardsoftdouble.HardSoftDoubleScoreHolder");
         SUPPORTED_SCORE_HOLDER_TYPES.add("org.optaplanner.core.api.score.buildin.hardsoftlong.HardSoftLongScoreHolder");
     }
-
-    @Inject
-    private Caller<ScoreHolderService> scoreHolderService;
 
     @Inject
     private ActionPluginClientService actionPluginClientService;
@@ -87,7 +82,7 @@ public class MultiConstraintHardSoftMatchRuleModellerActionPlugin implements Rul
 
     @Override
     public String getActionAddDescription() {
-        return translationService.getTranslation(GuidedRuleEditorConstants.RuleModellerActionPluginModifyMultipleScoreLevels);
+        return translationService.getTranslation(GuidedRuleEditorConstants.RuleModellerActionPlugin_ModifyMultipleScoreLevels);
     }
 
     @Override

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/plugin/SimpleConstraintMatchRuleModellerActionPlugin.java
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/plugin/SimpleConstraintMatchRuleModellerActionPlugin.java
@@ -26,12 +26,10 @@ import org.drools.workbench.models.datamodel.rule.IAction;
 import org.drools.workbench.screens.guided.rule.client.editor.RuleModeller;
 import org.drools.workbench.screens.guided.rule.client.editor.plugin.RuleModellerActionPlugin;
 import org.drools.workbench.screens.guided.rule.client.widget.RuleModellerWidget;
-import org.jboss.errai.common.client.api.Caller;
 import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.optaplanner.workbench.screens.guidedrule.client.resources.i18n.GuidedRuleEditorConstants;
 import org.optaplanner.workbench.screens.guidedrule.client.widget.ConstraintMatchRuleModellerWidget;
 import org.optaplanner.workbench.screens.guidedrule.model.ActionSimpleConstraintMatch;
-import org.optaplanner.workbench.screens.guidedrule.service.ScoreHolderService;
 import org.uberfire.mvp.Command;
 
 @ApplicationScoped
@@ -46,9 +44,6 @@ public class SimpleConstraintMatchRuleModellerActionPlugin implements RuleModell
         SUPPORTED_SCORE_HOLDER_TYPES.add("org.optaplanner.core.api.score.buildin.simpledouble.SimpleDoubleScoreHolder");
         SUPPORTED_SCORE_HOLDER_TYPES.add("org.optaplanner.core.api.score.buildin.simplelong.SimpleLongScoreHolder");
     }
-
-    @Inject
-    private Caller<ScoreHolderService> scoreHolderService;
 
     @Inject
     private ActionPluginClientService actionPluginClientService;
@@ -84,7 +79,7 @@ public class SimpleConstraintMatchRuleModellerActionPlugin implements RuleModell
 
     @Override
     public String getActionAddDescription() {
-        return translationService.getTranslation(GuidedRuleEditorConstants.RuleModellerActionPluginModifySimpleScore);
+        return translationService.getTranslation(GuidedRuleEditorConstants.RuleModellerActionPlugin_ModifySimpleScore);
     }
 
     @Override
@@ -98,7 +93,7 @@ public class SimpleConstraintMatchRuleModellerActionPlugin implements RuleModell
                                                                                          (ActionSimpleConstraintMatch) iAction,
                                                                                          translationService,
                                                                                          readOnly,
-                                                                                         GuidedRuleEditorConstants.RuleModellerActionPluginSimpleScore);
+                                                                                         GuidedRuleEditorConstants.RuleModellerActionPlugin_SimpleScore);
         actionPluginClientService.initScoreHolderAwarePlugin(ruleModeller,
                                                              widget,
                                                              SUPPORTED_SCORE_HOLDER_TYPES);

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/plugin/SoftConstraintMatchRuleModellerActionPlugin.java
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/plugin/SoftConstraintMatchRuleModellerActionPlugin.java
@@ -26,12 +26,10 @@ import org.drools.workbench.models.datamodel.rule.IAction;
 import org.drools.workbench.screens.guided.rule.client.editor.RuleModeller;
 import org.drools.workbench.screens.guided.rule.client.editor.plugin.RuleModellerActionPlugin;
 import org.drools.workbench.screens.guided.rule.client.widget.RuleModellerWidget;
-import org.jboss.errai.common.client.api.Caller;
 import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.optaplanner.workbench.screens.guidedrule.client.resources.i18n.GuidedRuleEditorConstants;
 import org.optaplanner.workbench.screens.guidedrule.client.widget.ConstraintMatchRuleModellerWidget;
 import org.optaplanner.workbench.screens.guidedrule.model.ActionSoftConstraintMatch;
-import org.optaplanner.workbench.screens.guidedrule.service.ScoreHolderService;
 import org.uberfire.mvp.Command;
 
 @ApplicationScoped
@@ -49,9 +47,6 @@ public class SoftConstraintMatchRuleModellerActionPlugin implements RuleModeller
         SUPPORTED_SCORE_HOLDER_TYPES.add("org.optaplanner.core.api.score.buildin.hardsoftdouble.HardSoftDoubleScoreHolder");
         SUPPORTED_SCORE_HOLDER_TYPES.add("org.optaplanner.core.api.score.buildin.hardsoftlong.HardSoftLongScoreHolder");
     }
-
-    @Inject
-    private Caller<ScoreHolderService> scoreHolderService;
 
     @Inject
     private ActionPluginClientService actionPluginClientService;
@@ -87,7 +82,7 @@ public class SoftConstraintMatchRuleModellerActionPlugin implements RuleModeller
 
     @Override
     public String getActionAddDescription() {
-        return translationService.getTranslation(GuidedRuleEditorConstants.RuleModellerActionPluginModifySoftScore);
+        return translationService.getTranslation(GuidedRuleEditorConstants.RuleModellerActionPlugin_ModifySoftScore);
     }
 
     @Override
@@ -101,7 +96,7 @@ public class SoftConstraintMatchRuleModellerActionPlugin implements RuleModeller
                                                                                          (ActionSoftConstraintMatch) iAction,
                                                                                          translationService,
                                                                                          readOnly,
-                                                                                         GuidedRuleEditorConstants.RuleModellerActionPluginSoftScore);
+                                                                                         GuidedRuleEditorConstants.RuleModellerActionPlugin_SoftScore);
         actionPluginClientService.initScoreHolderAwarePlugin(ruleModeller,
                                                              widget,
                                                              SUPPORTED_SCORE_HOLDER_TYPES);

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/resources/i18n/GuidedRuleEditorConstants.java
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/resources/i18n/GuidedRuleEditorConstants.java
@@ -21,56 +21,68 @@ import org.jboss.errai.ui.shared.api.annotations.TranslationKey;
 public interface GuidedRuleEditorConstants {
 
     @TranslationKey(defaultValue = "")
-    String RuleModellerActionPluginModifyHardScore = "RuleModellerActionPlugin.ModifyHardScore";
+    String RuleModellerActionPlugin_ModifyHardScore = "RuleModellerActionPlugin.ModifyHardScore";
 
     @TranslationKey(defaultValue = "")
-    String RuleModellerActionPluginModifyMediumScore = "RuleModellerActionPlugin.ModifyMediumScore";
+    String RuleModellerActionPlugin_ModifyMediumScore = "RuleModellerActionPlugin.ModifyMediumScore";
 
     @TranslationKey(defaultValue = "")
-    String RuleModellerActionPluginModifyMultipleScoreLevels = "RuleModellerActionPlugin.ModifyMultipleScoreLevels";
+    String RuleModellerActionPlugin_ModifyMultipleScoreLevels = "RuleModellerActionPlugin.ModifyMultipleScoreLevels";
 
     @TranslationKey(defaultValue = "")
-    String RuleModellerActionPluginModifySimpleScore = "RuleModellerActionPlugin.ModifySimpleScore";
+    String RuleModellerActionPlugin_ModifySimpleScore = "RuleModellerActionPlugin.ModifySimpleScore";
 
     @TranslationKey(defaultValue = "")
-    String RuleModellerActionPluginModifySoftScore = "RuleModellerActionPlugin.ModifySoftScore";
+    String RuleModellerActionPlugin_ModifySoftScore = "RuleModellerActionPlugin.ModifySoftScore";
 
     @TranslationKey(defaultValue = "")
-    String RuleModellerActionPluginHardScore = "RuleModellerActionPlugin.HardScore";
+    String RuleModellerActionPlugin_HardScore = "RuleModellerActionPlugin.HardScore";
 
     @TranslationKey(defaultValue = "")
-    String RuleModellerActionPluginMediumScore = "RuleModellerActionPlugin.MediumScore";
+    String RuleModellerActionPlugin_MediumScore = "RuleModellerActionPlugin.MediumScore";
 
     @TranslationKey(defaultValue = "")
-    String RuleModellerActionPluginSimpleScore = "RuleModellerActionPlugin.SimpleScore";
+    String RuleModellerActionPlugin_SimpleScore = "RuleModellerActionPlugin.SimpleScore";
 
     @TranslationKey(defaultValue = "")
-    String RuleModellerActionPluginSoftScore = "RuleModellerActionPlugin.SoftScore";
+    String RuleModellerActionPlugin_SoftScore = "RuleModellerActionPlugin.SoftScore";
 
     @TranslationKey(defaultValue = "")
-    String RuleModellerActionPluginMultiConstraintMatch = "RuleModellerActionPlugin.MultiConstraintMatch";
+    String RuleModellerActionPlugin_MultiConstraintMatch = "RuleModellerActionPlugin.MultiConstraintMatch";
 
     @TranslationKey(defaultValue = "")
-    String RuleModellerActionPluginHardScoreLevelSizeIsZero = "RuleModellerActionPlugin.HardScoreLevelSizeIsZero";
+    String RuleModellerActionPlugin_HardScoreLevelSizeIsZero = "RuleModellerActionPlugin.HardScoreLevelSizeIsZero";
 
     @TranslationKey(defaultValue = "")
-    String RuleModellerActionPluginSoftScoreLevelSizeIsZero = "RuleModellerActionPlugin.SoftScoreLevelSizeIsZero";
+    String RuleModellerActionPlugin_SoftScoreLevelSizeIsZero = "RuleModellerActionPlugin.SoftScoreLevelSizeIsZero";
 
     @TranslationKey(defaultValue = "")
-    String RuleModellerActionPluginScoreLevelExceeded = "RuleModellerActionPlugin.ScoreLevelExceeded";
+    String RuleModellerActionPlugin_ScoreLevelExceeded = "RuleModellerActionPlugin.ScoreLevelExceeded";
 
     @TranslationKey(defaultValue = "")
-    String RuleModellerActionPluginAmbigiousConstraintMatchesDetected = "RuleModellerActionPlugin.AmbigiousConstraintMatchesDetected";
+    String RuleModellerActionPlugin_AmbigiousConstraintMatchesDetected = "RuleModellerActionPlugin.AmbigiousConstraintMatchesDetected";
 
     @TranslationKey(defaultValue = "")
-    String RuleModellerActionPluginEmptyValuesAreNotAllowedForModifyScore = "RuleModellerActionPlugin.EmptyValuesAreNotAllowedForModifyScore";
+    String ConstraintMatchInputWidgetBlurHandler_EmptyValuesAreNotAllowedForModifyScore = "ConstraintMatchInputWidgetBlurHandler.EmptyValuesAreNotAllowedForModifyScore";
 
     @TranslationKey(defaultValue = "")
-    String ActionPluginClientServiceScoreHolderGlobalNotFound = "ActionPluginClientService.ScoreHolderGlobalNotFound";
+    String ConstraintMatchInputWidgetBlurHandler_IntegerValueParsingError = "ConstraintMatchInputWidgetBlurHandler.IntegerValueParsingError";
 
     @TranslationKey(defaultValue = "")
-    String ActionPluginClientServiceMultipleScoreHolderGlobals = "ActionPluginClientService.MultipleScoreHolderGlobals";
+    String ConstraintMatchInputWidgetBlurHandler_LongValueParsingError = "ConstraintMatchInputWidgetBlurHandler.LongValueParsingError";
 
     @TranslationKey(defaultValue = "")
-    String ActionPluginClientServiceScoreTypeNotSupported = "ActionPluginClientService.ScoreTypeNotSupported";
+    String ConstraintMatchInputWidgetBlurHandler_DoubleValueParsingError = "ConstraintMatchInputWidgetBlurHandler.DoubleValueParsingError";
+
+    @TranslationKey(defaultValue = "")
+    String ConstraintMatchInputWidgetBlurHandler_BigDecimalValueParsingError = "ConstraintMatchInputWidgetBlurHandler.BigDecimalValueParsingError";
+
+    @TranslationKey(defaultValue = "")
+    String ActionPluginClientService_ScoreHolderGlobalNotFound = "ActionPluginClientService.ScoreHolderGlobalNotFound";
+
+    @TranslationKey(defaultValue = "")
+    String ActionPluginClientService_MultipleScoreHolderGlobals = "ActionPluginClientService.MultipleScoreHolderGlobals";
+
+    @TranslationKey(defaultValue = "")
+    String ActionPluginClientService_ScoreTypeNotSupported = "ActionPluginClientService.ScoreTypeNotSupported";
 }

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/widget/AbstractConstraintMatchRuleModellerWidget.java
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/widget/AbstractConstraintMatchRuleModellerWidget.java
@@ -76,7 +76,7 @@ public abstract class AbstractConstraintMatchRuleModellerWidget extends RuleMode
         long actionConstraintMatchCount = Arrays.stream(model.rhs).filter(a -> a instanceof ActionConstraintMatch).count();
 
         if (actionConstraintMatchCount > 1) {
-            messages.add(translationService.getTranslation(GuidedRuleEditorConstants.RuleModellerActionPluginAmbigiousConstraintMatchesDetected));
+            messages.add(translationService.getTranslation(GuidedRuleEditorConstants.RuleModellerActionPlugin_AmbigiousConstraintMatchesDetected));
 
             displayMessages();
         }

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/widget/BendableConstraintMatchRuleModellerWidget.java
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/widget/BendableConstraintMatchRuleModellerWidget.java
@@ -47,10 +47,7 @@ public class BendableConstraintMatchRuleModellerWidget extends AbstractConstrain
               translationService);
 
         this.actionConstraintMatch = actionConstraintMatch;
-        constraintMatchInputWidget = new ConstraintMatchInputWidget(actionConstraintMatch,
-                                                                    translationService);
-        constraintMatchInputWidget
-                .addConstraintMatchBlurHandler(new ConstraintMatchInputWidgetBlurHandler(constraintMatchInputWidget));
+        constraintMatchInputWidget = new ConstraintMatchInputWidget(actionConstraintMatch);
         constraintMatchInputWidget
                 .addConstraintMatchValueChangeHandler(new ConstraintMatchValueChangeHandler(actionConstraintMatch));
 
@@ -106,16 +103,21 @@ public class BendableConstraintMatchRuleModellerWidget extends AbstractConstrain
     }
 
     @Override
-    public void scoreHolderGlobalLoadedCorrectly() {
+    public void scoreHolderGlobalLoadedCorrectly(final String scoreHolderType) {
         constraintMatchInputWidget.setEnabled(true);
         constraintLevelTextBox.setEnabled(true);
+
+        constraintMatchInputWidget
+                .addConstraintMatchBlurHandler(new ConstraintMatchInputWidgetBlurHandler(constraintMatchInputWidget,
+                                                                                         translationService,
+                                                                                         scoreHolderType));
     }
 
     public void setScoreLevels(final int scoreLevelSize) {
         int currentLevelSize = actionConstraintMatch.getPosition();
 
         if (currentLevelSize >= scoreLevelSize) {
-            constraintLevelSelectHelpIcon.setHelpContent(translationService.getTranslation(GuidedRuleEditorConstants.RuleModellerActionPluginScoreLevelExceeded));
+            constraintLevelSelectHelpIcon.setHelpContent(translationService.getTranslation(GuidedRuleEditorConstants.RuleModellerActionPlugin_ScoreLevelExceeded));
             constraintLevelSelectHelpIcon.setVisible(true);
         } else {
             constraintLevelTextBox.getElement().setAttribute("max",

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/widget/ConstraintMatchInputWidget.java
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/widget/ConstraintMatchInputWidget.java
@@ -24,8 +24,6 @@ import com.google.gwt.event.shared.HandlerRegistration;
 import org.gwtbootstrap3.client.ui.FormGroup;
 import org.gwtbootstrap3.client.ui.HelpBlock;
 import org.gwtbootstrap3.client.ui.TextBox;
-import org.jboss.errai.ui.client.local.spi.TranslationService;
-import org.optaplanner.workbench.screens.guidedrule.client.resources.i18n.GuidedRuleEditorConstants;
 import org.optaplanner.workbench.screens.guidedrule.model.AbstractActionConstraintMatch;
 import org.uberfire.client.views.pfly.widgets.ValidationState;
 
@@ -35,28 +33,17 @@ public class ConstraintMatchInputWidget extends FormGroup {
 
     private HelpBlock helpBlock;
 
-    private TranslationService translationService;
-
-    public ConstraintMatchInputWidget(AbstractActionConstraintMatch actionConstraintMatch,
-                                      TranslationService translationService) {
-
-        this.translationService = translationService;
-
+    public ConstraintMatchInputWidget(final AbstractActionConstraintMatch actionConstraintMatch) {
         constraintMatchTextBox = new TextBox();
         helpBlock = new HelpBlock();
         add(constraintMatchTextBox);
         add(helpBlock);
 
         constraintMatchTextBox.setValue(actionConstraintMatch.getConstraintMatch() == null ? "" : actionConstraintMatch.getConstraintMatch());
-
         constraintMatchTextBox.setEnabled(false);
     }
 
-    public void showEmptyValuesNotAllowedError() {
-        showError(translationService.getTranslation(GuidedRuleEditorConstants.RuleModellerActionPluginEmptyValuesAreNotAllowedForModifyScore));
-    }
-
-    private void showError(String errorMessage) {
+    public void showError(final String errorMessage) {
         addStyleName(ValidationState.ERROR.getCssName());
         helpBlock.setError(errorMessage);
     }
@@ -70,18 +57,19 @@ public class ConstraintMatchInputWidget extends FormGroup {
         return constraintMatchTextBox.getValue();
     }
 
-    public HandlerRegistration addConstraintMatchValueChangeHandler(ValueChangeHandler<String> valueChangeHandler) {
+    public HandlerRegistration addConstraintMatchValueChangeHandler(final ValueChangeHandler<String> valueChangeHandler) {
         return constraintMatchTextBox.addValueChangeHandler(valueChangeHandler);
     }
 
-    public HandlerRegistration addConstraintMatchBlurHandler(BlurHandler blurHandler) {
+    public HandlerRegistration addConstraintMatchBlurHandler(final BlurHandler blurHandler) {
         HandlerRegistration registration = constraintMatchTextBox.addBlurHandler(blurHandler);
-        DomEvent.fireNativeEvent(Document.get().createBlurEvent(), constraintMatchTextBox);
+        DomEvent.fireNativeEvent(Document.get().createBlurEvent(),
+                                 constraintMatchTextBox);
 
         return registration;
     }
 
-    public void setEnabled(boolean enabled) {
+    public void setEnabled(final boolean enabled) {
         constraintMatchTextBox.setEnabled(enabled);
     }
 }

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/widget/ConstraintMatchInputWidgetBlurHandler.java
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/widget/ConstraintMatchInputWidgetBlurHandler.java
@@ -16,22 +16,94 @@
 
 package org.optaplanner.workbench.screens.guidedrule.client.widget;
 
+import java.math.BigDecimal;
+
 import com.google.gwt.event.dom.client.BlurEvent;
 import com.google.gwt.event.dom.client.BlurHandler;
+import org.jboss.errai.ui.client.local.spi.TranslationService;
+
+import static org.optaplanner.workbench.screens.guidedrule.client.resources.i18n.GuidedRuleEditorConstants.ConstraintMatchInputWidgetBlurHandler_BigDecimalValueParsingError;
+import static org.optaplanner.workbench.screens.guidedrule.client.resources.i18n.GuidedRuleEditorConstants.ConstraintMatchInputWidgetBlurHandler_DoubleValueParsingError;
+import static org.optaplanner.workbench.screens.guidedrule.client.resources.i18n.GuidedRuleEditorConstants.ConstraintMatchInputWidgetBlurHandler_EmptyValuesAreNotAllowedForModifyScore;
+import static org.optaplanner.workbench.screens.guidedrule.client.resources.i18n.GuidedRuleEditorConstants.ConstraintMatchInputWidgetBlurHandler_IntegerValueParsingError;
+import static org.optaplanner.workbench.screens.guidedrule.client.resources.i18n.GuidedRuleEditorConstants.ConstraintMatchInputWidgetBlurHandler_LongValueParsingError;
 
 public class ConstraintMatchInputWidgetBlurHandler implements BlurHandler {
 
     private ConstraintMatchInputWidget widget;
+    private TranslationService translationService;
+    private String scoreHolderType;
 
-    public ConstraintMatchInputWidgetBlurHandler(ConstraintMatchInputWidget widget) {
+    public ConstraintMatchInputWidgetBlurHandler(final ConstraintMatchInputWidget widget,
+                                                 final TranslationService translationService,
+                                                 final String scoreHolderType) {
         this.widget = widget;
+        this.translationService = translationService;
+        this.scoreHolderType = scoreHolderType;
     }
 
     @Override
     public void onBlur(BlurEvent event) {
-        if (widget.getConstraintMatchValue() == null || widget.getConstraintMatchValue().trim().isEmpty()) {
-            widget.showEmptyValuesNotAllowedError();
+        String inputValue = widget.getConstraintMatchValue();
+        if (inputValue == null || inputValue.trim().isEmpty()) {
+            widget.showError(translationService.getTranslation(ConstraintMatchInputWidgetBlurHandler_EmptyValuesAreNotAllowedForModifyScore));
         } else {
+            inputValue = inputValue.trim();
+            if (inputValue.matches("-?\\s*\\d+(\\.\\d+)?.*")) {
+                switch (scoreHolderType) {
+                    // int
+                    case "org.optaplanner.core.api.score.buildin.bendable.BendableScoreHolder":
+                    case "org.optaplanner.core.api.score.buildin.simple.SimpleScoreHolder":
+                    case "org.optaplanner.core.api.score.buildin.hardsoft.HardSoftScoreHolder":
+                    case "org.optaplanner.core.api.score.buildin.hardmediumsoft.HardMediumSoftScoreHolder": {
+                        try {
+                            Integer.parseInt(inputValue);
+                        } catch (NumberFormatException e) {
+                            widget.showError(translationService.getTranslation(ConstraintMatchInputWidgetBlurHandler_IntegerValueParsingError));
+                            return;
+                        }
+                        break;
+                    }
+                    // long
+                    case "org.optaplanner.core.api.score.buildin.bendablelong.BendableLongScoreHolder":
+                    case "org.optaplanner.core.api.score.buildin.simplelong.SimpleLongScoreHolder":
+                    case "org.optaplanner.core.api.score.buildin.hardsoftlong.HardSoftLongScoreHolder":
+                    case "org.optaplanner.core.api.score.buildin.hardmediumsoftlong.HardMediumSoftLongScoreHolder": {
+                        try {
+                            Long.parseLong(inputValue);
+                        } catch (NumberFormatException e) {
+                            widget.showError(translationService.getTranslation(ConstraintMatchInputWidgetBlurHandler_LongValueParsingError));
+                            return;
+                        }
+                        break;
+                    }
+                    // double
+                    case "org.optaplanner.core.api.score.buildin.simpledouble.SimpleDoubleScoreHolder":
+                    case "org.optaplanner.core.api.score.buildin.hardsoftdouble.HardSoftDoubleScoreHolder": {
+                        try {
+                            Double.parseDouble(inputValue);
+                        } catch (NumberFormatException e) {
+                            widget.showError(translationService.getTranslation(ConstraintMatchInputWidgetBlurHandler_DoubleValueParsingError));
+                            return;
+                        }
+                        break;
+                    }
+                    // java.math.BigDecimal
+                    case "org.optaplanner.core.api.score.buildin.bendablebigdecimal.BendableBigDecimalScoreHolder":
+                    case "org.optaplanner.core.api.score.buildin.simplebigdecimal.SimpleBigDecimalScoreHolder":
+                    case "org.optaplanner.core.api.score.buildin.hardsoftbigdecimal.HardSoftBigDecimalScoreHolder":
+                    case "org.optaplanner.core.api.score.buildin.hardmediumsoftbigdecimal.HardMediumSoftBigDecimalScoreHolder": {
+                        try {
+                            new BigDecimal(inputValue);
+                        } catch (NumberFormatException e) {
+                            widget.showError(translationService.getTranslation(ConstraintMatchInputWidgetBlurHandler_BigDecimalValueParsingError));
+                            return;
+                        }
+                        break;
+                    }
+
+                }
+            }
             widget.clearError();
         }
     }

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/widget/ConstraintMatchRuleModellerWidget.java
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/widget/ConstraintMatchRuleModellerWidget.java
@@ -36,13 +36,6 @@ public class ConstraintMatchRuleModellerWidget extends AbstractConstraintMatchRu
               eventBus,
               translationService);
 
-        constraintMatchInputWidget = new ConstraintMatchInputWidget(actionConstraintMatch,
-                                                                    translationService);
-        constraintMatchInputWidget
-                .addConstraintMatchBlurHandler(new ConstraintMatchInputWidgetBlurHandler(constraintMatchInputWidget));
-        constraintMatchInputWidget
-                .addConstraintMatchValueChangeHandler(new ConstraintMatchValueChangeHandler(actionConstraintMatch));
-
         HorizontalPanel horizontalPanel = new HorizontalPanel();
 
         HorizontalPanel labelPanel = createLabelPanel(translationService.getTranslation(labelTranslationKey));
@@ -58,15 +51,23 @@ public class ConstraintMatchRuleModellerWidget extends AbstractConstraintMatchRu
     }
 
     private HorizontalPanel createConstraintMatchPanel(final AbstractActionConstraintMatch actionConstraintMatch) {
-        HorizontalPanel constraintMatchPanel = new HorizontalPanel();
+        constraintMatchInputWidget = new ConstraintMatchInputWidget(actionConstraintMatch);
+        constraintMatchInputWidget
+                .addConstraintMatchValueChangeHandler(new ConstraintMatchValueChangeHandler(actionConstraintMatch));
 
+        HorizontalPanel constraintMatchPanel = new HorizontalPanel();
         constraintMatchPanel.setWidth("100%");
         constraintMatchPanel.add(constraintMatchInputWidget);
 
         return constraintMatchPanel;
     }
 
-    public void scoreHolderGlobalLoadedCorrectly() {
+    public void scoreHolderGlobalLoadedCorrectly(final String scoreHolderType) {
         constraintMatchInputWidget.setEnabled(true);
+
+        constraintMatchInputWidget
+                .addConstraintMatchBlurHandler(new ConstraintMatchInputWidgetBlurHandler(constraintMatchInputWidget,
+                                                                                         translationService,
+                                                                                         scoreHolderType));
     }
 }

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/widget/MultiConstraintBendableMatchRuleModellerWidget.java
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/widget/MultiConstraintBendableMatchRuleModellerWidget.java
@@ -55,7 +55,7 @@ public class MultiConstraintBendableMatchRuleModellerWidget extends AbstractCons
 
         VerticalPanel verticalPanel = new VerticalPanel();
 
-        HorizontalPanel titlePanel = createLabelPanel(translationService.getTranslation(GuidedRuleEditorConstants.RuleModellerActionPluginMultiConstraintMatch));
+        HorizontalPanel titlePanel = createLabelPanel(translationService.getTranslation(GuidedRuleEditorConstants.RuleModellerActionPlugin_MultiConstraintMatch));
         verticalPanel.add(titlePanel);
         verticalPanel.setCellHeight(titlePanel,
                                     "25px");
@@ -64,10 +64,10 @@ public class MultiConstraintBendableMatchRuleModellerWidget extends AbstractCons
         hardScorePanel.getElement().getStyle().setWidth(100,
                                                         Style.Unit.PCT);
         if (actionConstraintMatch.getActionBendableHardConstraintMatches() == null || actionConstraintMatch.getActionBendableHardConstraintMatches().isEmpty()) {
-            hardScorePanel.add(new Label(translationService.getTranslation(GuidedRuleEditorConstants.RuleModellerActionPluginHardScoreLevelSizeIsZero)));
+            hardScorePanel.add(new Label(translationService.getTranslation(GuidedRuleEditorConstants.RuleModellerActionPlugin_HardScoreLevelSizeIsZero)));
         } else {
             for (int i = 0; i < actionConstraintMatch.getActionBendableHardConstraintMatches().size(); i++) {
-                HorizontalPanel horizontalPanel = createBendableConstraintMatchRow(translationService.getTranslation(GuidedRuleEditorConstants.RuleModellerActionPluginHardScore),
+                HorizontalPanel horizontalPanel = createBendableConstraintMatchRow(translationService.getTranslation(GuidedRuleEditorConstants.RuleModellerActionPlugin_HardScore),
                                                                                    i,
                                                                                    hardConstraintMatchHelpIcons,
                                                                                    hardConstraintMatchInputWidgets,
@@ -81,10 +81,10 @@ public class MultiConstraintBendableMatchRuleModellerWidget extends AbstractCons
         softScorePanel.getElement().getStyle().setWidth(100,
                                                         Style.Unit.PCT);
         if (actionConstraintMatch.getActionBendableSoftConstraintMatches() == null || actionConstraintMatch.getActionBendableSoftConstraintMatches().isEmpty()) {
-            softScorePanel.add(new Label(translationService.getTranslation(GuidedRuleEditorConstants.RuleModellerActionPluginSoftScoreLevelSizeIsZero)));
+            softScorePanel.add(new Label(translationService.getTranslation(GuidedRuleEditorConstants.RuleModellerActionPlugin_SoftScoreLevelSizeIsZero)));
         } else {
             for (int i = 0; i < actionConstraintMatch.getActionBendableSoftConstraintMatches().size(); i++) {
-                HorizontalPanel horizontalPanel = createBendableConstraintMatchRow(translationService.getTranslation(GuidedRuleEditorConstants.RuleModellerActionPluginSoftScore),
+                HorizontalPanel horizontalPanel = createBendableConstraintMatchRow(translationService.getTranslation(GuidedRuleEditorConstants.RuleModellerActionPlugin_SoftScore),
                                                                                    i,
                                                                                    softConstraintMatchHelpIcons,
                                                                                    softConstraintMatchInputWidgets,
@@ -122,17 +122,14 @@ public class MultiConstraintBendableMatchRuleModellerWidget extends AbstractCons
         HelpIcon constraintLevelSelectHelpIcon = new HelpIcon();
         hardConstraintMatchHelpIcons.add(constraintLevelSelectHelpIcon);
         constraintLevelSelectHelpIcon.setVisible(false);
-        constraintLevelSelectHelpIcon.setHelpContent(translationService.getTranslation(GuidedRuleEditorConstants.RuleModellerActionPluginScoreLevelExceeded));
+        constraintLevelSelectHelpIcon.setHelpContent(translationService.getTranslation(GuidedRuleEditorConstants.RuleModellerActionPlugin_ScoreLevelExceeded));
         constraintLevelSelectHelpIcon.getElement().getStyle().setPaddingLeft(5,
                                                                              Style.Unit.PX);
         selectPanel.add(constraintLevelSelectHelpIcon);
 
         horizontalPanel.add(selectPanel);
 
-        ConstraintMatchInputWidget constraintMatchInputWidget = new ConstraintMatchInputWidget(constraintMatch,
-                                                                                               translationService);
-        constraintMatchInputWidget
-                .addConstraintMatchBlurHandler(new ConstraintMatchInputWidgetBlurHandler(constraintMatchInputWidget));
+        ConstraintMatchInputWidget constraintMatchInputWidget = new ConstraintMatchInputWidget(constraintMatch);
         constraintMatchInputWidget
                 .addConstraintMatchValueChangeHandler(new ConstraintMatchValueChangeHandler(constraintMatch));
         constraintMatchInputWidgets.add(constraintMatchInputWidget);
@@ -151,16 +148,22 @@ public class MultiConstraintBendableMatchRuleModellerWidget extends AbstractCons
     }
 
     @Override
-    public void scoreHolderGlobalLoadedCorrectly() {
+    public void scoreHolderGlobalLoadedCorrectly(final String scoreHolderType) {
         if (hardConstraintMatchInputWidgets != null) {
             for (ConstraintMatchInputWidget hardConstraintMatchInputWidget : hardConstraintMatchInputWidgets) {
                 hardConstraintMatchInputWidget.setEnabled(true);
+                hardConstraintMatchInputWidget.addConstraintMatchBlurHandler(new ConstraintMatchInputWidgetBlurHandler(hardConstraintMatchInputWidget,
+                                                                                                                       translationService,
+                                                                                                                       scoreHolderType));
             }
         }
 
         if (softConstraintMatchInputWidgets != null) {
             for (ConstraintMatchInputWidget softConstraintMatchInputWidget : softConstraintMatchInputWidgets) {
                 softConstraintMatchInputWidget.setEnabled(true);
+                softConstraintMatchInputWidget.addConstraintMatchBlurHandler(new ConstraintMatchInputWidgetBlurHandler(softConstraintMatchInputWidget,
+                                                                                                                       translationService,
+                                                                                                                       scoreHolderType));
             }
         }
     }

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/widget/MultiConstraintHardMediumSoftMatchRuleModellerWidget.java
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/widget/MultiConstraintHardMediumSoftMatchRuleModellerWidget.java
@@ -42,38 +42,26 @@ public class MultiConstraintHardMediumSoftMatchRuleModellerWidget extends Abstra
               eventBus,
               translationService);
 
-        hardConstraintMatchInputWidget = new ConstraintMatchInputWidget(actionConstraintMatch.getActionHardConstraintMatch(),
-                                                                        translationService);
-        hardConstraintMatchInputWidget
-                .addConstraintMatchBlurHandler(new ConstraintMatchInputWidgetBlurHandler(hardConstraintMatchInputWidget));
+        hardConstraintMatchInputWidget = new ConstraintMatchInputWidget(actionConstraintMatch.getActionHardConstraintMatch());
         hardConstraintMatchInputWidget
                 .addConstraintMatchValueChangeHandler(new ConstraintMatchValueChangeHandler(actionConstraintMatch.getActionHardConstraintMatch()));
-        mediumConstraintMatchInputWidget = new ConstraintMatchInputWidget(actionConstraintMatch.getActionMediumConstraintMatch(),
-                                                                          translationService);
-        mediumConstraintMatchInputWidget
-                .addConstraintMatchBlurHandler(new ConstraintMatchInputWidgetBlurHandler(mediumConstraintMatchInputWidget));
+        mediumConstraintMatchInputWidget = new ConstraintMatchInputWidget(actionConstraintMatch.getActionMediumConstraintMatch());
         mediumConstraintMatchInputWidget
                 .addConstraintMatchValueChangeHandler(new ConstraintMatchValueChangeHandler(actionConstraintMatch.getActionMediumConstraintMatch()));
-        softConstraintMatchInputWidget = new ConstraintMatchInputWidget(actionConstraintMatch.getActionSoftConstraintMatch(),
-                                                                        translationService);
-        softConstraintMatchInputWidget
-                .addConstraintMatchBlurHandler(new ConstraintMatchInputWidgetBlurHandler(softConstraintMatchInputWidget));
+        softConstraintMatchInputWidget = new ConstraintMatchInputWidget(actionConstraintMatch.getActionSoftConstraintMatch());
         softConstraintMatchInputWidget
                 .addConstraintMatchValueChangeHandler(new ConstraintMatchValueChangeHandler(actionConstraintMatch.getActionSoftConstraintMatch()));
 
         VerticalPanel verticalPanel = new VerticalPanel();
 
-        HorizontalPanel labelPanel = createLabelPanel(translationService.getTranslation(GuidedRuleEditorConstants.RuleModellerActionPluginMultiConstraintMatch));
-
+        HorizontalPanel labelPanel = createLabelPanel(translationService.getTranslation(GuidedRuleEditorConstants.RuleModellerActionPlugin_MultiConstraintMatch));
         verticalPanel.add(labelPanel);
 
-        verticalPanel.add(getItemPanel(translationService.getTranslation(GuidedRuleEditorConstants.RuleModellerActionPluginHardScore),
+        verticalPanel.add(getItemPanel(translationService.getTranslation(GuidedRuleEditorConstants.RuleModellerActionPlugin_HardScore),
                                        hardConstraintMatchInputWidget));
-
-        verticalPanel.add(getItemPanel(translationService.getTranslation(GuidedRuleEditorConstants.RuleModellerActionPluginMediumScore),
+        verticalPanel.add(getItemPanel(translationService.getTranslation(GuidedRuleEditorConstants.RuleModellerActionPlugin_MediumScore),
                                        mediumConstraintMatchInputWidget));
-
-        verticalPanel.add(getItemPanel(translationService.getTranslation(GuidedRuleEditorConstants.RuleModellerActionPluginSoftScore),
+        verticalPanel.add(getItemPanel(translationService.getTranslation(GuidedRuleEditorConstants.RuleModellerActionPlugin_SoftScore),
                                        softConstraintMatchInputWidget));
 
         verticalPanel.addStyleName(GuidedRuleEditorResources.INSTANCE.css().multiConstraintMatch());
@@ -99,9 +87,22 @@ public class MultiConstraintHardMediumSoftMatchRuleModellerWidget extends Abstra
         return horizontalPanel;
     }
 
-    public void scoreHolderGlobalLoadedCorrectly() {
+    public void scoreHolderGlobalLoadedCorrectly(final String scoreHolderType) {
         hardConstraintMatchInputWidget.setEnabled(true);
         mediumConstraintMatchInputWidget.setEnabled(true);
         softConstraintMatchInputWidget.setEnabled(true);
+
+        hardConstraintMatchInputWidget
+                .addConstraintMatchBlurHandler(new ConstraintMatchInputWidgetBlurHandler(hardConstraintMatchInputWidget,
+                                                                                         translationService,
+                                                                                         scoreHolderType));
+        mediumConstraintMatchInputWidget
+                .addConstraintMatchBlurHandler(new ConstraintMatchInputWidgetBlurHandler(mediumConstraintMatchInputWidget,
+                                                                                         translationService,
+                                                                                         scoreHolderType));
+        softConstraintMatchInputWidget
+                .addConstraintMatchBlurHandler(new ConstraintMatchInputWidgetBlurHandler(softConstraintMatchInputWidget,
+                                                                                         translationService,
+                                                                                         scoreHolderType));
     }
 }

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/widget/MultiConstraintHardSoftMatchRuleModellerWidget.java
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/widget/MultiConstraintHardSoftMatchRuleModellerWidget.java
@@ -40,30 +40,24 @@ public class MultiConstraintHardSoftMatchRuleModellerWidget extends AbstractCons
         super(mod,
               eventBus,
               translationService);
-        hardConstraintMatchInputWidget = new ConstraintMatchInputWidget(actionConstraintMatch.getActionHardConstraintMatch(),
-                                                                        translationService);
-        hardConstraintMatchInputWidget
-                .addConstraintMatchBlurHandler(new ConstraintMatchInputWidgetBlurHandler(hardConstraintMatchInputWidget));
+        hardConstraintMatchInputWidget = new ConstraintMatchInputWidget(actionConstraintMatch.getActionHardConstraintMatch());
         hardConstraintMatchInputWidget
                 .addConstraintMatchValueChangeHandler(new ConstraintMatchValueChangeHandler(actionConstraintMatch.getActionHardConstraintMatch()));
-        softConstraintMatchInputWidget = new ConstraintMatchInputWidget(actionConstraintMatch.getActionSoftConstraintMatch(),
-                                                                        translationService);
-        softConstraintMatchInputWidget
-                .addConstraintMatchBlurHandler(new ConstraintMatchInputWidgetBlurHandler(softConstraintMatchInputWidget));
+        softConstraintMatchInputWidget = new ConstraintMatchInputWidget(actionConstraintMatch.getActionSoftConstraintMatch());
         softConstraintMatchInputWidget
                 .addConstraintMatchValueChangeHandler(new ConstraintMatchValueChangeHandler(actionConstraintMatch.getActionSoftConstraintMatch()));
 
         VerticalPanel verticalPanel = new VerticalPanel();
 
-        HorizontalPanel labelPanel = createLabelPanel(translationService.getTranslation(GuidedRuleEditorConstants.RuleModellerActionPluginMultiConstraintMatch));
+        HorizontalPanel labelPanel = createLabelPanel(translationService.getTranslation(GuidedRuleEditorConstants.RuleModellerActionPlugin_MultiConstraintMatch));
         verticalPanel.add(labelPanel);
         verticalPanel.setCellHeight(labelPanel,
                                     "25px");
 
-        verticalPanel.add(getItemPanel(translationService.getTranslation(GuidedRuleEditorConstants.RuleModellerActionPluginHardScore),
+        verticalPanel.add(getItemPanel(translationService.getTranslation(GuidedRuleEditorConstants.RuleModellerActionPlugin_HardScore),
                                        hardConstraintMatchInputWidget));
 
-        verticalPanel.add(getItemPanel(translationService.getTranslation(GuidedRuleEditorConstants.RuleModellerActionPluginSoftScore),
+        verticalPanel.add(getItemPanel(translationService.getTranslation(GuidedRuleEditorConstants.RuleModellerActionPlugin_SoftScore),
                                        softConstraintMatchInputWidget));
 
         verticalPanel.setStyleName(GuidedRuleEditorResources.INSTANCE.css().multiConstraintMatch());
@@ -89,8 +83,17 @@ public class MultiConstraintHardSoftMatchRuleModellerWidget extends AbstractCons
         return horizontalPanel;
     }
 
-    public void scoreHolderGlobalLoadedCorrectly() {
+    public void scoreHolderGlobalLoadedCorrectly(final String scoreHolderType) {
         hardConstraintMatchInputWidget.setEnabled(true);
         softConstraintMatchInputWidget.setEnabled(true);
+
+        hardConstraintMatchInputWidget
+                .addConstraintMatchBlurHandler(new ConstraintMatchInputWidgetBlurHandler(hardConstraintMatchInputWidget,
+                                                                                         translationService,
+                                                                                         scoreHolderType));
+        softConstraintMatchInputWidget
+                .addConstraintMatchBlurHandler(new ConstraintMatchInputWidgetBlurHandler(softConstraintMatchInputWidget,
+                                                                                         translationService,
+                                                                                         scoreHolderType));
     }
 }

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/widget/ScoreHolderGlobalAware.java
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/java/org/optaplanner/workbench/screens/guidedrule/client/widget/ScoreHolderGlobalAware.java
@@ -20,5 +20,5 @@ public interface ScoreHolderGlobalAware {
 
     void scoreHolderGlobalIssueDetected(final String message);
 
-    void scoreHolderGlobalLoadedCorrectly();
+    void scoreHolderGlobalLoadedCorrectly(final String scoreHolderType);
 }

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/resources/org/optaplanner/workbench/screens/guidedrule/client/resources/i18n/GuidedRuleEditorConstants.properties
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/main/resources/org/optaplanner/workbench/screens/guidedrule/client/resources/i18n/GuidedRuleEditorConstants.properties
@@ -29,7 +29,12 @@ RuleModellerActionPlugin.HardScoreLevelSizeIsZero=Hard score level size is 0
 RuleModellerActionPlugin.SoftScoreLevelSizeIsZero=Soft score level size is 0
 RuleModellerActionPlugin.ScoreLevelExceeded=Score level set for this score is greater than the maximum defined by current planning solution. Modify the bendable score levels size in the planning solution or remove this item.
 RuleModellerActionPlugin.AmbigiousConstraintMatchesDetected=Ambigious Planner score constraint matches detected within a single RHS of the rule. Remove one of the items.
-RuleModellerActionPlugin.EmptyValuesAreNotAllowedForModifyScore=Empty values are not allowed for the Modify Score actions. Please put either number or expression like $person.age
+
+ConstraintMatchInputWidgetBlurHandler.EmptyValuesAreNotAllowedForModifyScore=Empty values are not allowed for the Modify Score actions. Please put either number or expression like $person.age
+ConstraintMatchInputWidgetBlurHandler.IntegerValueParsingError=Invalid integer value. Please insert either a number or an expression like $person.age.
+ConstraintMatchInputWidgetBlurHandler.LongValueParsingError=Invalid long value. Please insert either a number or an expression like $person.age.
+ConstraintMatchInputWidgetBlurHandler.DoubleValueParsingError=Invalid double value. Please insert either a number or an expression like $person.age.
+ConstraintMatchInputWidgetBlurHandler.BigDecimalValueParsingError=Invalid BigDecimal value. Please insert either a number or an expression like $person.age.
 
 ActionPluginClientService.ScoreHolderGlobalNotFound=scoreHolder global variable not found. The global variable is created automatically when a Planning Solution is created. Make sure to create a planning solution before proceeding to rule definition.
 ActionPluginClientService.MultipleScoreHolderGlobals=Multiple scoreHolder global variables found. The global variable is created automatically when a Planning Solution is created. Make sure there are not multiple planning solution objects within the project and that you do not define the 'scoreHolder' global variable manually.

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/test/java/org/optaplanner/workbench/screens/guidedrule/client/plugin/ActionPluginClientServiceTest.java
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/test/java/org/optaplanner/workbench/screens/guidedrule/client/plugin/ActionPluginClientServiceTest.java
@@ -110,7 +110,7 @@ public class ActionPluginClientServiceTest {
                                            Arrays.asList(HardSoftScoreHolder.class.getName()));
 
         verify(scoreHolderGlobalAware,
-               times(1)).scoreHolderGlobalLoadedCorrectly();
+               times(1)).scoreHolderGlobalLoadedCorrectly(HardSoftScoreHolder.class.getName());
     }
 
     @Test

--- a/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/test/java/org/optaplanner/workbench/screens/guidedrule/client/widget/ConstraintMatchInputWidgetBlurHandlerTest.java
+++ b/optaplanner-wb-screens/optaplanner-wb-guided-rule-editor/optaplanner-wb-guided-rule-editor-client/src/test/java/org/optaplanner/workbench/screens/guidedrule/client/widget/ConstraintMatchInputWidgetBlurHandlerTest.java
@@ -18,79 +18,365 @@ package org.optaplanner.workbench.screens.guidedrule.client.widget;
 
 import com.google.gwt.event.dom.client.BlurEvent;
 import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.optaplanner.core.api.score.buildin.bendable.BendableScoreHolder;
+import org.optaplanner.core.api.score.buildin.bendablebigdecimal.BendableBigDecimalScoreHolder;
+import org.optaplanner.core.api.score.buildin.bendablelong.BendableLongScoreHolder;
+import org.optaplanner.core.api.score.buildin.hardmediumsoft.HardMediumSoftScoreHolder;
+import org.optaplanner.core.api.score.buildin.hardmediumsoftbigdecimal.HardMediumSoftBigDecimalScoreHolder;
+import org.optaplanner.core.api.score.buildin.hardmediumsoftlong.HardMediumSoftLongScoreHolder;
+import org.optaplanner.core.api.score.buildin.hardsoft.HardSoftScoreHolder;
+import org.optaplanner.core.api.score.buildin.hardsoftbigdecimal.HardSoftBigDecimalScoreHolder;
+import org.optaplanner.core.api.score.buildin.hardsoftdouble.HardSoftDoubleScoreHolder;
+import org.optaplanner.core.api.score.buildin.hardsoftlong.HardSoftLongScoreHolder;
+import org.optaplanner.core.api.score.buildin.simple.SimpleScoreHolder;
+import org.optaplanner.core.api.score.buildin.simplebigdecimal.SimpleBigDecimalScoreHolder;
+import org.optaplanner.core.api.score.buildin.simpledouble.SimpleDoubleScoreHolder;
+import org.optaplanner.core.api.score.buildin.simplelong.SimpleLongScoreHolder;
+import org.optaplanner.workbench.screens.guidedrule.client.resources.i18n.GuidedRuleEditorConstants;
 
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @RunWith(GwtMockitoTestRunner.class)
 public class ConstraintMatchInputWidgetBlurHandlerTest {
 
-    ConstraintMatchInputWidgetBlurHandler handler;
+    @Mock
+    private ConstraintMatchInputWidget widget;
 
     @Mock
-    ConstraintMatchInputWidget widget;
+    private TranslationService translationService;
+
+    private ConstraintMatchInputWidgetBlurHandler handler;
 
     @Before
     public void setUp() throws Exception {
-        handler = new ConstraintMatchInputWidgetBlurHandler(widget);
-
+        handler = new ConstraintMatchInputWidgetBlurHandler(widget,
+                                                            translationService,
+                                                            HardSoftScoreHolder.class.getName());
     }
 
     @Test
-    public void testNullConstraintMatch() throws Exception {
+    public void nullConstraintMatch() throws Exception {
         when(widget.getConstraintMatchValue()).thenReturn(null);
+        when(translationService.getTranslation(GuidedRuleEditorConstants.ConstraintMatchInputWidgetBlurHandler_EmptyValuesAreNotAllowedForModifyScore))
+                .thenReturn("translation");
 
         handler.onBlur(mock(BlurEvent.class));
 
-        verify(widget).showEmptyValuesNotAllowedError();
-        verify(widget, never()).clearError();
+        verify(widget).showError("translation");
+        verify(widget,
+               never()).clearError();
     }
 
     @Test
-    public void testEmptyConstraintMatch() throws Exception {
+    public void emptyConstraintMatch() throws Exception {
         when(widget.getConstraintMatchValue()).thenReturn("");
+        when(translationService.getTranslation(GuidedRuleEditorConstants.ConstraintMatchInputWidgetBlurHandler_EmptyValuesAreNotAllowedForModifyScore))
+                .thenReturn("translation");
 
         handler.onBlur(mock(BlurEvent.class));
 
-        verify(widget).showEmptyValuesNotAllowedError();
-        verify(widget, never()).clearError();
+        verify(widget).showError("translation");
+        verify(widget,
+               never()).clearError();
     }
 
     @Test
-    public void testJustWhiteSpaceConstraintMatch() throws Exception {
+    public void whiteSpaceConstraintMatch() throws Exception {
         when(widget.getConstraintMatchValue()).thenReturn(" ");
+        when(translationService.getTranslation(GuidedRuleEditorConstants.ConstraintMatchInputWidgetBlurHandler_EmptyValuesAreNotAllowedForModifyScore))
+                .thenReturn("translation");
 
         handler.onBlur(mock(BlurEvent.class));
 
-        verify(widget).showEmptyValuesNotAllowedError();
-        verify(widget, never()).clearError();
+        verify(widget).showError("translation");
+        verify(widget,
+               never()).clearError();
     }
 
     @Test
-    public void testNumberConstraintMatch() throws Exception {
+    public void numberConstraintMatch() throws Exception {
         when(widget.getConstraintMatchValue()).thenReturn("123");
 
         handler.onBlur(mock(BlurEvent.class));
 
-        verify(widget, never()).showEmptyValuesNotAllowedError();
+        verify(widget,
+               never()).showError(anyString());
         verify(widget).clearError();
     }
 
     @Test
-    public void testExpressionConstraintMatch() throws Exception {
+    public void validNumericValueConstraintMatchBendableScoreHolder() throws Exception {
+        testValidNumericValueConstraintMatch(BendableScoreHolder.class.getName(),
+                                             "-1");
+    }
+
+    @Test
+    public void validNumericValueConstraintMatchSimpleScoreHolder() throws Exception {
+        testValidNumericValueConstraintMatch(SimpleScoreHolder.class.getName(),
+                                             "-1");
+    }
+
+    @Test
+    public void validNumericValueConstraintMatchHardSoftScoreHolder() throws Exception {
+        testValidNumericValueConstraintMatch(HardSoftScoreHolder.class.getName(),
+                                             "-1");
+    }
+
+    @Test
+    public void validNumericValueConstraintMatchHardMediumSoftScoreHolder() throws Exception {
+        testValidNumericValueConstraintMatch(HardMediumSoftScoreHolder.class.getName(),
+                                             "-1");
+    }
+
+    @Test
+    public void validNumericValueConstraintMatchBendableLongScoreHolder() throws Exception {
+        testValidNumericValueConstraintMatch(BendableLongScoreHolder.class.getName(),
+                                             "-9999999999");
+    }
+
+    @Test
+    public void validNumericValueConstraintMatchSimpleLongScoreHolder() throws Exception {
+        testValidNumericValueConstraintMatch(SimpleLongScoreHolder.class.getName(),
+                                             "-9999999999");
+    }
+
+    @Test
+    public void validNumericValueConstraintMatchHardSoftLongScoreHolder() throws Exception {
+        testValidNumericValueConstraintMatch(HardSoftLongScoreHolder.class.getName(),
+                                             "-9999999999");
+    }
+
+    @Test
+    public void validNumericValueConstraintMatchHardMediumSoftLongScoreHolder() throws Exception {
+        testValidNumericValueConstraintMatch(HardMediumSoftLongScoreHolder.class.getName(),
+                                             "-9999999999");
+    }
+
+    @Test
+    public void validNumericValueConstraintMatchSimpleDoubleScoreHolder() throws Exception {
+        testValidNumericValueConstraintMatch(SimpleDoubleScoreHolder.class.getName(),
+                                             "-3.14");
+    }
+
+    @Test
+    public void validNumericValueConstraintMatchHardSoftDoubleScoreHolder() throws Exception {
+        testValidNumericValueConstraintMatch(HardSoftDoubleScoreHolder.class.getName(),
+                                             "-3.14");
+    }
+
+    @Test
+    public void validNumericValueConstraintMatchBendableBigDecimalScoreHolder() throws Exception {
+        testValidNumericValueConstraintMatch(BendableBigDecimalScoreHolder.class.getName(),
+                                             "-5.599");
+    }
+
+    @Test
+    public void validNumericValueConstraintMatchSimpleBigDecimalScoreHolder() throws Exception {
+        testValidNumericValueConstraintMatch(SimpleBigDecimalScoreHolder.class.getName(),
+                                             "-5.599");
+    }
+
+    @Test
+    public void validNumericValueConstraintMatchHardSoftBigDecimalScoreHolder() throws Exception {
+        testValidNumericValueConstraintMatch(HardSoftBigDecimalScoreHolder.class.getName(),
+                                             "-5.599");
+    }
+
+    @Test
+    public void validNumericValueConstraintMatchHardMediumSoftBigDecimalScoreHolder() throws Exception {
+        testValidNumericValueConstraintMatch(HardMediumSoftBigDecimalScoreHolder.class.getName(),
+                                             "-5.599");
+    }
+
+    private void testValidNumericValueConstraintMatch(final String scoreHolderClass,
+                                                      final String constraintMatchValue) throws Exception {
+        ConstraintMatchInputWidgetBlurHandler handler = new ConstraintMatchInputWidgetBlurHandler(widget,
+                                                                                                  translationService,
+                                                                                                  scoreHolderClass);
+
+        when(widget.getConstraintMatchValue()).thenReturn(constraintMatchValue);
+        when(translationService.getTranslation(GuidedRuleEditorConstants.ConstraintMatchInputWidgetBlurHandler_IntegerValueParsingError))
+                .thenReturn("translation");
+
+        handler.onBlur(mock(BlurEvent.class));
+
+        verify(widget,
+               never()).showError("translation");
+        verify(widget,
+               times(1)).clearError();
+    }
+
+    @Test
+    public void invalidValueConstraintMatchBendableScoreHolder() throws Exception {
+        testInvalidValueConstraintMatch(BendableScoreHolder.class.getName());
+    }
+
+    @Test
+    public void invalidValueConstraintMatchSimpleScoreHolder() throws Exception {
+        testInvalidValueConstraintMatch(SimpleScoreHolder.class.getName());
+    }
+
+    @Test
+    public void invalidValueConstraintMatchHardSoftScoreHolder() throws Exception {
+        testInvalidValueConstraintMatch(HardSoftScoreHolder.class.getName());
+    }
+
+    @Test
+    public void invalidValueConstraintMatchHardMediumSoftScoreHolder() throws Exception {
+        testInvalidValueConstraintMatch(HardMediumSoftScoreHolder.class.getName());
+    }
+
+    @Test
+    public void invalidValueConstraintMatchBendableLongScoreHolder() throws Exception {
+        testInvalidValueConstraintMatch(BendableLongScoreHolder.class.getName());
+    }
+
+    @Test
+    public void invalidValueConstraintMatchSimpleLongScoreHolder() throws Exception {
+        testInvalidValueConstraintMatch(SimpleLongScoreHolder.class.getName());
+    }
+
+    @Test
+    public void invalidValueConstraintMatchHardSoftLongScoreHolder() throws Exception {
+        testInvalidValueConstraintMatch(HardSoftLongScoreHolder.class.getName());
+    }
+
+    @Test
+    public void invalidValueConstraintMatchHardMediumSoftLongScoreHolder() throws Exception {
+        testInvalidValueConstraintMatch(HardMediumSoftLongScoreHolder.class.getName());
+    }
+
+    @Test
+    public void invalidValueConstraintMatchSimpleDoubleScoreHolder() throws Exception {
+        testInvalidValueConstraintMatch(SimpleDoubleScoreHolder.class.getName());
+    }
+
+    @Test
+    public void invalidValueConstraintMatchHardSoftDoubleScoreHolder() throws Exception {
+        testInvalidValueConstraintMatch(HardSoftDoubleScoreHolder.class.getName());
+    }
+
+    @Test
+    public void invalidValueConstraintMatchBendableBigDecimalScoreHolder() throws Exception {
+        testInvalidValueConstraintMatch(BendableBigDecimalScoreHolder.class.getName());
+    }
+
+    @Test
+    public void invalidValueConstraintMatchSimpleBigDecimalScoreHolder() throws Exception {
+        testInvalidValueConstraintMatch(SimpleBigDecimalScoreHolder.class.getName());
+    }
+
+    @Test
+    public void invalidValueConstraintMatchHardSoftBigDecimalScoreHolder() throws Exception {
+        testInvalidValueConstraintMatch(HardSoftBigDecimalScoreHolder.class.getName());
+    }
+
+    @Test
+    public void invalidValueConstraintMatchHardMediumSoftBigDecimalScoreHolder() throws Exception {
+        testInvalidValueConstraintMatch(HardMediumSoftBigDecimalScoreHolder.class.getName());
+    }
+
+    private void testInvalidValueConstraintMatch(final String scoreHolderClass) {
+        ConstraintMatchInputWidgetBlurHandler handler = new ConstraintMatchInputWidgetBlurHandler(widget,
+                                                                                                  translationService,
+                                                                                                  scoreHolderClass);
+        when(widget.getConstraintMatchValue()).thenReturn("123zzz");
+        when(translationService.getTranslation(anyString()))
+                .thenReturn("translation");
+
+        handler.onBlur(mock(BlurEvent.class));
+
+        verify(widget,
+               times(1)).showError("translation");
+        verify(widget,
+               never()).clearError();
+    }
+
+    @Test
+    public void validExpressionConstraintMatchBendableScoreHolder() throws Exception {
+        testValidExpressionConstraintMatch(BendableScoreHolder.class.getName());
+    }
+
+    @Test
+    public void validExpressionConstraintMatchSimpleScoreHolder() throws Exception {
+        testValidExpressionConstraintMatch(SimpleScoreHolder.class.getName());
+    }
+
+    @Test
+    public void validExpressionConstraintMatchHardSoftScoreHolder() throws Exception {
+        testValidExpressionConstraintMatch(HardSoftScoreHolder.class.getName());
+    }
+
+    @Test
+    public void validExpressionConstraintMatchHardMediumSoftScoreHolder() throws Exception {
+        testValidExpressionConstraintMatch(HardMediumSoftScoreHolder.class.getName());
+    }
+
+    @Test
+    public void validExpressionConstraintMatchBendableLongScoreHolder() throws Exception {
+        testValidExpressionConstraintMatch(BendableLongScoreHolder.class.getName());
+    }
+
+    @Test
+    public void validExpressionConstraintMatchSimpleLongScoreHolder() throws Exception {
+        testValidExpressionConstraintMatch(SimpleLongScoreHolder.class.getName());
+    }
+
+    @Test
+    public void validExpressionConstraintMatchHardSoftLongScoreHolder() throws Exception {
+        testValidExpressionConstraintMatch(HardSoftLongScoreHolder.class.getName());
+    }
+
+    @Test
+    public void validExpressionConstraintMatchHardMediumSoftLongScoreHolder() throws Exception {
+        testValidExpressionConstraintMatch(HardMediumSoftLongScoreHolder.class.getName());
+    }
+
+    @Test
+    public void validExpressionConstraintMatchSimpleDoubleScoreHolder() throws Exception {
+        testValidExpressionConstraintMatch(SimpleDoubleScoreHolder.class.getName());
+    }
+
+    @Test
+    public void validExpressionConstraintMatchHardSoftDoubleScoreHolder() throws Exception {
+        testValidExpressionConstraintMatch(HardSoftDoubleScoreHolder.class.getName());
+    }
+
+    @Test
+    public void validExpressionConstraintMatchBendableBigDecimalScoreHolder() throws Exception {
+        testValidExpressionConstraintMatch(BendableBigDecimalScoreHolder.class.getName());
+    }
+
+    @Test
+    public void validExpressionConstraintMatchSimpleBigDecimalScoreHolder() throws Exception {
+        testValidExpressionConstraintMatch(SimpleBigDecimalScoreHolder.class.getName());
+    }
+
+    @Test
+    public void validExpressionConstraintMatchHardSoftBigDecimalScoreHolder() throws Exception {
+        testValidExpressionConstraintMatch(HardSoftBigDecimalScoreHolder.class.getName());
+    }
+
+    @Test
+    public void validExpressionConstraintMatchHardMediumSoftBigDecimalScoreHolder() throws Exception {
+        testValidExpressionConstraintMatch(HardMediumSoftBigDecimalScoreHolder.class.getName());
+    }
+
+    private void testValidExpressionConstraintMatch(final String scoreHolderClass) throws Exception {
+        ConstraintMatchInputWidgetBlurHandler handler = new ConstraintMatchInputWidgetBlurHandler(widget,
+                                                                                                  translationService,
+                                                                                                  scoreHolderClass);
         when(widget.getConstraintMatchValue()).thenReturn("$person.getAge()");
 
         handler.onBlur(mock(BlurEvent.class));
 
-        verify(widget, never()).showEmptyValuesNotAllowedError();
+        verify(widget,
+               never()).showError(anyString());
         verify(widget).clearError();
     }
-
-
 }


### PR DESCRIPTION
This PR improves validation of score holder input fields. GRE uses mvel dialect by default, which is kind of forgiving in the way it handles incorrect types passed to scoreHolder.addConstraintMatch methods. With float -> int conversion, this will lead to unexpected results.

As users may insert both numeric values and complex expressions, I defined numeric values as the ones starting with number (data objects and drl bindings cannot start with a number). See `ConstraintMatchInputWidgetBlurHandler`. As to BigDecimal score holders, I kept default numeric -> BigDecimal conversion as-is, as it potentially avoids some boilerplate code (BigDecimal.valueOf..).

Other than that, just a minor cleanup.

@jomarko @manstis Mind taking a look? Thanks in advance.