### PR TITLE
RHDM-257: Avoid CDI warning

### DIFF
--- a/optaplanner-wb-screens/optaplanner-wb-solver-editor/optaplanner-wb-solver-editor-backend/src/main/resources/META-INF/beans.xml
+++ b/optaplanner-wb-screens/optaplanner-wb-solver-editor/optaplanner-wb-solver-editor-backend/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,24 @@
+<!--
+  ~ Copyright 2018 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~       http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_1_2.xsd"
+       bean-discovery-mode="all">
+  <scan>
+    <exclude name="org.optaplanner.workbench.screens.solver.backend.server.SolverValidator$SolverValidatorImpl"/>
+  </scan>
+</beans>


### PR DESCRIPTION
```
WELD-000167: Class SolverValidator$1 is annotated with @ApplicationScoped
but it does not declare an appropriate constructor therefore is not
registered as a bean!
```

The inner class slightly alters behavior of `DefaultGenericKieValidator` by
overriding one of its methods. As a side effect it becomes a bean
because `@ApplicationScoped` is inherited.

The solution is to exclude the inner class from bean scanning as it's
never being used as a bean.