### PR TITLE
DROOLS-2848: Update VerifierWebWorkerServlet FQCN

### DIFF
--- a/optaplanner-wb-webapp/src/main/webapp/WEB-INF/web.xml
+++ b/optaplanner-wb-webapp/src/main/webapp/WEB-INF/web.xml
@@ -87,7 +87,7 @@ profile in pom.xml to use that. -->
 
   <servlet>
     <servlet-name>VerifierWebWorkerServlet</servlet-name>
-    <servlet-class>org.drools.workbench.services.verifier.plugin.backend.VerifierWebWorkerServlet</servlet-class>
+    <servlet-class>org.kie.workbench.common.services.verifier.service.VerifierWebWorkerServlet</servlet-class>
   </servlet>
   <servlet-mapping>
     <servlet-name>VerifierWebWorkerServlet</servlet-name>


### PR DESCRIPTION
Fixes the following exception during webapp deployment:

    java.lang.ClassNotFoundException: org.drools.workbench.services.verifier.plugin.backend.VerifierWebWorkerServlet
    from [Module \"deployment.optaplanner-wb.war\" from Service Module Loader]