### PR TITLE
[master] AF-1226: Improve error handling displaying additional info to the GenericErrorPopup

### DIFF
--- a/optaplanner-wb-ui/src/main/java/org/optaplanner/workbench/client/OptaPlannerWorkbenchEntryPoint.java
+++ b/optaplanner-wb-ui/src/main/java/org/optaplanner/workbench/client/OptaPlannerWorkbenchEntryPoint.java
@@ -26,6 +26,7 @@ import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.jboss.errai.ui.shared.api.annotations.Bundle;
 import org.kie.workbench.common.workbench.client.PerspectiveIds;
 import org.kie.workbench.common.workbench.client.entrypoint.DefaultWorkbenchEntryPoint;
+import org.kie.workbench.common.workbench.client.error.DefaultWorkbenchErrorCallback;
 import org.kie.workbench.common.workbench.client.menu.DefaultWorkbenchFeaturesMenusHelper;
 import org.optaplanner.workbench.client.resources.i18n.AppConstants;
 import org.uberfire.client.mvp.ActivityBeansCache;
@@ -57,9 +58,11 @@ public class OptaPlannerWorkbenchEntryPoint extends DefaultWorkbenchEntryPoint {
                                           final WorkbenchMegaMenuPresenter menuBar,
                                           final UserMenu userMenu,
                                           final AdminPage adminPage,
-                                          final TranslationService translationService) {
+                                          final TranslationService translationService,
+                                          final DefaultWorkbenchErrorCallback defaultWorkbenchErrorCallback) {
         super(appConfigService,
-              activityBeansCache);
+              activityBeansCache,
+              defaultWorkbenchErrorCallback);
         this.menusHelper = menusHelper;
         this.menuBar = menuBar;
         this.userMenu = userMenu;

--- a/optaplanner-wb-ui/src/test/java/org/optaplanner/workbench/client/OptaPlannerWorkbenchEntryPointTest.java
+++ b/optaplanner-wb-ui/src/test/java/org/optaplanner/workbench/client/OptaPlannerWorkbenchEntryPointTest.java
@@ -26,6 +26,7 @@ import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.kie.workbench.common.workbench.client.error.DefaultWorkbenchErrorCallback;
 import org.kie.workbench.common.workbench.client.menu.DefaultWorkbenchFeaturesMenusHelper;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
@@ -73,6 +74,9 @@ public class OptaPlannerWorkbenchEntryPointTest {
     @Mock
     private TranslationService translationService;
 
+    @Mock
+    private DefaultWorkbenchErrorCallback defaultWorkbenchErrorCallback;
+
     private OptaPlannerWorkbenchEntryPoint optaPlannerWorkbenchEntryPoint;
 
     @Before
@@ -85,7 +89,8 @@ public class OptaPlannerWorkbenchEntryPointTest {
                                                                                 menuBar,
                                                                                 userMenu,
                                                                                 adminPage,
-                                                                                translationService, null));
+                                                                                translationService,
+                                                                                defaultWorkbenchErrorCallback));
         mockMenuHelper();
     }
 

--- a/optaplanner-wb-ui/src/test/java/org/optaplanner/workbench/client/OptaPlannerWorkbenchEntryPointTest.java
+++ b/optaplanner-wb-ui/src/test/java/org/optaplanner/workbench/client/OptaPlannerWorkbenchEntryPointTest.java
@@ -85,7 +85,7 @@ public class OptaPlannerWorkbenchEntryPointTest {
                                                                                 menuBar,
                                                                                 userMenu,
                                                                                 adminPage,
-                                                                                translationService));
+                                                                                translationService, null));
         mockMenuHelper();
     }
 


### PR DESCRIPTION
This is already merged in 7.7.x. Cherry-picking to master.

Related:
https://github.com/errai/errai/pull/352
https://github.com/kiegroup/appformer/pull/412
https://github.com/kiegroup/kie-wb-common/pull/1951
https://github.com/kiegroup/drools-wb/pull/883
https://github.com/kiegroup/jbpm-wb/pull/1169
https://github.com/kiegroup/optaplanner-wb/pull/290
https://github.com/kiegroup/kie-wb-distributions/pull/776
