### PR TITLE
Add logback.xml to configure logging related to GWT compilation

### DIFF
--- a/optaplanner-wb-ui/src/main/resources/logback.xml
+++ b/optaplanner-wb-ui/src/main/resources/logback.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2015 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<configuration>
+
+  <appender name="consoleAppender" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%-30(%d{HH:mm:ss.SSS} [%thread]) %-5level %logger{32} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <logger name="org.jboss.errai" level="${logback.level.errai:-info}"/>
+
+  <root level="info">
+    <appender-ref ref="consoleAppender"/>
+  </root>
+
+</configuration>


### PR DESCRIPTION
First of all, this limits Errai logging level from DEBUG to INFO which
significantly reduces output size. This is important when analyzing
console output on Jenkins.

It should be possible to adjust Errai logging level using a system
property for debugging purpose but I wasn't able to get it working
locally. The syntax looks as expected and it used to work like this
in OptaPlanner Examples. We'll figure this out later.