### PR TITLE
RHDM-228: Add UI support for Variable Neighborhood Descent LS type

### DIFF
--- a/optaplanner-wb-screens/optaplanner-wb-solver-editor/optaplanner-wb-solver-editor-client/src/main/java/org/optaplanner/workbench/screens/solver/client/resources/i18n/SolverEditorLookupConstants.java
+++ b/optaplanner-wb-screens/optaplanner-wb-solver-editor/optaplanner-wb-solver-editor-client/src/main/java/org/optaplanner/workbench/screens/solver/client/resources/i18n/SolverEditorLookupConstants.java
@@ -55,4 +55,6 @@ public interface SolverEditorLookupConstants extends ConstantsWithLookup {
     String SIMULATED_ANNEALING();
 
     String LATE_ACCEPTANCE();
+
+    String VARIABLE_NEIGHBORHOOD_DESCENT();
 }

--- a/optaplanner-wb-screens/optaplanner-wb-solver-editor/optaplanner-wb-solver-editor-client/src/main/resources/org/optaplanner/workbench/screens/solver/client/resources/i18n/SolverEditorLookupConstants.properties
+++ b/optaplanner-wb-screens/optaplanner-wb-solver-editor/optaplanner-wb-solver-editor-client/src/main/resources/org/optaplanner/workbench/screens/solver/client/resources/i18n/SolverEditorLookupConstants.properties
@@ -32,3 +32,4 @@ HILL_CLIMBING=Hill Climbing
 TABU_SEARCH=Tabu Search
 SIMULATED_ANNEALING=Simulated Annealing
 LATE_ACCEPTANCE=Late Acceptance
+VARIABLE_NEIGHBORHOOD_DESCENT=Variable Neighborhood Descent


### PR DESCRIPTION
Just added missing constant for a new enum item of LocalSearchType from optaplanner-core.