### PR TITLE
upgrade build-chain @v2.6.8

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -35,7 +35,7 @@ jobs:
           restore-keys: ${{ runner.os }}-${{ matrix.java-version }}-m2
       - name: Build Chain ${{ matrix.java-version }}
         id: build-chain
-        uses: kiegroup/github-action-build-chainv2.6.8
+        uses: kiegroup/github-action-build-chain@v2.6.8
         with:
           definition-file: https://raw.githubusercontent.com/${GROUP}/droolsjbpm-build-bootstrap/${BRANCH}/.ci/pull-request-config.yaml
         env:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -35,7 +35,7 @@ jobs:
           restore-keys: ${{ runner.os }}-${{ matrix.java-version }}-m2
       - name: Build Chain ${{ matrix.java-version }}
         id: build-chain
-        uses: kiegroup/github-action-build-chain@issue_165
+        uses: kiegroup/github-action-build-chainv2.6.8
         with:
           definition-file: https://raw.githubusercontent.com/${GROUP}/droolsjbpm-build-bootstrap/${BRANCH}/.ci/pull-request-config.yaml
         env:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -35,7 +35,7 @@ jobs:
           restore-keys: ${{ runner.os }}-${{ matrix.java-version }}-m2
       - name: Build Chain ${{ matrix.java-version }}
         id: build-chain
-        uses: kiegroup/github-action-build-chain@v2.6.3
+        uses: kiegroup/github-action-build-chain@issue_167
         with:
           definition-file: https://raw.githubusercontent.com/${GROUP}/droolsjbpm-build-bootstrap/${BRANCH}/.ci/pull-request-config.yaml
         env:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -35,7 +35,7 @@ jobs:
           restore-keys: ${{ runner.os }}-${{ matrix.java-version }}-m2
       - name: Build Chain ${{ matrix.java-version }}
         id: build-chain
-        uses: kiegroup/github-action-build-chain@issue_167
+        uses: kiegroup/github-action-build-chain@issue_165
         with:
           definition-file: https://raw.githubusercontent.com/${GROUP}/droolsjbpm-build-bootstrap/${BRANCH}/.ci/pull-request-config.yaml
         env:


### PR DESCRIPTION
build chain changes:

-  https://github.com/kiegroup/github-action-build-chain/pull/169

upgrades:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1729
* https://github.com/kiegroup/kie-soup/pull/225
* https://github.com/kiegroup/droolsjbpm-knowledge/pull/545
* https://github.com/kiegroup/drools/pull/3791
* https://github.com/kiegroup/optaplanner/pull/1515
* https://github.com/kiegroup/lienzo-core/pull/151
* https://github.com/kiegroup/lienzo-tests/pull/125
* https://github.com/kiegroup/appformer/pull/1189
* https://github.com/kiegroup/kie-uberfire-extensions/pull/123
* https://github.com/kiegroup/jbpm/pull/2000
* https://github.com/kiegroup/kie-jpmml-integration/pull/63
* https://github.com/kiegroup/droolsjbpm-integration/pull/2573
* https://github.com/kiegroup/kie-wb-playground/pull/118
* https://github.com/kiegroup/kie-wb-common/pull/3676
* https://github.com/kiegroup/drools-wb/pull/1511
* https://github.com/kiegroup/jbpm-designer/pull/915
* https://github.com/kiegroup/jbpm-work-items/pull/214
* https://github.com/kiegroup/jbpm-wb/pull/1510
* https://github.com/kiegroup/optaplanner-wb/pull/402
* https://github.com/kiegroup/kie-wb-distributions/pull/1120
* https://github.com/kiegroup/openshift-drools-hacep/pull/117
* https://github.com/kiegroup/process-migration-service/pull/6
* https://github.com/kiegroup/optaweb-employee-rostering/pull/679
* https://github.com/kiegroup/optaweb-vehicle-routing/pull/549