### PR TITLE
[BXMSPROD-1845] elasticsearch removed from appformer

### DIFF
--- a/optaplanner-wb-webapp/pom.xml
+++ b/optaplanner-wb-webapp/pom.xml
@@ -720,11 +720,6 @@
 
     <dependency>
       <groupId>org.uberfire</groupId>
-      <artifactId>uberfire-metadata-backend-elasticsearch</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.uberfire</groupId>
       <artifactId>uberfire-metadata-backend-infinispan</artifactId>
     </dependency>
 


### PR DESCRIPTION
https://issues.redhat.com/browse/BXMSPROD-1845

Related PRs:

* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/2097
* https://github.com/kiegroup/appformer/pull/1312
* https://github.com/kiegroup/kie-wb-common/pull/3781
* https://github.com/kiegroup/drools-wb/pull/1558
* https://github.com/kiegroup/jbpm-wb/pull/1572
* https://github.com/kiegroup/optaplanner-wb/pull/413
* https://github.com/kiegroup/kie-wb-distributions/pull/1196