### PR TITLE
AF-1512: Support new profile preferences

### DIFF
--- a/optaplanner-wb-ui/pom.xml
+++ b/optaplanner-wb-ui/pom.xml
@@ -517,6 +517,15 @@
     <!-- Common -->
 
     <dependency>
+      <groupId>org.kie.workbench.profile</groupId>
+      <artifactId>kie-wb-common-profile-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.kie.workbench.profile</groupId>
+      <artifactId>kie-wb-common-profile-api</artifactId>
+      <classifier>sources</classifier>
+    </dependency>
+    <dependency>
       <groupId>org.kie.workbench.services</groupId>
       <artifactId>kie-wb-common-services-api</artifactId>
     </dependency>

--- a/optaplanner-wb-ui/src/main/java/org/optaplanner/workbench/client/home/HomeProducer.java
+++ b/optaplanner-wb-ui/src/main/java/org/optaplanner/workbench/client/home/HomeProducer.java
@@ -19,6 +19,7 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
 import org.jboss.errai.ui.client.local.spi.TranslationService;
+import org.kie.workbench.common.profile.api.preferences.ProfilePreferences;
 import org.kie.workbench.common.screens.home.model.HomeModel;
 import org.kie.workbench.common.screens.home.model.HomeModelProvider;
 import org.kie.workbench.common.screens.home.model.ModelUtils;
@@ -38,7 +39,7 @@ public class HomeProducer implements HomeModelProvider {
     @Inject
     private TranslationService translationService;
 
-    public HomeModel get() {
+    public HomeModel get(ProfilePreferences profilePreferences) {
         final HomeModel model = new HomeModel(translationService.getTranslation(AppConstants.HomeProducer_Heading),
                                               translationService.getTranslation(AppConstants.HomeProducer_SubHeading),
                                               "images/home_bg.jpg");

--- a/optaplanner-wb-ui/src/main/module.gwt.xml
+++ b/optaplanner-wb-ui/src/main/module.gwt.xml
@@ -28,6 +28,9 @@
   <inherits name="org.guvnor.common.services.workingset.GuvnorWorkingsetClient"/>
   <inherits name="org.guvnor.messageconsole.GuvnorMessageConsoleClient"/>
 
+  <!-- Profile API-->
+  <inherits name="org.kie.workbench.common.profile.ProfileAPI"/>
+
   <!--Common Screens -->
   <inherits name="org.kie.workbench.common.screens.home.KieWorkbenchHomeClient"/>
   <inherits name="org.kie.workbench.common.screens.explorer.KieWorkbenchProjectExplorerClient"/>


### PR DESCRIPTION
DO NOT MERGE

Part of an ensemble:

kiegroup/appformer#493 << add combo support for preferences API and a test utility for ParametrizedCommand
kiegroup/droolsjbpm-build-bootstrap#849 - changes version to use BC and add profile API
kiegroup/kie-wb-common#2178 -- add the preference itself
Once the preference API is merged (see PRs above), this webapp needs to be updated because now the HomeProvider has access to the profiles preferences.