### PR TITLE
[Do not merge] PLANNER-988 : [Project Oriented] Cannot validate solver config due to the path's first letter being cut away

### DIFF
--- a/optaplanner-wb-screens/optaplanner-wb-solver-editor/optaplanner-wb-solver-editor-backend/src/main/java/org/optaplanner/workbench/screens/solver/backend/server/PathUtil.java
+++ b/optaplanner-wb-screens/optaplanner-wb-solver-editor/optaplanner-wb-solver-editor-backend/src/main/java/org/optaplanner/workbench/screens/solver/backend/server/PathUtil.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.optaplanner.workbench.screens.solver.backend.server;
+
+import org.kie.soup.commons.validation.PortablePreconditions;
+import org.uberfire.backend.server.util.Paths;
+import org.uberfire.backend.vfs.Path;
+
+public class PathUtil {
+
+    /**
+     * Subtsring the second path from the first. This can be used to for example to substring the repository prefix from a Path.
+     * @param from The Path we want to substring
+     * @param what What we want to substring from the first Path
+     * @return The result. For example the File URI from the Repository root or from a submodule root.
+     */
+    public static String removePrefix(final Path from,
+                                      final Path what) {
+        PortablePreconditions.checkNotNull("From Path", from);
+        PortablePreconditions.checkNotNull("What Path", what);
+
+        return normalizePath(from).toURI().substring(normalizePath(what).toURI().length());
+    }
+
+    /**
+     * git:// and default:// can point to the same location. This normalizes the Paths for easier use with length and removePrefix functions.
+     * @param path
+     * @return
+     */
+    public static Path normalizePath(final Path path) {
+        return Paths.convert(Paths.convert(path));
+    }
+}

--- a/optaplanner-wb-screens/optaplanner-wb-solver-editor/optaplanner-wb-solver-editor-backend/src/main/java/org/optaplanner/workbench/screens/solver/backend/server/SolverValidator.java
+++ b/optaplanner-wb-screens/optaplanner-wb-solver-editor/optaplanner-wb-solver-editor-backend/src/main/java/org/optaplanner/workbench/screens/solver/backend/server/SolverValidator.java
@@ -16,7 +16,6 @@
 
 package org.optaplanner.workbench.screens.solver.backend.server;
 
-import java.io.ByteArrayInputStream;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -25,7 +24,6 @@ import java.util.function.Predicate;
 
 import javax.inject.Inject;
 
-import com.google.common.base.Charsets;
 import org.drools.compiler.kie.builder.impl.InternalKieModule;
 import org.drools.compiler.kie.builder.impl.KieContainerImpl;
 import org.drools.compiler.kie.builder.impl.KieModuleKieProject;
@@ -42,7 +40,6 @@ import org.kie.workbench.common.services.shared.project.KieModule;
 import org.kie.workbench.common.services.shared.project.KieModuleService;
 import org.optaplanner.core.api.solver.Solver;
 import org.optaplanner.core.api.solver.SolverFactory;
-import org.uberfire.backend.server.util.Paths;
 import org.uberfire.backend.vfs.Path;
 
 public class SolverValidator {
@@ -104,10 +101,6 @@ public class SolverValidator {
         } catch (NoModuleException e) {
             return new ArrayList<ValidationMessage>();
         }
-    }
-
-    private ByteArrayInputStream inputStream(final String content) {
-        return new ByteArrayInputStream(content.getBytes(Charsets.UTF_8));
     }
 
     private List<ValidationMessage> buildSolver(final Path resourcePath,
@@ -188,7 +181,8 @@ public class SolverValidator {
 
     private String getSolverConfigResource(final Path resourcePath,
                                            final KieModule kieWorkbenchModule) {
-        return Paths.convert(Paths.convert(resourcePath)).toURI().substring(Paths.convert(Paths.convert(kieWorkbenchModule.getRootPath())).toURI().length() + "/src/main/resources/".length());
+        return PathUtil.removePrefix(resourcePath,
+                                     kieWorkbenchModule.getRootPath()).substring("src/main/resources/".length());
     }
 
     private ValidationMessage make(final Exception e,

--- a/optaplanner-wb-screens/optaplanner-wb-solver-editor/optaplanner-wb-solver-editor-backend/src/test/java/org/optaplanner/workbench/screens/solver/backend/server/PathUtilTest.java
+++ b/optaplanner-wb-screens/optaplanner-wb-solver-editor/optaplanner-wb-solver-editor-backend/src/test/java/org/optaplanner/workbench/screens/solver/backend/server/PathUtilTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.workbench.screens.solver.backend.server;
+
+import org.junit.Test;
+import org.uberfire.backend.vfs.Path;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class PathUtilTest {
+
+    @Test
+    public void getFilePathFromProjectRoot() throws Exception {
+        final Path repositoryRoot = getPath("default:///spaceName/repositoryName",
+                                            "/");
+        final Path pathToFile = getPath("default:///spaceName/repositoryName/org/test/file.txt",
+                                        "file.txt");
+
+        assertEquals("/org/test/file.txt", PathUtil.removePrefix(pathToFile,
+                                                                repositoryRoot));
+    }
+
+    @Test
+    public void getFilePath() throws Exception {
+        final Path repositoryRoot = getPath("default:///spaceName/repositoryName/org/test",
+                                            "test");
+        final Path pathToFile = getPath("default:///spaceName/repositoryName/org/test/file.txt",
+                                        "file.txt");
+
+        assertEquals("/file.txt", PathUtil.removePrefix(pathToFile,
+                                                       repositoryRoot));
+    }
+
+    private Path getPath(final String uri,
+                         final String fileName) {
+        final Path path = mock(Path.class);
+
+        when(path.toURI()).thenReturn(uri);
+        when(path.getFileName()).thenReturn(fileName);
+        return path;
+    }
+}


### PR DESCRIPTION
https://issues.jboss.org/browse/PLANNER-988

I suspect that the PathUtil class will move to appformer before I have finished fixing all of these Project Orientated bugs.