### PR TITLE
Add missing dependency on drools-cdi

### DIFF
--- a/optaplanner-wb-webapp/pom.xml
+++ b/optaplanner-wb-webapp/pom.xml
@@ -260,6 +260,12 @@
       <artifactId>kie-soup-project-datamodel-api</artifactId>
     </dependency>
 
+    <!-- Contains Producer method for MVELEvaluator -->
+    <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-cdi</artifactId>
+    </dependency>
+
     <!-- Models held within Drools -->
     <dependency>
       <groupId>org.drools</groupId>


### PR DESCRIPTION
This is related to AF-593: Decouple DMO from Drools.

Replicates kiegroup/drools-wb#659.