### PR TITLE
DROOLS-2846 : Move Verifier core from drools-wb to drools

### DIFF
--- a/optaplanner-wb-ui/pom.xml
+++ b/optaplanner-wb-ui/pom.xml
@@ -762,16 +762,47 @@
     <!-- Drools Verifier Web Worker -->
     <dependency>
       <groupId>org.drools</groupId>
-      <artifactId>drools-wb-verifier-api</artifactId>
+      <artifactId>drools-verifier-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.drools</groupId>
-      <artifactId>drools-wb-verifier-api</artifactId>
+      <artifactId>drools-verifier-api</artifactId>
       <classifier>sources</classifier>
     </dependency>
     <dependency>
       <groupId>org.drools</groupId>
-      <artifactId>drools-wb-verifier-client</artifactId>
+      <artifactId>drools-verifier-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-verifier-core</artifactId>
+      <classifier>sources</classifier>
+    </dependency>
+    <dependency>
+      <groupId>org.kie.workbench.services</groupId>
+      <artifactId>kie-wb-common-verifier-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.kie.workbench.services</groupId>
+      <artifactId>kie-wb-common-verifier-api</artifactId>
+      <classifier>sources</classifier>
+    </dependency>
+    <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-wb-verifier-guided-decision-table-adapter</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-wb-verifier-guided-decision-table-adapter</artifactId>
+      <classifier>sources</classifier>
+    </dependency>
+    <dependency>
+      <groupId>org.kie.workbench.services</groupId>
+      <artifactId>kie-wb-common-verifier-reporting</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.kie.workbench.services</groupId>
+      <artifactId>kie-wb-common-verifier-reporting</artifactId>
       <classifier>sources</classifier>
     </dependency>
 

--- a/optaplanner-wb-webapp/pom.xml
+++ b/optaplanner-wb-webapp/pom.xml
@@ -425,7 +425,28 @@
     <!-- Drools Verifier Web Worker -->
     <dependency>
       <groupId>org.drools</groupId>
-      <artifactId>drools-wb-verifier-backend</artifactId>
+      <artifactId>drools-verifier-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-verifier-core</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-wb-verifier-guided-decision-table-adapter</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.kie.workbench.services</groupId>
+      <artifactId>kie-wb-common-verifier-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.kie.workbench.services</groupId>
+      <artifactId>kie-wb-common-verifier-reporting</artifactId>
+      <scope>provided</scope>
     </dependency>
 
     <!-- Drools Workbench Screens -->


### PR DESCRIPTION
https://issues.jboss.org/browse/DROOLS-2846
https://issues.jboss.org/browse/DROOLS-2847

Pretty much just moving code for the 99% of the changes and then 1% of refactorings to make the move easier.

Bundle:
https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/800
https://github.com/kiegroup/drools/pull/2021
https://github.com/kiegroup/kie-wb-common/pull/2054
https://github.com/kiegroup/drools-wb/pull/916
https://github.com/kiegroup/optaplanner-wb/pull/301
https://github.com/kiegroup/kie-wb-distributions/pull/795