### PR TITLE
AF-2310: Removed deprecated samples project

### DIFF
--- a/optaplanner-wb-ui/pom.xml
+++ b/optaplanner-wb-ui/pom.xml
@@ -785,11 +785,6 @@
       <artifactId>kie-wb-common-examples-screen-api</artifactId>
       <classifier>sources</classifier>
     </dependency>
-    <dependency>
-      <groupId>org.kie.workbench.screens</groupId>
-      <artifactId>kie-wb-common-examples-screen-client</artifactId>
-      <classifier>sources</classifier>
-    </dependency>
 
     <!-- KIE Workbench Playground Repository -->
     <dependency>

--- a/optaplanner-wb-ui/src/main/module.gwt.xml
+++ b/optaplanner-wb-ui/src/main/module.gwt.xml
@@ -41,7 +41,6 @@
   <inherits name="org.kie.workbench.common.screens.library.LibraryClient"/>
   <inherits name="org.kie.workbench.common.screens.contributors.KieWorkbenchContributorsClient"/>
   <inherits name="org.kie.workbench.common.workbench.KieDefaultWorkbenchClient"/>
-  <inherits name="org.kie.workbench.common.screens.examples.KieWorkbenchCommonExamplesClient"/>
 
   <!-- Common Services -->
   <inherits name="org.kie.workbench.common.services.datamodeller.DataModellerCore"/>


### PR DESCRIPTION
Main PR: https://github.com/kiegroup/kie-wb-common/pull/2991

An old samples project was removed. Nothing should change because it was deprecated long time ago

## Related to: 
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1092
* https://github.com/kiegroup/kie-wb-common/pull/2991
* https://github.com/kiegroup/jbpm-wb/pull/1401
* https://github.com/kiegroup/drools-wb/pull/1256
* https://github.com/kiegroup/kie-wb-distributions/pull/986
* https://github.com/kiegroup/optaplanner-wb/pull/349