### PR TITLE
RHDM-390,RHDM-391: Work around ERRAI-1101 using antrun

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -187,6 +187,29 @@
         </configuration>
       </plugin>
 
+      <plugin>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <executions>
+          <execution>
+            <!-- Temporary workaround for https://issues.jboss.org/browse/ERRAI-1101. Needs to stay here until
+            we find a general solution (e.g. moving all localized code to Errai TranslationService. -->
+            <id>create-default-i18n-resource</id>
+            <phase>process-resources</phase>
+            <configuration>
+              <target>
+                <copy todir="${project.build.directory}/classes"
+                      includeemptydirs="false" failonerror="false" quiet="true">
+                  <fileset dir="${project.build.directory}/classes"/>
+                  <globmapper from="*Constants.properties" to="*Constants_default.properties"/>
+                </copy>
+              </target>
+            </configuration>
+            <goals>
+              <goal>run</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
 
   </build>


### PR DESCRIPTION
Alternative solution to #266.

Downside: creates '*_default.properties' even if it's not needed (i.e. code that doesn't use TranslationService).
Benefits:
* No maintenance - will automatically apply the workaround for new code that uses TranslationService or old code that is migrated to it.
* No risk of breaking Zanata integration.

What do you think? @manstis @mbarkley 

Related PRs:
kiegroup/appformer/pull/267
kiegroup/kie-wb-common/pull/1553
kiegroup/drools-wb/pull/837
kiegroup/jbpm-wb/pull/1026
kiegroup/optaplanner-wb/pull/268
kiegroup/kie-wb-distributions/pull/720