### PR TITLE
[DO NOT MERGE] BAQE-650: Remove drools.datetimeformat property

### DIFF
--- a/optaplanner-wb-webapp/src/main/java/org/optaplanner/workbench/backend/server/AppSetup.java
+++ b/optaplanner-wb-webapp/src/main/java/org/optaplanner/workbench/backend/server/AppSetup.java
@@ -91,8 +91,6 @@ public class AppSetup extends BaseAppSetup {
                                                                       "");
         group.addConfigItem(configurationFactory.newConfigItem("drools.dateformat",
                                                                "dd-MMM-yyyy"));
-        group.addConfigItem(configurationFactory.newConfigItem("drools.datetimeformat",
-                                                               "dd-MMM-yyyy hh:mm:ss"));
         group.addConfigItem(configurationFactory.newConfigItem("drools.defaultlanguage",
                                                                "en"));
         group.addConfigItem(configurationFactory.newConfigItem("drools.defaultcountry",


### PR DESCRIPTION
After investigating the codebase it seems that the system property drools.datetimeformat is set, but never used. So this PR removest. The time format pask for dates can be set using drools.dateformat property.

Ensemble with:
- https://github.com/kiegroup/kie-wb-distributions/pull/826
- https://github.com/kiegroup/drools-wb/pull/954
- https://github.com/kiegroup/kie-wb-common/pull/2173