### PR TITLE
Fix possible null dereference

### DIFF
--- a/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-backend/src/main/java/org/optaplanner/workbench/screens/domaineditor/backend/server/file/PlannerDataModelerHelperUtils.java
+++ b/optaplanner-wb-screens/optaplanner-wb-domain-editor/optaplanner-wb-domain-editor-backend/src/main/java/org/optaplanner/workbench/screens/domaineditor/backend/server/file/PlannerDataModelerHelperUtils.java
@@ -18,6 +18,7 @@ package org.optaplanner.workbench.screens.domaineditor.backend.server.file;
 
 import java.util.Comparator;
 import java.util.Optional;
+
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Observes;
 import javax.inject.Inject;
@@ -63,7 +64,7 @@ public class PlannerDataModelerHelperUtils {
 
         DataObject dataObject = generationResult.getDataObject();
 
-        if (dataObject != null && generationResult.getErrors() == null || generationResult.getErrors().isEmpty()) {
+        if (dataObject != null && (generationResult.getErrors() == null || generationResult.getErrors().isEmpty())) {
             JavaClass comparatorObject = getComparatorObject(dataObject);
             if (comparatorObject != null) {
                 JavaClass updatedComparatorObject = comparatorDefinitionService.updateComparatorObject(dataObject,


### PR DESCRIPTION
This PR fixes possible null dereference revealed by the infer tool. See the report below.

src/main/java/org/optaplanner/workbench/screens/domaineditor/backend/server/file/PlannerDataModelerHelperUtils.java:68: error: NULL_DEREFERENCE
  object `dataObject` last assigned on line 65 could be null and is dereferenced by call to `getComparatorObject(...)` at line 68.

@yurloc could you please have a look? I spotted this during #298 review.