### PR TITLE
AF-819: Renaming assets discards changes

### DIFF
--- a/optaplanner-wb-screens/optaplanner-wb-solver-editor/optaplanner-wb-solver-editor-api/src/main/java/org/optaplanner/workbench/screens/solver/service/SolverEditorService.java
+++ b/optaplanner-wb-screens/optaplanner-wb-solver-editor/optaplanner-wb-solver-editor-api/src/main/java/org/optaplanner/workbench/screens/solver/service/SolverEditorService.java
@@ -18,6 +18,7 @@ package org.optaplanner.workbench.screens.solver.service;
 import java.util.List;
 
 import org.guvnor.common.services.shared.file.SupportsUpdate;
+import org.guvnor.common.services.shared.metadata.model.Metadata;
 import org.guvnor.common.services.shared.validation.ValidationService;
 import org.guvnor.common.services.shared.validation.model.ValidationMessage;
 import org.jboss.errai.bus.server.annotations.Remote;
@@ -30,6 +31,7 @@ import org.uberfire.ext.editor.commons.service.support.SupportsCreate;
 import org.uberfire.ext.editor.commons.service.support.SupportsDelete;
 import org.uberfire.ext.editor.commons.service.support.SupportsRead;
 import org.uberfire.ext.editor.commons.service.support.SupportsRename;
+import org.uberfire.ext.editor.commons.service.support.SupportsSaveAndRename;
 
 @Remote
 public interface SolverEditorService
@@ -38,10 +40,9 @@ public interface SolverEditorService
         ViewSourceService<SolverConfigModel>,
         SupportsCreate<SolverConfigModel>,
         SupportsRead<SolverConfigModel>,
-        SupportsUpdate<SolverConfigModel>,
+        SupportsSaveAndRename<SolverConfigModel, Metadata>,
         SupportsDelete,
-        SupportsCopy,
-        SupportsRename {
+        SupportsCopy {
 
     SolverModelContent loadContent(final Path path);
 

--- a/optaplanner-wb-screens/optaplanner-wb-solver-editor/optaplanner-wb-solver-editor-backend/pom.xml
+++ b/optaplanner-wb-screens/optaplanner-wb-solver-editor/optaplanner-wb-solver-editor-backend/pom.xml
@@ -121,6 +121,11 @@
       <artifactId>uberfire-commons-editor-api</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-commons-editor-backend</artifactId>
+    </dependency>
+
     <!-- XML -->
     <dependency>
       <groupId>com.thoughtworks.xstream</groupId>

--- a/optaplanner-wb-screens/optaplanner-wb-solver-editor/optaplanner-wb-solver-editor-backend/src/main/java/org/optaplanner/workbench/screens/solver/backend/server/SolverEditorServiceImpl.java
+++ b/optaplanner-wb-screens/optaplanner-wb-solver-editor/optaplanner-wb-solver-editor-backend/src/main/java/org/optaplanner/workbench/screens/solver/backend/server/SolverEditorServiceImpl.java
@@ -17,6 +17,8 @@
 package org.optaplanner.workbench.screens.solver.backend.server;
 
 import java.util.List;
+
+import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Event;
 import javax.inject.Inject;
@@ -35,6 +37,7 @@ import org.optaplanner.workbench.screens.solver.service.SolverEditorService;
 import org.optaplanner.workbench.screens.solver.type.SolverResourceTypeDefinition;
 import org.uberfire.backend.server.util.Paths;
 import org.uberfire.backend.vfs.Path;
+import org.uberfire.ext.editor.commons.backend.service.SaveAndRenameServiceImpl;
 import org.uberfire.ext.editor.commons.service.CopyService;
 import org.uberfire.ext.editor.commons.service.DeleteService;
 import org.uberfire.ext.editor.commons.service.RenameService;
@@ -79,6 +82,14 @@ public class SolverEditorServiceImpl
 
     @Inject
     private CommentedOptionFactory commentedOptionFactory;
+
+    @Inject
+    private SaveAndRenameServiceImpl<SolverConfigModel, Metadata> saveAndRenameService;
+
+    @PostConstruct
+    public void init() {
+        saveAndRenameService.init(this);
+    }
 
     @Override
     public Path create(final Path context,
@@ -231,5 +242,14 @@ public class SolverEditorServiceImpl
         } catch (Exception e) {
             throw ExceptionUtilities.handleException(e);
         }
+    }
+
+    @Override
+    public Path saveAndRename(final Path path,
+                              final String newFileName,
+                              final Metadata metadata,
+                              final SolverConfigModel content,
+                              final String comment) {
+        return saveAndRenameService.saveAndRename(path, newFileName, metadata, content, comment);
     }
 }

--- a/optaplanner-wb-screens/optaplanner-wb-solver-editor/optaplanner-wb-solver-editor-backend/src/test/java/org/optaplanner/workbench/screens/solver/backend/server/SolverEditorServiceImplTest.java
+++ b/optaplanner-wb-screens/optaplanner-wb-solver-editor/optaplanner-wb-solver-editor-backend/src/test/java/org/optaplanner/workbench/screens/solver/backend/server/SolverEditorServiceImplTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.screens.solver.backend.server;
+
+import org.guvnor.common.services.shared.metadata.model.Metadata;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.optaplanner.workbench.screens.solver.model.SolverConfigModel;
+import org.uberfire.backend.vfs.Path;
+import org.uberfire.ext.editor.commons.backend.service.SaveAndRenameServiceImpl;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SolverEditorServiceImplTest {
+
+    @Mock
+    private SaveAndRenameServiceImpl<SolverConfigModel, Metadata> saveAndRenameService;
+
+    @InjectMocks
+    private SolverEditorServiceImpl service = new SolverEditorServiceImpl();
+
+    @Test
+    public void testInit() throws Exception {
+        service.init();
+
+        verify(saveAndRenameService).init(service);
+    }
+
+    @Test
+    public void testSaveAndRename() throws Exception {
+
+        final Path path = mock(Path.class);
+        final String newFileName = "newFileName";
+        final Metadata metadata = mock(Metadata.class);
+        final SolverConfigModel content = mock(SolverConfigModel.class);
+        final String comment = "comment";
+
+        service.saveAndRename(path, newFileName, metadata, content, comment);
+
+        verify(saveAndRenameService).saveAndRename(path, newFileName, metadata, content, comment);
+    }
+}

--- a/optaplanner-wb-screens/optaplanner-wb-solver-editor/optaplanner-wb-solver-editor-client/pom.xml
+++ b/optaplanner-wb-screens/optaplanner-wb-solver-editor/optaplanner-wb-solver-editor-client/pom.xml
@@ -146,6 +146,11 @@
       <artifactId>errai-ui</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-commons-editor-api</artifactId>
+    </dependency>
+
     <!-- GWT and GWT Extensions -->
     <dependency>
       <groupId>com.google.gwt</groupId>


### PR DESCRIPTION
See:
- https://issues.jboss.org/browse/RHBA-148
- https://issues.jboss.org/browse/AF-819

---
Demo:
![demo](https://user-images.githubusercontent.com/1079279/35909185-e79488d6-0bd9-11e8-8223-97e9718f444f.gif)

---

Important topics:

I) I'm keeping the editors, that have their own implementation of the save-and-rename operation, intact;

II) I couldn't apply the generic approach on `jbpm-designer`, due to the save operation that is coupled to native JS code. Thus, I needed to implement a custom solution there;

III) The "save commit" and the "rename commit" are not being squashed. I don't think that it's a problem since we're showing explicitly to the user that two operations are being executed (but, maybe I'm missing something, wdyt @manstis?).

---

Part of an ensemble:
- https://github.com/kiegroup/appformer/pull/170
- https://github.com/kiegroup/kie-wb-common/pull/1414
- https://github.com/kiegroup/drools-wb/pull/804
- https://github.com/kiegroup/optaplanner-wb/pull/251
- https://github.com/kiegroup/jbpm-designer/pull/743