### PR TITLE
DROOLS-2848 : Make the Verifier Web Worker connector reusable for different V&V types

### DIFF
--- a/optaplanner-wb-ui/pom.xml
+++ b/optaplanner-wb-ui/pom.xml
@@ -770,15 +770,6 @@
       <classifier>sources</classifier>
     </dependency>
     <dependency>
-      <groupId>org.drools</groupId>
-      <artifactId>drools-verifier-core</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.drools</groupId>
-      <artifactId>drools-verifier-core</artifactId>
-      <classifier>sources</classifier>
-    </dependency>
-    <dependency>
       <groupId>org.kie.workbench.services</groupId>
       <artifactId>kie-wb-common-verifier-api</artifactId>
     </dependency>
@@ -788,21 +779,35 @@
       <classifier>sources</classifier>
     </dependency>
     <dependency>
-      <groupId>org.drools</groupId>
-      <artifactId>drools-wb-verifier-guided-decision-table-adapter</artifactId>
+      <groupId>org.kie.workbench.services</groupId>
+      <artifactId>kie-wb-common-verifier-reporting-client</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.drools</groupId>
-      <artifactId>drools-wb-verifier-guided-decision-table-adapter</artifactId>
+      <groupId>org.kie.workbench.services</groupId>
+      <artifactId>kie-wb-common-verifier-reporting-client</artifactId>
       <classifier>sources</classifier>
     </dependency>
     <dependency>
-      <groupId>org.kie.workbench.services</groupId>
-      <artifactId>kie-wb-common-verifier-reporting</artifactId>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-verifier-core</artifactId>
+      <classifier>sources</classifier>
     </dependency>
     <dependency>
-      <groupId>org.kie.workbench.services</groupId>
-      <artifactId>kie-wb-common-verifier-reporting</artifactId>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-verifier-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-wb-verifier-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-wb-verifier-api</artifactId>
+      <classifier>sources</classifier>
+    </dependency>
+    <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-wb-verifier-guided-decision-table-adapter</artifactId>
       <classifier>sources</classifier>
     </dependency>
 

--- a/optaplanner-wb-webapp/pom.xml
+++ b/optaplanner-wb-webapp/pom.xml
@@ -425,27 +425,16 @@
     <!-- Drools Verifier Web Worker -->
     <dependency>
       <groupId>org.drools</groupId>
-      <artifactId>drools-verifier-api</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.drools</groupId>
       <artifactId>drools-verifier-core</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.drools</groupId>
-      <artifactId>drools-wb-verifier-guided-decision-table-adapter</artifactId>
-      <scope>provided</scope>
+      <artifactId>drools-wb-verifier-webworker</artifactId>
     </dependency>
     <dependency>
       <groupId>org.kie.workbench.services</groupId>
-      <artifactId>kie-wb-common-verifier-api</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.kie.workbench.services</groupId>
-      <artifactId>kie-wb-common-verifier-reporting</artifactId>
+      <artifactId>kie-wb-common-verifier-reporting-client</artifactId>
       <scope>provided</scope>
     </dependency>
 


### PR DESCRIPTION
Follow up for: https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/800

https://issues.jboss.org/browse/DROOLS-2848
https://issues.jboss.org/browse/DROOLS-2849

Bundle:
https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/809
https://github.com/kiegroup/kie-wb-common/pull/2073
https://github.com/kiegroup/drools-wb/pull/919
https://github.com/kiegroup/optaplanner-wb/pull/302
https://github.com/kiegroup/kie-wb-distributions/pull/802