### PR TITLE
optaplanner-wb should use same findbugs rank as drools-wb

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -128,14 +128,6 @@
     <pluginManagement>
       <plugins>
         <plugin>
-          <groupId>org.codehaus.mojo</groupId>
-          <artifactId>findbugs-maven-plugin</artifactId>
-          <configuration>
-            <maxRank>14</maxRank>
-            <includeTests>true</includeTests>
-          </configuration>
-        </plugin>
-        <plugin>
           <groupId>net.ltgt.gwt.maven</groupId>
           <artifactId>gwt-maven-plugin</artifactId>
           <configuration>


### PR DESCRIPTION
Prepares for migration to spotbugs, see DROOLS-1781
Prepares for merger of drools-wb and optaplanner-wb.